### PR TITLE
Add support for importing and parsing files from frameworks

### DIFF
--- a/.changeset/smooth-candles-rhyme.md
+++ b/.changeset/smooth-candles-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': minor
+---
+
+Add support for loading files from non-JSX frameworks such as Vue and Svelte

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -19,7 +19,7 @@
     "test": "tap --no-coverage test/**"
   },
   "dependencies": {
-    "@astrojs/svelte-language-integration": "*",
+    "@astrojs/svelte-language-integration": "^0.1.0",
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -10,7 +10,6 @@
   },
   "files": [
     "dist",
-    "astro.d.ts",
     "bin",
     "types"
   ],
@@ -20,6 +19,7 @@
     "test": "tap --no-coverage test/**"
   },
   "dependencies": {
+    "@astrojs/svelte-language-integration": "*",
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -1,12 +1,12 @@
 import * as ts from 'typescript';
-import { readFileSync } from 'fs';
 import { TextDocumentContentChangeEvent, Position, Range } from 'vscode-languageserver';
 import { Document, DocumentMapper, IdentityMapper } from '../../core/documents';
 import { isInTag, positionAt, offsetAt } from '../../core/documents/utils';
 import { pathToUrl } from '../../utils';
-import { getScriptKindFromFileName, isAstroFilePath, toVirtualAstroFilePath } from './utils';
+import { getScriptKindFromFileName, isAstroFilePath, toVirtualAstroFilePath, isVirtualSvelteFilePath, isFrameworkFilePath, isVirtualFrameworkFilePath } from './utils';
 import { EOL } from 'os';
 import astro2tsx from './astro2tsx';
+import { toTSX as Svelte2TSX } from "@astrojs/svelte-language-integration"
 
 /**
  * The mapper to get from original snapshot positions to generated and vice versa.
@@ -26,233 +26,311 @@ export interface SnapshotFragment extends DocumentMapper {
 }
 
 export interface DocumentSnapshot extends ts.IScriptSnapshot {
-  version: number;
-  filePath: string;
-  scriptKind: ts.ScriptKind;
-  parserError: ParserError | null;
-  positionAt(offset: number): Position;
-  /**
-   * Instantiates a source mapper.
-   * `destroyFragment` needs to be called when
-   * it's no longer needed / the class should be cleaned up
-   * in order to prevent memory leaks.
-   */
-  getFragment(): Promise<DocumentFragmentSnapshot>;
-  /**
-   * Needs to be called when source mapper
-   * is no longer needed / the class should be cleaned up
-   * in order to prevent memory leaks.
-   */
-  destroyFragment(): void;
-  /**
-   * Convenience function for getText(0, getLength())
-   */
-  getFullText(): string;
+	version: number;
+	filePath: string;
+	scriptKind: ts.ScriptKind;
+	parserError: ParserError | null;
+
+	positionAt(offset: number): Position;
+	/**
+	 * Instantiates a source mapper.
+	 * `destroyFragment` needs to be called when
+	 * it's no longer needed / the class should be cleaned up
+	 * in order to prevent memory leaks.
+	 */
+	getFragment(): Promise<DocumentFragmentSnapshot>;
+	/**
+	 * Needs to be called when source mapper
+	 * is no longer needed / the class should be cleaned up
+	 * in order to prevent memory leaks.
+	 */
+	destroyFragment(): void;
+	/**
+	 * Convenience function for getText(0, getLength())
+	 */
+	getFullText(): string;
+
+	createFragment(mapper: IdentityMapper): DocumentFragmentSnapshot;
+
+	toTSX(code: string, filePath: string): string
 }
 
-export const createDocumentSnapshot = (filePath: string, currentText: string | null, createDocument?: (_filePath: string, text: string, overrideText: boolean) => Document): DocumentSnapshot => {
-  const text = currentText || (ts.sys.readFile(filePath) ?? '');
+export abstract class DocumentFragmentSnapshot implements Omit<DocumentSnapshot, 'createFragment' | 'getFragment' | 'destroyFragment' | 'toTSX'>, SnapshotFragment {
+	version: number;
+	filePath: string;
+	url: string;
+	text: string;
+	parserError = null;
 
-  if (isAstroFilePath(filePath)) {
-    if (!createDocument) throw new Error('Astro documents require the "createDocument" utility to be provided');
-    const snapshot = new AstroDocumentSnapshot(createDocument(filePath, text, currentText !== null));
-    return snapshot;
-  }
+	scriptKind = ts.ScriptKind.TSX;
+	scriptInfo = null;
 
-  return new TypeScriptDocumentSnapshot(0, filePath, text);
-};
+	constructor(private mapper: any, private parent: Document, toTSX: (code: string, filePath: string) => string) {
+		const filePath = parent.getFilePath();
+		if (!filePath) throw new Error('Cannot create a document fragment from a non-local document');
+		const text = parent.getText();
+		this.version = parent.version;
+		this.filePath = this.toVirtualFilePath(filePath);
+		this.url = this.toVirtualFilePath(filePath);
+		this.text = toTSX(text, this.filePath);
+	}
 
-class AstroDocumentSnapshot implements DocumentSnapshot {
-  version = this.doc.version;
-  scriptKind = ts.ScriptKind.Unknown;
-  parserError = null;
+	abstract toVirtualFilePath(filePath: string): string;
 
-  constructor(private doc: Document) {}
+	getText(start: number, end: number) {
+		return this.text.substring(start, end);
+	}
 
-  async getFragment(): Promise<DocumentFragmentSnapshot> {
-    const uri = pathToUrl(this.filePath);
-    const mapper = await this.getMapper(uri);
-    return new DocumentFragmentSnapshot(mapper, this.doc);
-  }
+	getLength() {
+		return this.text.length;
+	}
 
-  async destroyFragment() {
-    return;
-  }
+	getFullText() {
+		return this.text;
+	}
 
-  get text() {
-    let raw = this.doc.getText();
-    return astro2tsx(raw).code;
-  }
+	getChangeRange() {
+		return undefined;
+	}
 
-  get filePath() {
-    return this.doc.getFilePath() || '';
-  }
+	positionAt(offset: number) {
+		return positionAt(offset, this.text);
+	}
 
-  getText(start: number, end: number) {
-    return this.text.substring(start, end);
-  }
+	getLineContainingOffset(offset: number) {
+		const chunks = this.getText(0, offset).split(EOL);
+		return chunks[chunks.length - 1];
+	}
 
-  getLength() {
-    return this.text.length;
-  }
+	offsetAt(position: Position): number {
+		return offsetAt(position, this.text);
+	}
 
-  getFullText() {
-    return this.text;
-  }
+	getOriginalPosition(pos: Position): Position {
+		return this.mapper.getOriginalPosition(pos);
+	}
 
-  getChangeRange() {
-    return undefined;
-  }
+	getGeneratedPosition(pos: Position): Position {
+		return this.mapper.getGeneratedPosition(pos);
+	}
 
-  positionAt(offset: number) {
-    return positionAt(offset, this.text);
-  }
+	isInGenerated(pos: Position): boolean {
+		return !isInTag(pos, this.parent.styleInfo);
+	}
 
-  getLineContainingOffset(offset: number) {
-    const chunks = this.getText(0, offset).split(EOL);
-    return chunks[chunks.length - 1];
-  }
-
-  offsetAt(position: Position) {
-    return offsetAt(position, this.text);
-  }
-
-  private getMapper(uri: string) {
-    return new IdentityMapper(uri);
-  }
+	getURL(): string {
+		return this.url;
+	}
 }
 
-export class DocumentFragmentSnapshot implements Omit<DocumentSnapshot, 'getFragment' | 'destroyFragment'>, SnapshotFragment {
-  version: number;
-  filePath: string;
-  url: string;
-  text: string;
-  parserError = null;
+abstract class DocumentSnapshotBase implements DocumentSnapshot {
+	version = this.doc.version;
+	scriptKind = ts.ScriptKind.TSX;
+	parserError = null;
 
-  scriptKind = ts.ScriptKind.TSX;
-  scriptInfo = null;
+	constructor(public doc: Document) {}
 
-  constructor(private mapper: any, private parent: Document) {
-    const filePath = parent.getFilePath();
-    if (!filePath) throw new Error('Cannot create a document fragment from a non-local document');
-    const text = parent.getText();
-    this.version = parent.version;
-    this.filePath = toVirtualAstroFilePath(filePath);
-    this.url = toVirtualAstroFilePath(filePath);
-    this.text = astro2tsx(text).code;
-  }
+	abstract getFragment(): Promise<DocumentFragmentSnapshot>;
+	abstract destroyFragment(): void
+	abstract createFragment(mapper: IdentityMapper): DocumentFragmentSnapshot
+	abstract toTSX(code: string, filePath: string): string
 
-  getText(start: number, end: number) {
-    return this.text.substring(start, end);
-  }
+	get text() {
+		let raw = this.doc.getText();
+		return this.toTSX(raw, this.filePath);
+	}
 
-  getLength() {
-    return this.text.length;
-  }
+	get filePath() {
+		return this.doc.getFilePath() || '';
+	}
 
-  getFullText() {
-    return this.text;
-  }
+	getText(start: number, end: number) {
+		return this.text.substring(start, end);
+	}
 
-  getChangeRange() {
-    return undefined;
-  }
+	getLength() {
+		return this.text.length;
+	}
 
-  positionAt(offset: number) {
-    return positionAt(offset, this.text);
-  }
+	getFullText() {
+		return this.text;
+	}
 
-  getLineContainingOffset(offset: number) {
-    const chunks = this.getText(0, offset).split(EOL);
-    return chunks[chunks.length - 1];
-  }
+	getChangeRange() {
+		return undefined;
+	}
 
-  offsetAt(position: Position): number {
-    return offsetAt(position, this.text);
-  }
+	positionAt(offset: number) {
+		return positionAt(offset, this.text);
+	}
 
-  getOriginalPosition(pos: Position): Position {
-    return this.mapper.getOriginalPosition(pos);
-  }
+	getLineContainingOffset(offset: number) {
+		const chunks = this.getText(0, offset).split(EOL);
+		return chunks[chunks.length - 1];
+	}
 
-  getGeneratedPosition(pos: Position): Position {
-    return this.mapper.getGeneratedPosition(pos);
-  }
+	offsetAt(position: Position) {
+		return offsetAt(position, this.text);
+	}
 
-  isInGenerated(pos: Position): boolean {
-    return !isInTag(pos, this.parent.styleInfo);
-  }
+	public getMapper(uri: string) {
+		return new IdentityMapper(uri);
+	}
+}
 
-  getURL(): string {
-    return this.url;
-  }
+class FrameworkDocumentSnapshot extends DocumentSnapshotBase {
+	toTSX(code: string, filePath: string): string {
+		if (isVirtualSvelteFilePath(filePath)) {
+			return Svelte2TSX(code);
+		}
+		return 'export default function() {}';
+	}
+
+	createFragment(mapper: IdentityMapper): FrameworkDocumentFragmentSnapshot {
+			return new FrameworkDocumentFragmentSnapshot(mapper, this.doc, this.toTSX)
+	}
+
+	async getFragment(): Promise<FrameworkDocumentFragmentSnapshot> {
+		const uri = pathToUrl(this.filePath);
+		const mapper = await this.getMapper(uri);
+		return this.createFragment(mapper)
+	}
+
+	async destroyFragment() {
+		return;
+	}
+}
+
+class FrameworkDocumentFragmentSnapshot extends DocumentFragmentSnapshot {
+	toVirtualFilePath(filePath: string): string {
+		return filePath;
+	}
+}
+
+
+class AstroDocumentSnapshot extends DocumentSnapshotBase {
+	createFragment(mapper: IdentityMapper): AstroDocumentFragmentSnapshot {
+		return new AstroDocumentFragmentSnapshot(mapper, this.doc, this.toTSX);
+	}
+
+	async getFragment(): Promise<FrameworkDocumentFragmentSnapshot> {
+		const uri = pathToUrl(this.filePath);
+		const mapper = await this.getMapper(uri);
+		return new AstroDocumentFragmentSnapshot(mapper, this.doc, this.toTSX);
+	}
+
+	async destroyFragment() {
+		return;
+	}
+
+	toTSX(code: string, filePath: string): string {
+		return astro2tsx(code).code;
+	}
+}
+
+export class AstroDocumentFragmentSnapshot extends DocumentFragmentSnapshot {
+	toVirtualFilePath(filePath: string): string {
+		return toVirtualAstroFilePath(filePath)
+	}
 }
 
 export class TypeScriptDocumentSnapshot implements DocumentSnapshot {
-  scriptKind = getScriptKindFromFileName(this.filePath);
-  scriptInfo = null;
-  parserError = null;
-  url: string;
+	scriptKind = getScriptKindFromFileName(this.filePath);
+	scriptInfo = null;
+	parserError = null;
+	url: string;
 
-  constructor(public version: number, public readonly filePath: string, private text: string) {
-    this.url = pathToUrl(filePath);
-  }
+	constructor(public version: number, public readonly filePath: string, private text: string) {
+		this.url = pathToUrl(filePath);
+	}
 
-  getText(start: number, end: number) {
-    return this.text.substring(start, end);
-  }
+	// We don't create Fragments for TypescriptDocument, nor do we convert them to TSX so those three methods are not
+	// necessary, though they're required to be implemented for DocumentSnapshot
+	toTSX(): any {
+		return;
+	}
 
-  getLength() {
-    return this.text.length;
-  }
+	createFragment(): any {
+		return;
+	}
 
-  getFullText() {
-    return this.text;
-  }
+	destroyFragment() {
+		return;
+	}
 
-  getChangeRange() {
-    return undefined;
-  }
+	getText(start: number, end: number) {
+		return this.text.substring(start, end);
+	}
 
-  positionAt(offset: number) {
-    return positionAt(offset, this.text);
-  }
+	getLength() {
+		return this.text.length;
+	}
 
-  offsetAt(position: Position): number {
-    return offsetAt(position, this.text);
-  }
+	getFullText() {
+		return this.text;
+	}
 
-  async getFragment(): Promise<DocumentFragmentSnapshot> {
-    return this as unknown as any;
-  }
+	getChangeRange() {
+		return undefined;
+	}
 
-  getOriginalPosition(pos: Position): Position {
-    return pos;
-  }
+	positionAt(offset: number) {
+		return positionAt(offset, this.text);
+	}
 
-  destroyFragment() {
-    // nothing to clean up
-  }
+	offsetAt(position: Position): number {
+		return offsetAt(position, this.text);
+	}
 
-  getLineContainingOffset(offset: number) {
-    const chunks = this.getText(0, offset).split('\n');
-    return chunks[chunks.length - 1];
-  }
+	async getFragment(): Promise<FrameworkDocumentFragmentSnapshot> {
+		return this as unknown as any;
+	}
 
-  update(changes: TextDocumentContentChangeEvent[]): void {
-    for (const change of changes) {
-      let start = 0;
-      let end = 0;
-      if ('range' in change) {
-        start = this.offsetAt(change.range.start);
-        end = this.offsetAt(change.range.end);
-      } else {
-        end = this.getLength();
-      }
+	getOriginalPosition(pos: Position): Position {
+		return pos;
+	}
 
-      this.text = this.text.slice(0, start) + change.text + this.text.slice(end);
-    }
+	getLineContainingOffset(offset: number) {
+		const chunks = this.getText(0, offset).split('\n');
+		return chunks[chunks.length - 1];
+	}
 
-    this.version++;
-  }
+	update(changes: TextDocumentContentChangeEvent[]): void {
+		for (const change of changes) {
+			let start = 0;
+			let end = 0;
+			if ('range' in change) {
+				start = this.offsetAt(change.range.start);
+				end = this.offsetAt(change.range.end);
+			} else {
+				end = this.getLength();
+			}
+
+			this.text = this.text.slice(0, start) + change.text + this.text.slice(end);
+		}
+
+		this.version++;
+	}
 }
+
+export const createDocumentSnapshot = (
+	filePath: string,
+	currentText: string | null,
+	createDocument?: (_filePath: string, text: string, overrideText: boolean) => Document
+): DocumentSnapshot => {
+	let text = currentText || (ts.sys.readFile(filePath.replace(".tsx", "")) ?? '');
+
+	if (isVirtualFrameworkFilePath('vue', 'tsx', filePath) || isVirtualFrameworkFilePath('svelte', 'tsx', filePath)) {
+		if (!createDocument) throw new Error('Framework documents require the "createDocument" utility to be provided');
+		const snapshot = new FrameworkDocumentSnapshot(createDocument(filePath, text, currentText !== null));
+		return snapshot;
+	}
+
+	if (isAstroFilePath(filePath)) {
+		if (!createDocument) throw new Error('Astro documents require the "createDocument" utility to be provided');
+		const snapshot = new AstroDocumentSnapshot(createDocument(filePath, text, currentText !== null));
+		return snapshot;
+	}
+
+	return new TypeScriptDocumentSnapshot(0, filePath, text);
+};

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver';
-import { toVirtualAstroFilePath } from './utils';
+import { toVirtualFilePath } from './utils';
 import { DocumentSnapshot, TypeScriptDocumentSnapshot, createDocumentSnapshot } from './DocumentSnapshot';
 
 export interface TsFilesSpec {
@@ -66,11 +66,13 @@ export class SnapshotManager {
   }
 
   getFileNames() {
-    return Array.from(this.documents.keys()).map((fileName) => toVirtualAstroFilePath(fileName));
+    return Array.from(this.documents.keys()).map((fileName) => toVirtualFilePath(fileName));
   }
 
   getProjectFileNames() {
-    return [...this.projectFiles];
+    return this.projectFiles.map((file) => {
+			return toVirtualFilePath(file)
+		});
   }
 
   private logStatistics() {

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -15,7 +15,7 @@ import { CompletionContext, DefinitionLink, FileChangeType, Position, LocationLi
 import * as ts from 'typescript';
 import { LanguageServiceManager } from './LanguageServiceManager';
 import { SnapshotManager } from './SnapshotManager';
-import { convertToLocationRange, isVirtualAstroFilePath, ensureRealAstroFilePath, getScriptKindFromFileName, toVirtualAstroFilePath } from './utils';
+import { convertToLocationRange, ensureRealAstroFilePath, getScriptKindFromFileName, toVirtualAstroFilePath, ensureRealFilePath, isVirtualFilePath } from './utils';
 import { isNotNullOrUndefined, pathToUrl } from '../../utils';
 import { CompletionsProviderImpl, CompletionEntryWithIdentifer } from './features/CompletionsProvider';
 import { HoverProviderImpl } from './features/HoverProvider';
@@ -125,8 +125,8 @@ export class TypeScriptPlugin implements CompletionsProvider {
         const { fragment, snapshot } = await docs.retrieve(def.fileName);
 
         if (isNoTextSpanInGeneratedCode(snapshot.getFullText(), def.textSpan)) {
-          const fileName = ensureRealAstroFilePath(def.fileName);
-          const textSpan = isVirtualAstroFilePath(tsFilePath) ? { start: 0, length: 0 } : def.textSpan;
+          const fileName = ensureRealFilePath(def.fileName);
+          const textSpan = isVirtualFilePath(tsFilePath) ? { start: 0, length: 0 } : def.textSpan;
           return LocationLink.create(
             pathToUrl(fileName),
             convertToLocationRange(fragment, textSpan),

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -147,7 +147,7 @@ export function convertToLocationRange(defDoc: SnapshotFragment, textSpan: ts.Te
   return range;
 }
 
-type FrameworkExt = 'astro' | 'vue' | 'jsx' | 'tsx' | 'svelte';
+type FrameworkExt = 'astro' | 'vue' | 'jsx' | 'tsx' | 'svelte' | 'ts';
 type FrameworkVirtualExt = 'ts' | 'tsx';
 
 const VirtualExtension: Record<FrameworkVirtualExt, FrameworkVirtualExt> = {
@@ -168,12 +168,16 @@ export function isAstroFilePath(filePath: string) {
   return filePath.endsWith('.astro');
 }
 
+export function isFrameworkFilePath(filePath: string) {
+	return filePath.endsWith('.svelte') || filePath.endsWith('.vue')
+}
+
 export function isVirtualAstroFilePath(filePath: string) {
   return isVirtualFrameworkFilePath('astro', VirtualExtension.tsx, filePath);
 }
 
 export function isVirtualVueFilePath(filePath: string) {
-  return isVirtualFrameworkFilePath('vue', VirtualExtension.ts, filePath);
+  return isVirtualFrameworkFilePath('vue', VirtualExtension.tsx, filePath);
 }
 
 export function isVirtualJsxFilePath(filePath: string) {
@@ -181,11 +185,15 @@ export function isVirtualJsxFilePath(filePath: string) {
 }
 
 export function isVirtualSvelteFilePath(filePath: string) {
-  return isVirtualFrameworkFilePath('svelte', VirtualExtension.ts, filePath);
+  return isVirtualFrameworkFilePath('svelte', VirtualExtension.tsx, filePath);
+}
+
+export function isVirtualTsFilePath(filePath: string) {
+	return isVirtualFrameworkFilePath('ts', VirtualExtension.tsx, filePath);
 }
 
 export function isVirtualFilePath(filePath: string) {
-  return isVirtualAstroFilePath(filePath) || isVirtualVueFilePath(filePath) || isVirtualSvelteFilePath(filePath) || isVirtualJsxFilePath(filePath);
+  return isVirtualAstroFilePath(filePath) || isVirtualVueFilePath(filePath) || isVirtualSvelteFilePath(filePath) || isVirtualJsxFilePath(filePath) || isVirtualTsFilePath(filePath);
 }
 
 export function toVirtualAstroFilePath(filePath: string) {
@@ -196,6 +204,16 @@ export function toVirtualAstroFilePath(filePath: string) {
   } else {
     return filePath;
   }
+}
+
+export function toVirtualFilePath(filePath: string) {
+	if (isVirtualFilePath(filePath)) {
+		return filePath;
+	} else if (isFrameworkFilePath(filePath) || isAstroFilePath(filePath) || filePath.endsWith('.ts')) {
+		return `${filePath}.tsx`;
+	} else {
+		return filePath;
+	}
 }
 
 export function toRealAstroFilePath(filePath: string) {

--- a/packages/svelte-language-integration/package.json
+++ b/packages/svelte-language-integration/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@astrojs/svelte-language-integration",
+  "version": "0.1.0",
+  "description": "",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "astro-scripts dev \"src/**/*.ts\""
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "svelte2tsx": "^0.5.5"
+  }
+}

--- a/packages/svelte-language-integration/src/index.ts
+++ b/packages/svelte-language-integration/src/index.ts
@@ -1,0 +1,17 @@
+import { svelte2tsx } from "svelte2tsx"
+
+export const languageId = "svelte"
+export const extension = ".svelte"
+
+export function toTSX(code: string): string {
+	const result = `${svelte2tsx(code).code}
+
+	let Props = render().props;
+
+	export default function(props: typeof Props) {
+		<></>
+	}
+`;
+
+	return result
+}

--- a/packages/svelte-language-integration/tsconfig.json
+++ b/packages/svelte-language-integration/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2019",
+    "module": "CommonJS"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
 
   packages/language-server:
     specifiers:
-      '@astrojs/svelte-language-integration': '*'
+      '@astrojs/svelte-language-integration': ^0.1.0
       '@types/lodash': ^4.14.179
       '@vscode/emmet-helper': ^2.8.4
       astro: ^0.23.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ importers:
 
   packages/language-server:
     specifiers:
+      '@astrojs/svelte-language-integration': '*'
       '@types/lodash': ^4.14.179
       '@vscode/emmet-helper': ^2.8.4
       astro: ^0.23.7
@@ -47,6 +48,7 @@ importers:
       vscode-languageserver-types: ^3.16.0
       vscode-uri: ^3.0.3
     dependencies:
+      '@astrojs/svelte-language-integration': link:../svelte-language-integration
       '@vscode/emmet-helper': 2.8.4
       lodash: 4.17.21
       source-map: 0.7.3
@@ -64,6 +66,12 @@ importers:
       astro: 0.23.7_typescript@4.5.5
       astro-scripts: link:../../scripts
       tap: 15.2.3_typescript@4.5.5
+
+  packages/svelte-language-integration:
+    specifiers:
+      svelte2tsx: ^0.5.5
+    dependencies:
+      svelte2tsx: 0.5.5_typescript@4.5.5
 
   packages/ts-plugin:
     specifiers:
@@ -1819,6 +1827,10 @@ packages:
     dependencies:
       character-entities: 2.0.1
     dev: true
+
+  /dedent-js/1.0.1:
+    resolution: {integrity: sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU=}
+    dev: false
 
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -3720,6 +3732,12 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /lower-case/2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
   /lru-cache/4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -4348,6 +4366,13 @@ packages:
       '@types/nlcst': 1.0.0
     dev: true
 
+  /no-case/3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.3.1
+    dev: false
+
   /node-preload/0.2.1:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
     engines: {node: '>=8'}
@@ -4604,6 +4629,13 @@ packages:
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: true
+
+  /pascal-case/3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.3.1
+    dev: false
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -5533,6 +5565,17 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /svelte2tsx/0.5.5_typescript@4.5.5:
+    resolution: {integrity: sha512-5n8jP721bM3vXPk36AM9diZg2aasLvsfP/Zt9CQVrcqcnzexOYVeS8kpGk+3mofOPvPvXnOCLdff62usI/KOMw==}
+    peerDependencies:
+      svelte: ^3.24
+      typescript: ^4.1.2
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      typescript: 4.5.5
+    dev: false
+
   /table/6.8.0:
     resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
     engines: {node: '>=10.0.0'}
@@ -5734,6 +5777,10 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib/2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: false
 
   /tsm/2.2.1:
     resolution: {integrity: sha512-qvJB0baPnxQJolZru11mRgGTdNlx17WqgJnle7eht3Vhb+VUR4/zFA5hFl6NqRe7m8BD9w/6yu0B2XciRrdoJA==}


### PR DESCRIPTION
## Changes

I first want to start this by giving huge thanks to @matthewp for helping me out with this because between the Document, DocumentSnapshot, DocumentFragmentSnapshot and other Java-like classes I was (and still fairly is) lost most of the time, he really helped me out figure out how to do this!

This PR adds support for importing Svelte and Vue files and for Svelte files especially, converting them to TSX and getting proper props information, like we do for Astro files. 

This setup a bigger plan to eventually allow users to add support for any kind of framework that doesn't use JSX/TSX files without needing to make changes to the language-server itself. We're not there just yet (and we probably want to make things a lot cleaner before we do that) but, this is a first step

Additionally, this PR fix needing to remove the extension from `.ts` file in order to get types and completions. Technically, it is not wrong from TypeScript to require the extension to be removed as it is its normal behavior. However, Astro (by the past at least) as always recommended to put the extension, so we'll match that here. The way it works on the technical side is that we pretend that `.ts` files are `.tsx` files. I'm not sure why it works, but it does

I am not proud of the code but, it works and it is an improvement. Notably, the error when importing Svelte and Vue files was one of the most mentioned issues in our support threads last month

Fixes https://github.com/withastro/language-tools/issues/142 https://github.com/withastro/language-tools/issues/126

### Known issues

#### Diagnostics and hover information is currently unavailable for imported framework components

Not sure why, my guess is that TypeScript doesn't get the DocumentSnapshot of our Svelte file. I'm not sure why, it should technically be going through our SnapshotManager and get the proper Snapshot for said file but it seems like it doesn't. Completions however are working nicely because they go through a different system (which maybe diagnostics could also use, not sure)

#### Types from imported Vue and Svelte files are not updated when those files are changed

Again not sure why, I think this is part of a potentially bigger issue related to cache (ex https://github.com/withastro/language-tools/issues/106) or maybe it's just a question of getting the language-server to update its cache when those files are updated

## Testing

Tested manually for now. When I figure out how to make diagnostics works (in a later PR), I plan to also write tests for diagnostics for different framework's components

## Docs

Technically a bug fix so no docs needed
