### PR TITLE
Fix errors with malformed Svelte components, fix missing libs in some context

### DIFF
--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -222,9 +222,6 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 
 		configJson.compilerOptions = Object.assign(getDefaultCompilerOptions(), configJson.compilerOptions);
 
-		// If the user supplied exclude, let's use theirs
-		configJson.exclude ?? (configJson.exclude = getDefaultExclude());
-
 		// Delete include so that .astro files don't get mistakenly excluded by the user
 		delete configJson.include;
 
@@ -235,9 +232,6 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 		const forcedCompilerOptions: ts.CompilerOptions = {
 			// Our TSX is currently not typed, which unfortunately means that we can't support `noImplicitAny`
 			noImplicitAny: false,
-			// Most of the code people write in an .astro file is in the frontmatter which is executed server side
-			// Thus, we don't want the DOM lib. We'll need to overwrite this for script tags however
-			lib: ['ESNext'],
 
 			noEmit: true,
 			declaration: false,

--- a/packages/svelte-language-integration/src/index.ts
+++ b/packages/svelte-language-integration/src/index.ts
@@ -4,14 +4,20 @@ export const languageId = 'svelte';
 export const extension = '.svelte';
 
 export function toTSX(code: string): string {
-	const result = `${svelte2tsx(code).code}
+	let result = 'export default function() {}';
 
-	let Props = render().props;
+	try {
+		result = `${svelte2tsx(code).code}
 
-	export default function(props: typeof Props) {
-		<></>
+		let Props = render().props;
+
+		export default function(props: typeof Props) {
+			<></>
+		}
+	`;
+	} catch(e: any) {
+		return result
 	}
-`;
 
 	return result;
 }


### PR DESCRIPTION
## Changes

Wrap the call to `svelte2tsx` in a try block in order to avoid the extension crashing because of a malformed Svelte component. Instead, when it doesn't work it just returns a default empty function like we do for Vue components. I alternatively tried to set the `emitOnTemplateError` to `true` but it didn't seems to work (and wouldn't be a really reliable solution anyway). 

In the future, a better fix would be to return the error from the Svelte compiler to users directly in the Astro file, that'd be neat

This also removes the forcing of `lib: ['ESNext'],` in the TypeScript config for Astro files as it didn't work in certain contexts, not sure why but this fixes the issue for now

## Testing

Both fixes tested manually on repos where it didn't work previously

## Docs

No docs needed
