### PR TITLE
Upgrade TypeScript from 4.5.2 to 4.5.4 (stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.2.1",
     "svelte": "^3.38.0",
     "tiny-glob": "^0.2.8",
-    "typescript": "^4.5.2",
+    "typescript": "^4.5.4",
     "uvu": "^0.5.1"
   },
   "engines": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
     "ts-morph": "^12.0.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.5.4",
     "vscode-css-languageservice": "^5.1.1",
     "vscode-emmet-helper": "2.1.2",
     "vscode-html-languageservice": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9245,15 +9245,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*:
+typescript@*, typescript@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
   integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
-
-typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
## Changes

- Updates `typescript` from `4.5.2` to `4.5.2`
- [Improvements in TypeScript 4.5.3](https://github.com/microsoft/TypeScript/issues?q=milestone%3A%22TypeScript+4.5.3%22+)
- [Improvements in TypeScript 4.5.3](https://github.com/microsoft/TypeScript/issues?q=milestone%3A%22TypeScript+4.5.4%22+)

## Testing

dependency update only

## Docs

dependency update only