### PR TITLE
Add support for reloading the language server on Astro / TS config changes

### DIFF
--- a/.changeset/sharp-onions-tell.md
+++ b/.changeset/sharp-onions-tell.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Add feature to reload language server on ts/jsconfig change

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-this-alias": "off",
-    "no-console": "warn",
+    "no-console": ["error", { allow: ["warn", "error"] }],
     "no-shadow": "error",
     "prefer-const": "off",
     // 'require-jsdoc': 'error', // re-enable this to enforce JSDoc for all functions

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -53,6 +53,12 @@
         "enableForWorkspaceTypeScriptVersions": true
       }
     ],
+    "commands": [
+      {
+        "command": "astro.restartLanguageServer",
+        "title": "Astro: Restart Language Server"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Astro configuration",

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,71 +1,103 @@
-import * as vscode from 'vscode';
-import * as lsp from 'vscode-languageclient/node.js';
+import { window, commands, workspace, ExtensionContext, TextDocument, Position } from 'vscode';
+import { LanguageClient, RequestType, TextDocumentPositionParams, ServerOptions, TransportKind } from 'vscode-languageclient/node';
+import { LanguageClientOptions } from 'vscode-languageclient';
 import { activateTagClosing } from './html/autoClose.js';
 
-let docClient: lsp.LanguageClient;
+const TagCloseRequest: RequestType<TextDocumentPositionParams, string, any> = new RequestType('html/tag');
 
-const TagCloseRequest: lsp.RequestType<lsp.TextDocumentPositionParams, string, any> = new lsp.RequestType('html/tag');
+export async function activate(context: ExtensionContext) {
+	const serverModule = require.resolve('@astrojs/language-server/bin/server.js');
 
-/**  */
-export async function activate(context: vscode.ExtensionContext) {
-  docClient = createLanguageService(context, 'doc', 'astro', 'Astro', 6040);
+	const port = 6040;
+	const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
 
-  await docClient.onReady();
+	const serverOptions: ServerOptions = {
+		run: { module: serverModule, transport: TransportKind.ipc },
+		debug: {
+			module: serverModule,
+			transport: TransportKind.ipc,
+			options: debugOptions,
+		},
+	};
+
+	const clientOptions: LanguageClientOptions = {
+		documentSelector: [{ scheme: 'file', language: 'astro' }],
+		synchronize: {
+			configurationSection: ['astro', 'javascript', 'typescript', 'prettier'],
+			fileEvents: workspace.createFileSystemWatcher('{**/*.js,**/*.ts}', false, false, false),
+		},
+		initializationOptions: {
+			configuration: {
+				astro: workspace.getConfiguration('astro'),
+				prettier: workspace.getConfiguration('prettier'),
+				emmet: workspace.getConfiguration('emmet'),
+				typescript: workspace.getConfiguration('typescript'),
+				javascript: workspace.getConfiguration('javascript'),
+			},
+			dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
+		},
+	};
+
+	let client = createLanguageServer(serverOptions, clientOptions);
+	context.subscriptions.push(client.start());
+
+	client
+		.onReady()
+		.then(() => {
+			const tagRequestor = (document: TextDocument, position: Position) => {
+				const param = client.code2ProtocolConverter.asTextDocumentPositionParams(document, position);
+				return client.sendRequest(TagCloseRequest, param);
+			};
+			const disposable = activateTagClosing(tagRequestor, { astro: true }, 'html.autoClosingTags');
+			context.subscriptions.push(disposable);
+		})
+		.catch((err) => {
+			console.error('Astro, unable to load language server.', err);
+		});
+
+	// Restart the language server if any critical files that are outside our jurisdiction got changed (tsconfig, jsconfig etc)
+	workspace.onDidSaveTextDocument(async (doc: TextDocument) => {
+		const fileName = doc.fileName.split('/').pop() ?? doc.fileName;
+		if ([/^tsconfig\.json$/, /^jsconfig\.json$/, /^astro\.config\.(js|cjs|mjs|ts)$/].some((regex) => regex.test(fileName))) {
+			await restartClient(false);
+		}
+	});
+
+	context.subscriptions.push(
+		commands.registerCommand('astro.restartLanguageServer', async () => {
+			await restartClient(true);
+		})
+	);
+
+	let restartingClient = false;
+	async function restartClient(showNotification: boolean) {
+		if (restartingClient) {
+			return;
+		}
+
+		restartingClient = true;
+		await client.stop();
+
+		client = createLanguageServer(serverOptions, clientOptions);
+		context.subscriptions.push(client.start());
+		await client.onReady();
+
+		if (showNotification) {
+			window.showInformationMessage('Astro language server restarted.');
+		}
+
+		restartingClient = false;
+	}
+
+	function getLSClient() {
+		return client;
+	}
+
+	return {
+		getLanguageServer: getLSClient,
+	};
 }
 
-/**  */
-function createLanguageService(context: vscode.ExtensionContext, mode: 'doc', id: string, name: string, port: number) {
-  const { workspace } = vscode;
-  const serverModule = require.resolve('@astrojs/language-server/bin/server.js');
-  const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
-  const serverOptions: lsp.ServerOptions = {
-    run: { module: serverModule, transport: lsp.TransportKind.ipc },
-    debug: {
-      module: serverModule,
-      transport: lsp.TransportKind.ipc,
-      options: debugOptions,
-    },
-  };
-  const serverInitOptions: any = {
-    mode: mode,
-    appRoot: vscode.env.appRoot,
-    language: vscode.env.language,
-  };
-  const clientOptions: lsp.LanguageClientOptions = {
-    documentSelector: [{ scheme: 'file', language: 'astro' }],
-    synchronize: {
-      configurationSection: ['astro', 'javascript', 'typescript', 'prettier'],
-      fileEvents: workspace.createFileSystemWatcher('{**/*.js,**/*.ts}', false, false, false),
-    },
-    initializationOptions: {
-      ...serverInitOptions,
-      configuration: {
-        astro: workspace.getConfiguration('astro'),
-        prettier: workspace.getConfiguration('prettier'),
-        emmet: workspace.getConfiguration('emmet'),
-        typescript: workspace.getConfiguration('typescript'),
-        javascript: workspace.getConfiguration('javascript'),
-      },
-      dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
-    },
-  };
-  const client = new lsp.LanguageClient(id, name, serverOptions, clientOptions);
-
-  context.subscriptions.push(client.start());
-
-  client
-    .onReady()
-    .then(() => {
-      const tagRequestor = (document: vscode.TextDocument, position: vscode.Position) => {
-        const param = client.code2ProtocolConverter.asTextDocumentPositionParams(document, position);
-        return client.sendRequest(TagCloseRequest, param);
-      };
-      const disposable = activateTagClosing(tagRequestor, { astro: true }, 'html.autoClosingTags');
-      context.subscriptions.push(disposable);
-    })
-    .catch((err) => {
-      console.error('Astro, unable to load language server.', err);
-    });
-
-  return client;
+function createLanguageServer(serverOptions: ServerOptions, clientOptions: LanguageClientOptions) {
+	return new LanguageClient('astro', 'Astro', serverOptions, clientOptions);
 }


### PR DESCRIPTION
## Changes

This add support for reloading the language server whenever `tsconfig.json` (and other similar files) is modified. I also added a command to manually reload the language server. This is helpful for whenever users encounter an issue where just reloading fix it (this help avoid needing to reload the entire VS Code window, which is not always pleasant to do)

The commit is a bit bigger than it should be because of formatting changes and also a small refactor removing unnecessary wrappers and abstractions. See GitHub comments on code for more info on why some changes were made

This fixes https://github.com/withastro/language-tools/issues/171

## Testing

Tested manually as our tests don't cover this (not sure if it's even possible to test a VS Code extension)

## Docs

No docs needed, the added command is self explanatory
