### PR TITLE
Add support for Emmet inside components, upgrade version

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -25,7 +25,7 @@
     "ts-morph": "^12.0.0",
     "typescript": "^4.5.4",
     "vscode-css-languageservice": "^5.1.1",
-    "vscode-emmet-helper": "2.1.2",
+    "@vscode/emmet-helper": "^2.8.4",
     "vscode-html-languageservice": "^3.0.3",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "^3.16.0",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.116",
-    "astro": "0.23.5",
+    "astro": "^0.23.5",
     "astro-scripts": "0.0.1",
     "tap": "^15.0.9"
   }

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -1,4 +1,4 @@
-import { VSCodeEmmetConfig } from 'vscode-emmet-helper';
+import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { UserPreferences } from 'typescript';
 import { merge, get } from 'lodash';
 

--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -89,6 +89,19 @@ export function isInTag(position: Position, tagInfo: TagInformation | null): tag
   return !!tagInfo && isInRange(position, Range.create(tagInfo.startPos, tagInfo.endPos));
 }
 
+export function isComponentTag(node: Node) {
+	if (!node.tag) {
+		return false;
+	}
+	const firstChar = node.tag[0];
+	return /[A-Z]/.test(firstChar);
+}
+
+export function isInComponentStartTag(html: HTMLDocument, offset: number): boolean {
+	const node = html.findNodeAt(offset);
+	return (isComponentTag(node) && (!node.startTagEnd || offset < node.startTagEnd))
+}
+
 /**
  * Get the line and character based on the offset
  * @param offset The index of the position

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -1,7 +1,7 @@
 import type { CompletionsProvider } from '../interfaces';
 import type { Document, DocumentManager } from '../../core/documents';
 import type { ConfigManager } from '../../core/config';
-import { getEmmetCompletionParticipants, doComplete as doEmmetComplete } from 'vscode-emmet-helper';
+import { doComplete as getEmmetCompletions } from '@vscode/emmet-helper';
 import { CompletionContext, CompletionList, CompletionTriggerKind, Position } from 'vscode-languageserver';
 import { isInsideFrontmatter } from '../../core/documents/utils';
 import { CSSDocument, CSSDocumentBase } from './CSSDocument';
@@ -63,7 +63,7 @@ export class CSSPlugin implements CompletionsProvider {
     if (isSASS(cssDocument)) {
       // the css language service does not support sass, still we can use
       // the emmet helper directly to at least get emmet completions
-      return doEmmetComplete(document, position, 'sass', this.configManager.getEmmetConfig());
+      return getEmmetCompletions(document, position, 'sass', this.configManager.getEmmetConfig()) || null;
     }
 
     const type = extractLanguage(cssDocument);
@@ -73,11 +73,7 @@ export class CSSPlugin implements CompletionsProvider {
       isIncomplete: true,
       items: [],
     };
-    if (false /* this.configManager.getConfig().css.completions.emmet */) {
-      lang.setCompletionParticipants([
-        getEmmetCompletionParticipants(cssDocument, cssDocument.getGeneratedPosition(position), getLanguage(type), this.configManager.getEmmetConfig(), emmetResults),
-      ]);
-    }
+
     const results = lang.doComplete(cssDocument, cssDocument.getGeneratedPosition(position), cssDocument.stylesheet);
     return CompletionList.create(
       [...(results ? results.items : []), ...emmetResults.items].map((completionItem) => mapCompletionItemToOriginal(cssDocument, completionItem)),

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -26,8 +26,6 @@
   "dependencies": {
     "@astrojs/language-server": "0.9.0",
     "@astrojs/ts-plugin": "0.2.0",
-    "vscode-emmet-helper": "2.1.2",
-    "vscode-html-languageservice": "^3.0.3",
     "vscode-languageclient": "~7.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,24 @@
   dependencies:
     typescript "^4.3.5"
 
+"@astrojs/language-server@^0.8.6":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@astrojs/language-server/-/language-server-0.8.10.tgz#d898390dc79776e1e93d1cc2c0288da7537fc310"
+  integrity sha512-F3ceZrBKywnNkDq9mK/6RgRDAGUAv9Z45oljpBx9dlMQHnWOnPdJFWncw1jVItAT57SEflLJqTuFaDphKQAFtQ==
+  dependencies:
+    lodash "^4.17.21"
+    source-map "^0.7.3"
+    ts-morph "^12.0.0"
+    typescript "^4.5.4"
+    vscode-css-languageservice "^5.1.1"
+    vscode-emmet-helper "2.1.2"
+    vscode-html-languageservice "^3.0.3"
+    vscode-languageserver "6.1.1"
+    vscode-languageserver-protocol "^3.16.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.16.0"
+    vscode-uri "^3.0.2"
+
 "@astrojs/markdown-remark@^0.6.4":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@astrojs/markdown-remark/-/markdown-remark-0.6.4.tgz#d56ca29c0b6e5bf7766f74d3a46dea60da8698c3"
@@ -787,6 +805,13 @@
   dependencies:
     "@emmetio/scanner" "^1.0.0"
 
+"@emmetio/abbreviation@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz#2b3c0383c1a4652f677d5b56fb3f1616fe16ef10"
+  integrity sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==
+  dependencies:
+    "@emmetio/scanner" "^1.0.0"
+
 "@emmetio/css-abbreviation@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz#90362e8a1122ce3b76f6c3157907d30182f53f54"
@@ -1233,6 +1258,18 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.2.4.tgz#ab8b199ca82496b05d2654c5f34ffcf9b947243d"
   integrity sha512-ev9AOlp0ljCaDkFZF3JwC/pD2N4Hh+r5srl5JHM6BKg5+99jiiK0rE/XaRs3pVm1wzyKkjUy/StBSoXX5fFzcw==
 
+"@vscode/emmet-helper@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@vscode/emmet-helper/-/emmet-helper-2.8.4.tgz#ab937e3ce79b0873c604d1ad50a9eeb7abae2937"
+  integrity sha512-lUki5QLS47bz/U8IlG9VQ+1lfxMtxMZENmU5nu4Z71eOD5j9FK0SmYGL5NiVJg9WBWeAU0VxRADMY2Qpq7BfVg==
+  dependencies:
+    emmet "^2.3.0"
+    jsonc-parser "^2.3.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.15.1"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
+
 "@vue/compiler-core@3.2.31":
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.31.tgz#d38f06c2cf845742403b523ab4596a3fda152e89"
@@ -1534,7 +1571,7 @@ astral-regex@^2.0.0:
     globby "^11.0.3"
     tar "^6.1.0"
 
-astro@0.23.5:
+astro@^0.23.5:
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/astro/-/astro-0.23.5.tgz#f8b9d543238822a4a2ecc80d628f8b6f0ebe590f"
   integrity sha512-6w2q4yYWR9hKnDjzj4tzH/5wfweBVeZ0qGbKWTdp0fRlzHySSuKgRHWw8Yfw429ASLqXB6dYgqWrN89C4kJh7g==
@@ -2303,6 +2340,14 @@ emmet@^2.1.5:
   integrity sha512-3IqSwmO+N2ZGeuhDyhV/TIOJFUbkChi53bcasSNRE7Yd+4eorbbYz4e53TpMECt38NtYkZNupQCZRlwdAYA42A==
   dependencies:
     "@emmetio/abbreviation" "^2.2.2"
+    "@emmetio/css-abbreviation" "^2.1.4"
+
+emmet@^2.3.0:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/emmet/-/emmet-2.3.6.tgz#1d93c1ac03164da9ddf74864c1f341ed6ff6c336"
+  integrity sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==
+  dependencies:
+    "@emmetio/abbreviation" "^2.2.3"
     "@emmetio/css-abbreviation" "^2.1.4"
 
 emoji-regex@^7.0.1:


### PR DESCRIPTION
## Changes

This add support for Emmet inside components slots, in most cases users are using slots for HTML so this is really helpful. 

Additionally, this PR upgrade Emmet to the latest version (well, it upgrade the vscode helper which in turns upgrade Emmet). This fixes a bunch of issues in the background and add a few missing completions that were adding over time. 

This also remove the annoying message you got every time you install the language-server (which affect the main astro project due to the check command) where it tells you that vscode-emmet-helper is deprecated

Fixes https://github.com/withastro/language-tools/issues/81

## Testing

Tested manually

## Docs

No docs needed