### PR TITLE
add publishing to OpenVSX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,17 @@ jobs:
 
       - name: Publish to VSCode Marketplace
         if: steps.changesets.outputs.published == 'true'
+        working-directory: ./packages/vscode
         run: |
-          npm i -g vsce
-          cd packages/vscode
-          npm install
-          vsce publish -p ${{ secrets.VSCE_TOKEN }}
+          npm i
+          npx vsce publish -p ${{ secrets.VSCE_TOKEN }}
+
+      - name: Publish to OpenVSX
+        if: steps.changesets.outputs.published == 'true'
+        working-directory: ./packages/vscode
+        run: |
+          npm i
+          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }}
 
       - name: Send a Discord notification if a publish happens
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Changes

- fix #16: add step to publish to OpenVSX

Someone has to configure OVSX_TOKEN secret in this repo before running the job. See https://github.com/eclipse/openvsx/wiki/Publishing-Extensions

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
