### PR TITLE
Add EditorConfig, ESLint and Prettier config files from main repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[{.*,*.md,*.json,*.toml,*.yml,}]
+indent_style = space

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+.github
+.changeset

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  extends: ["plugin:@typescript-eslint/recommended", "prettier"],
+  plugins: ["@typescript-eslint", "prettier"],
+  rules: {
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-this-alias": "off",
+    "no-console": "warn",
+    "no-shadow": "error",
+    "prefer-const": "off",
+    // 'require-jsdoc': 'error', // re-enable this to enforce JSDoc for all functions
+  },
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+**/dist
+**/node_modules
+**/fixtures
+.github
+.changeset

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,16 @@
+{
+  "printWidth": 180,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": true,
+  "overrides": [
+    {
+      "files": [".*", "*.json", "*.md", "*.toml", "*.yml"],
+      "options": {
+        "useTabs": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

This adds the config files used by ESLint, Prettier, EditorConfig from the main repo to this repo as well, in order to promote consistent formatting and linting across Astro project

I removed a few things from the ignores files that were applicable only to the main repo. Additionally, despite the plugins used for Prettier and ESLint, I don't think any new dependencies are needed as I think they were already installed

## Testing

No tests needed

## Docs

No docs needed
