### PR TITLE
Add `types: ['vite/client']` to the default tsconfig used for .astro files

### DIFF
--- a/packages/language-server/src/plugins/typescript/languageService.ts
+++ b/packages/language-server/src/plugins/typescript/languageService.ts
@@ -171,6 +171,8 @@ function getDefaultJsConfig(): {
       maxNodeModuleJsDepth: 2,
       allowSyntheticDefaultImports: true,
       allowJs: true,
+      // By providing vite/client here, our users get proper typing on import.meta in .astro files
+      types: ['vite/client']
    };
    return {
       compilerOptions,


### PR DESCRIPTION
## Changes

This adds `types: ['vite/client']` to the default TypeScript config the extension uses for .astro files. What this provide us with is nice typing for `import.meta.env` without the user needing to do anything on their end

Additionally, the user can provide their own typing through [the method Vite recommend](https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript), it work just fine (as far as I tested), as demonstrated by the screenshot below

![image](https://user-images.githubusercontent.com/3019731/149632848-a0534f42-e9d8-4dfb-a2e1-2d8060588627.png)

### Caveats

This only add the typing for `.astro` files, the user still need to provide a `tsconfig.json` with `types: ['vite/client']` for support in other file formats (notably in our case, that includes .ts, .vue, .svelte etc files). As far as I know, they do not need to add `vite` as a dependency of their project, just the types in their tsconfig

On a personal level, I do not think this is a problem as long as it's properly documented somewhere. I tried to search for a way to fix this but couldn't find anything, if someone has an idea, I'm open to adding it to this PR (might need a bit of guidance however)

## Testing

Tested manually using the `minimal` example with all three majors package manager (npm, yarn, pnpm)

## Docs

No docs needed, I added a comment to explain why it's been added there however (as it's a bit out of line with the other default settings)
