### PR TITLE
Fix missing whitespace in generated TSX

### DIFF
--- a/.changeset/heavy-dodos-brake.md
+++ b/.changeset/heavy-dodos-brake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix errors showing on wrong line due to an error in TSX generation

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -44,8 +44,9 @@ export default function (content: string): Astro2TSXResult {
 	}
 
 	// Content replacement
+	const htmlBegin = astroDocument.frontmatter.endOffset ? astroDocument.frontmatter.endOffset + 3 : 0
 	let htmlRaw = content
-		.substring(astroDocument.content.firstNonWhitespaceOffset ?? 0)
+		.substring(htmlBegin)
 		// Turn comments into JS comments
 		.replace(/<\s*!--([^-->]*)(.*?)-->/gs, (whole) => {
 			return `{/*${whole}*/}`;
@@ -86,7 +87,6 @@ export default function (content: string): Astro2TSXResult {
 
 	result.code =
 		frontMatterRaw +
-		'\n' +
 		htmlRaw +
 		EOL +
 		// Add TypeScript definitions


### PR DESCRIPTION
## Changes

Previously we were making up our TSX's template content from where the template part started in the .astro files, however what this meant is that we were missing crucial whitespace between the frontmatter and the template part. So now, we start our HTML from where the frontmatter end and not where the content starts

This fixes https://github.com/withastro/language-tools/issues/173

## Testing

Tested manually and ran tests locally

![image](https://user-images.githubusercontent.com/3019731/156194559-0a6dde44-5647-4a80-9faa-c1864e870d08.png)

(Error now appears on the right line no matter the amount of white lines before)

## Docs

Bug fix only
