### PR TITLE
Improve import assertion support

### DIFF
--- a/.changeset/itchy-chefs-cover.md
+++ b/.changeset/itchy-chefs-cover.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Improve import assertion syntax highlighting

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -244,6 +244,11 @@
         "embeddedLanguages": {
           "meta.embedded.block.astro": "astro"
         }
+      },
+      {
+        "injectTo": ["source.js", "source.ts", "source.tsx", "text.html.astro"],
+        "scopeName": "meta.import",
+        "path": "./syntaxes/assert.inject-to-script.tmLanguage.json"
       }
     ]
   }

--- a/packages/vscode/syntaxes/assert.inject-to-script.tmLanguage.json
+++ b/packages/vscode/syntaxes/assert.inject-to-script.tmLanguage.json
@@ -1,0 +1,29 @@
+{
+	"name": "Import Assertions",
+	"injectionSelector": "meta.import",
+	"scopeName": "meta.import",
+	"patterns": [
+		{
+			"begin": "\\s+(assert)\\s+(\\{)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.${1:/downcase}.js"
+				},
+				"2": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "source.js#object-member"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Changes

- Improves `assert` syntax highlighting
- Aligns syntax highlighting with pre-existing capabilities

## Testing

**Before**:
<img width="480" alt="before syntax highlighting fix" src="https://user-images.githubusercontent.com/188426/149246604-387268e0-03a4-4262-9fa1-a2c23f919e3d.png">
- Keyword `assert` was displayed as a variable.
- Assertion object was displayed as a series of variables and delimiters.

**After**:
<img width="460" alt="after syntax highlighting fix" src="https://user-images.githubusercontent.com/188426/149246998-6873e7e5-9a09-4ffd-9917-17dfff69b227.png">

- Keyword `assert` is displayed as a keyword. 
- Assertion object is displayed as an object with a key and a string member.


## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
