### PR TITLE
Bring back loading the user js/tsconfig.json

### DIFF
--- a/.changeset/witty-feet-change.md
+++ b/.changeset/witty-feet-change.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Bring back loading the user js/tsconfig.json, notably, this allow us to support aliases


### PR DESCRIPTION
## Changes

This bring back the feature of loading the user `js/tsconfig.json` that was removed in https://github.com/withastro/language-tools/pull/144

It was removed because users with `strict: true` or `alwaysStrict: true` in their config experienced unrelated errors in .astro files (see https://github.com/withastro/language-tools/issues/91). However removing it causes other issues, most importantly, aliases don't work anymore (https://github.com/withastro/language-tools/issues/156)

This PR fix this by bringing back loading the user config but forcing `strict: false` for .astro files. Additionally, unlike the previous solution, we gently add some of our default settings through merging with the user config (so they're overwrittable if needed), for instance `type: ["vite/client"]` that was added in https://github.com/withastro/language-tools/pull/151. This way, even if the user has a .tsconfig.json file only for ex: aliases, they'll still get the benefits of having types for ImportMeta in their .astro files

This fix #156 

## Testing

Tested manually

## Docs

No docs needed, for now at least. It'd probably be great to document how this operate in some way (perhaps in the extension README that shows in VSCode?)
