### PR TITLE
Apply relevant content transformations for TSX generation only in relevant parts

### DIFF
--- a/.changeset/famous-apes-vanish.md
+++ b/.changeset/famous-apes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Only apply content transformations for TSX generation in relevant places

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -23,70 +23,74 @@ interface Astro2TSXResult {
   code: string;
 }
 
-export default function(content: string): Astro2TSXResult {
-  let result: Astro2TSXResult = {
-    code: ''
-  };
+export default function (content: string): Astro2TSXResult {
+	let result: Astro2TSXResult = {
+		code: '',
+	};
 
-	const astroDocument = parseAstro(content)
+	const astroDocument = parseAstro(content);
 
 	// Frontmatter replacements
-  let frontMatterRaw = content
-		// Handle case where semicolons is not used in the frontmatter section
-		.replace(/((?!^)(?<!;)\n)(---)/g, (_whole, start, _dashes) => {
-			return start + ';' + '//';
-		})
-		// Replace frontmatter marks with comments
-		.replace(/---/g, '///');
+	let frontMatterRaw = '';
+	if (astroDocument.frontmatter.state === 'closed') {
+		frontMatterRaw = content
+			.substring(astroDocument.frontmatter.startOffset ?? 0, (astroDocument.frontmatter.endOffset ?? 0) + 3)
+			// Handle case where semicolons is not used in the frontmatter section
+			.replace(/((?!^)(?<!;)\n)(---)/g, (_whole, start, _dashes) => {
+				return start + ';' + '//';
+			})
+			// Replace frontmatter marks with comments
+			.replace(/---/g, '///');
+	}
 
 	// Content replacement
-	let htmlRaw = content.substring(astroDocument.content.firstNonWhitespaceOffset ?? 0)
-    // Turn comments into JS comments
-    .replace(/<\s*!--([^-->]*)(.*?)-->/gs, (whole) => {
-      return `{/*${whole}*/}`;
-    })
-    // Turn styles into internal strings
-    .replace(/<\s*style([^>]*)>(.*?)<\s*\/\s*style>/gs, (_whole, attrs, children) => {
-      return `<style${attrs}>{\`${escapeTemplateLiteralContent(children)}\`}</style>`;
-    })
-    // Turn scripts into function calls
-    .replace(/<\s*script([^\/>]*)>(.*?)<\s*\/\s*script>/gs, (_whole, attrs, children, offset) => {
-      return `<script${attrs}>{()=>{${children}}}</script>`;
-    })
-    // Close void elements
-    .replace(/<(\s*(meta|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([^>]*))>/g, (whole, inner) => {
-      if(whole.endsWith('/>')) return whole;
-      return `<${inner} />`;
-    })
-    // Replace `@` prefixed attributes with `_` prefix
-    .replace(/<([$A-Z_a-z][^\s\/>]*)([^\/>]*)>/g, (whole: string, tag: string, attrs: string) => {
-      if (attrs.includes('@')) {
-        return `<${tag}${attrs.replace(
-          // the following regular expression captures:
-          //   $1. any character that may appear before an attribute name (https://html.spec.whatwg.org/#before-attribute-name-state)
-          // then, one `@` at sign, then:
-          //   $2. any characters that may appear in an attribute name (https://html.spec.whatwg.org/#attribute-name-state)
-          // then, looking ahead any one character that may not appear in an attribute name, or the end
-          /([\f\n\r\t "'])@([^\f\n\r\t /=>"'<]+)(?=[\f\n\r\t /=>"'<]|$)/g,
-          '$1_$2'
-        )}>`
-      } else {
-        return whole;
-      }
-    })
-    // Fix doctypes
-    .replace(/<!(doctype html)>/gi, (_whole, main) => {
-      return `<${main.toLowerCase()}/>`;
-    });
+	let htmlRaw = content
+		.substring(astroDocument.content.firstNonWhitespaceOffset ?? 0)
+		// Turn comments into JS comments
+		.replace(/<\s*!--([^-->]*)(.*?)-->/gs, (whole) => {
+			return `{/*${whole}*/}`;
+		})
+		// Turn styles into internal strings
+		.replace(/<\s*style([^>]*)>(.*?)<\s*\/\s*style>/gs, (_whole, attrs, children) => {
+			return `<style${attrs}>{\`${escapeTemplateLiteralContent(children)}\`}</style>`;
+		})
+		// Turn scripts into function calls
+		.replace(/<\s*script([^\/>]*)>(.*?)<\s*\/\s*script>/gs, (_whole, attrs, children, offset) => {
+			return `<script${attrs}>{()=>{${children}}}</script>`;
+		})
+		// Close void elements
+		.replace(/<(\s*(meta|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([^>]*))>/g, (whole, inner) => {
+			if (whole.endsWith('/>')) return whole;
+			return `<${inner} />`;
+		})
+		// Replace `@` prefixed attributes with `_` prefix
+		.replace(/<([$A-Z_a-z][^\s\/>]*)([^\/>]*)>/g, (whole: string, tag: string, attrs: string) => {
+			if (attrs.includes('@')) {
+				return `<${tag}${attrs.replace(
+					// the following regular expression captures:
+					//   $1. any character that may appear before an attribute name (https://html.spec.whatwg.org/#before-attribute-name-state)
+					// then, one `@` at sign, then:
+					//   $2. any characters that may appear in an attribute name (https://html.spec.whatwg.org/#attribute-name-state)
+					// then, looking ahead any one character that may not appear in an attribute name, or the end
+					/([\f\n\r\t "'])@([^\f\n\r\t /=>"'<]+)(?=[\f\n\r\t /=>"'<]|$)/g,
+					'$1_$2'
+				)}>`;
+			} else {
+				return whole;
+			}
+		})
+		// Fix doctypes
+		.replace(/<!(doctype html)>/gi, (_whole, main) => {
+			return `<${main.toLowerCase()}/>`;
+		});
 
-
-
-  result.code =
+	result.code =
 		frontMatterRaw +
+		'\n' +
 		htmlRaw +
 		EOL +
 		// Add TypeScript definitions
 		addProps(frontMatterRaw, ASTRO_DEFINITION_STR);
 
-  return result;
+	return result;
 }


### PR DESCRIPTION
## Changes

Before, transformations (also knowns as, `.replace`s) used when generating TSX from `.astro` files were applied to the entire file, which meant that sometimes, we'd get false positive where the regexes thinks they're transforming HTML but really they were operating on the frontmatter content. I think that in the past, this might have been allowable because we could have JSX in the frontmatter, but this isn't the case anymore 

This fixes https://github.com/withastro/language-tools/issues/155 though I reckon that this probably caused other undocumented issues for other people in the past

I realize that this is a bit of a crude fix, but then again, the original code is already a bit brittle (not that there's necessarily another way to do it without making a whole thing). In the future, I'd assume we'd use the compiler for this. This is more so a temporary fix

## Testing

Tested manually using the snippet shared in the previously mentioned issue

## Docs

No docs needed
