### PR TITLE
Add support for document color

### DIFF
--- a/.changeset/dirty-eggs-tell.md
+++ b/.changeset/dirty-eggs-tell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for colors indicators and color picker

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -141,6 +141,24 @@ export class PluginHost {
 		return this.execute<any>('rename', [document, position, newName], ExecuteMode.FirstNonNull);
 	}
 
+	async getDocumentColors(textDocument: TextDocumentIdentifier): Promise<ColorInformation[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(await this.execute<ColorInformation[]>('getDocumentColors', [document], ExecuteMode.Collect));
+	}
+
+	async getColorPresentations(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		color: Color
+	): Promise<ColorPresentation[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(
+			await this.execute<ColorPresentation[]>('getColorPresentations', [document, range, color], ExecuteMode.Collect)
+		);
+	}
+
 	async getSignatureHelp(
 		textDocument: TextDocumentIdentifier,
 		position: Position,

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -81,6 +81,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 						':',
 					],
 				},
+				colorProvider: true,
 				hoverProvider: true,
 				signatureHelpProvider: {
 					triggerCharacters: ['(', ',', '<'],
@@ -147,6 +148,11 @@ export function startLanguageServer(connection: vscode.Connection) {
 		}
 		return pluginHost.resolveCompletion(data, completionItem);
 	});
+
+	connection.onDocumentColor((params: vscode.DocumentColorParams) => pluginHost.getDocumentColors(params.textDocument));
+	connection.onColorPresentation((params: vscode.ColorPresentationParams) =>
+		pluginHost.getColorPresentations(params.textDocument, params.range, params.color)
+	);
 
 	connection.onRequest(TagCloseRequest, (evt: any) => pluginHost.doTagComplete(evt.textDocument, evt.position));
 	connection.onSignatureHelp((evt, cancellationToken) =>

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -60,4 +60,86 @@ describe('CSS Plugin', () => {
 			expect(completions, 'Expected completions to be null').to.be.null;
 		});
 	});
+
+	describe('provide document colors', () => {
+		it('for normal css', () => {
+			const { plugin, document } = setup('<style>h1 {color:blue;}</style>');
+
+			const colors = plugin.getColorPresentations(
+				document,
+				{
+					start: { line: 0, character: 17 },
+					end: { line: 0, character: 21 },
+				},
+				{ alpha: 1, blue: 255, green: 0, red: 0 }
+			);
+
+			expect(colors).to.deep.equal([
+				{
+					label: 'rgb(0, 0, 65025)',
+					textEdit: {
+						range: {
+							end: {
+								character: 21,
+								line: 0,
+							},
+							start: {
+								character: 17,
+								line: 0,
+							},
+						},
+						newText: 'rgb(0, 0, 65025)',
+					},
+				},
+				{
+					label: '#00000fe01',
+					textEdit: {
+						range: {
+							end: {
+								character: 21,
+								line: 0,
+							},
+							start: {
+								character: 17,
+								line: 0,
+							},
+						},
+						newText: '#00000fe01',
+					},
+				},
+				{
+					label: 'hsl(240, -101%, 12750%)',
+					textEdit: {
+						range: {
+							end: {
+								character: 21,
+								line: 0,
+							},
+							start: {
+								character: 17,
+								line: 0,
+							},
+						},
+						newText: 'hsl(240, -101%, 12750%)',
+					},
+				},
+				{
+					label: 'hwb(240 0% -25400%)',
+					textEdit: {
+						newText: 'hwb(240 0% -25400%)',
+						range: {
+							end: {
+								character: 21,
+								line: 0,
+							},
+							start: {
+								character: 17,
+								line: 0,
+							},
+						},
+					},
+				},
+			]);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

This add support for getting document colors and adding color presentations in style tags

![image](https://user-images.githubusercontent.com/3019731/158813239-de14f46c-4057-4698-989c-55ce038164f8.png)

Thanks to updating to the latest version of the CSS language service in the refactor, we benefits from hwb support, which is nice and very modern!

## Testing

Tests were added for this feature in normal CSS

The values expected in the test might look weird but they're the right ones :woman_shrugging: 

## Docs

No docs needed
