### PR TITLE
Fix language server reload on config changes not working on Windows

### DIFF
--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -57,7 +57,7 @@ export async function activate(context: ExtensionContext) {
 
 	// Restart the language server if any critical files that are outside our jurisdiction got changed (tsconfig, jsconfig etc)
 	workspace.onDidSaveTextDocument(async (doc: TextDocument) => {
-		const fileName = doc.fileName.split('/').pop() ?? doc.fileName;
+		const fileName = doc.fileName.split(/\/|\\/).pop() ?? doc.fileName;
 		if ([/^tsconfig\.json$/, /^jsconfig\.json$/, /^astro\.config\.(js|cjs|mjs|ts)$/].some((regex) => regex.test(fileName))) {
 			await restartClient(false);
 		}


### PR DESCRIPTION
## Changes

Previously, we splitted the path to a potential ts/jsconfig using a forward slash, I thought that was fine because I thought that VS Code normalized paths but it turns out, that: it doesn't. So we need to also split on backslashes for Windows 

## Testing

Tested manually on both Windows and Linux

## Docs

No docs needed
