### PR TITLE
fix: doctype syntax highlighting

### DIFF
--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -89,39 +89,32 @@
       ]
     },
     {
-      "begin": "<!",
-      "captures": {
+      "begin": "<!(?=(?i:DOCTYPE\\s))",
+      "beginCaptures": {
         "0": {
-          "name": "punctuation.definition.tag.html"
+          "name": "punctuation.definition.tag.begin.html"
         }
       },
       "end": ">",
-      "name": "meta.tag.sgml.html",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.html"
+        }
+      },
+      "name": "meta.tag.metadata.doctype.html",
       "patterns": [
         {
-          "begin": "(?i:DOCTYPE|doctype)",
-          "captures": {
-            "1": {
-              "name": "entity.name.tag.doctype.html"
-            }
-          },
-          "end": "(?=>)",
-          "name": "meta.tag.sgml.doctype.html",
-          "patterns": [
-            {
-              "match": "\"[^\">]*\"",
-              "name": "string.quoted.double.doctype.identifiers-and-DTDs.html"
-            }
-          ]
+          "match": "\\G(?i:DOCTYPE)",
+          "name": "entity.name.tag.html"
         },
         {
-          "begin": "\\[CDATA\\[",
-          "end": "]](?=>)",
-          "name": "constant.other.inline-data.html"
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.html"
         },
         {
-          "match": "(\\s*)(?!--|>)\\S(\\s*)",
-          "name": "invalid.illegal.bad-comments-or-CDATA.html"
+          "match": "[^\\s>]+",
+          "name": "entity.other.attribute-name.html"
         }
       ]
     },


### PR DESCRIPTION
## Changes

This updates the doctype syntax highlighting to match the [`html.tmLanguage.json` extension in VSCode](https://github.com/Microsoft/vscode/blob/main/extensions/html/syntaxes/html.tmLanguage.json#L503-L530).

Resolves https://github.com/snowpackjs/astro-language-tools/issues/2

## Testing

Followed the guide from this repository.

## Docs

Bug fix only. This has no impact on documentation that I know of.