### PR TITLE
Provide types for our TSX output

### DIFF
--- a/packages/language-server/src/core/documents/AstroDocument.ts
+++ b/packages/language-server/src/core/documents/AstroDocument.ts
@@ -1,4 +1,4 @@
-import { HTMLDocument } from 'vscode-html-languageservice';
+import { HTMLDocument, Range } from 'vscode-html-languageservice';
 import { urlToPath } from '../../utils';
 import { WritableDocument } from './DocumentBase';
 import { AstroMetadata, parseAstro } from './parseAstro';
@@ -29,7 +29,12 @@ export class AstroDocument extends WritableDocument {
 		this.updateDocInfo();
 	}
 
-	getText(): string {
+	getText(range?: Range | undefined): string {
+		if (range) {
+			const start = this.offsetAt(range.start);
+			const end = this.offsetAt(range.end);
+			return this.content.substring(start, end);
+		}
 		return this.content;
 	}
 

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -5,6 +5,7 @@ import {
 	TextEdit,
 	CompletionItemKind,
 	FoldingRange,
+	Hover,
 } from 'vscode-languageserver';
 import { doComplete as getEmmetCompletions } from '@vscode/emmet-helper';
 import { getLanguageService } from 'vscode-html-languageservice';
@@ -13,6 +14,7 @@ import { ConfigManager } from '../../core/config/ConfigManager';
 import { AstroDocument } from '../../core/documents/AstroDocument';
 import { isInComponentStartTag, isInsideExpression, isInsideFrontmatter } from '../../core/documents/utils';
 import { LSHTMLConfig } from '../../core/config/interfaces';
+import { isPossibleComponent } from '../../utils';
 
 export class HTMLPlugin implements Plugin {
 	__name = 'html';
@@ -23,6 +25,24 @@ export class HTMLPlugin implements Plugin {
 
 	constructor(configManager: ConfigManager) {
 		this.configManager = configManager;
+	}
+
+	doHover(document: AstroDocument, position: Position): Hover | null {
+		if (!this.featureEnabled('hover')) {
+			return null;
+		}
+
+		const html = document.html;
+		if (!html) {
+			return null;
+		}
+
+		const node = html.findNodeAt(document.offsetAt(position));
+		if (!node || isPossibleComponent(node)) {
+			return null;
+		}
+
+		return this.lang.doHover(document, position, html);
 	}
 
 	/**

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -1,0 +1,130 @@
+import { newHTMLDataProvider } from 'vscode-html-languageservice';
+
+export const astroAttributes = newHTMLDataProvider('astro-attributes', {
+	version: 1,
+	globalAttributes: [
+		{
+			name: 'class:list',
+			description: 'Utility to provide a list of class',
+		},
+		{
+			name: 'set:html',
+			description: 'Inject unescaped HTML into this tag',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/migrate/#deprecated-unescaped-html',
+				},
+			],
+		},
+		{
+			name: 'set:text',
+			description: 'Inject escaped text into this tag',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/migrate/#deprecated-unescaped-html',
+				},
+			],
+		},
+	],
+	tags: [
+		{
+			name: 'script',
+			attributes: [
+				{
+					// The VS Code tag definitions does not provide a description for the deprecated `charset` attribute on script tags
+					// Which mean that since we get no hover info for this, we instead get JSX hover info. So we'll just specify a description ourselves for this specific case
+					name: 'charset',
+					description:
+						"(Deprecated) It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document.",
+				},
+				{
+					name: 'define:vars',
+					description: 'Passes serializable server-side variables into a client-side script element',
+					references: [
+						{
+							name: 'Astro documentation',
+							url: 'https://docs.astro.build/en/guides/styling/#variables-in-scripts--styles',
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'style',
+			attributes: [
+				{
+					name: 'define:vars',
+					description: 'Passes serializable server-side variables into a client-side style element',
+					references: [
+						{
+							name: 'Astro documentation',
+							url: 'https://docs.astro.build/en/guides/styling/#variables-in-scripts--styles',
+						},
+					],
+				},
+			],
+		},
+	],
+});
+
+export const astroDirectives = newHTMLDataProvider('astro-directives', {
+	version: 1,
+	globalAttributes: [
+		{
+			name: 'client:load',
+			description: 'Start importing the component JS at page load. Hydrate the component when import completes.',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/core-concepts/component-hydration/#hydrate-interactive-components',
+				},
+			],
+		},
+		{
+			name: 'client:idle',
+			description:
+				'Start importing the component JS as soon as main thread is free (uses requestIdleCallback()). Hydrate the component when import completes.',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/core-concepts/component-hydration/#hydrate-interactive-components',
+				},
+			],
+		},
+		{
+			name: 'client:visible',
+			description:
+				'Start importing the component JS as soon as the element enters the viewport (uses IntersectionObserver). Hydrate the component when import completes. Useful for content lower down on the page.',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/core-concepts/component-hydration/#hydrate-interactive-components',
+				},
+			],
+		},
+		{
+			name: 'client:media',
+			description:
+				'Start importing the component JS as soon as the browser matches the given media query (uses matchMedia). Hydrate the component when import completes. Useful for sidebar toggles, or other elements that should only display on mobile or desktop devices.',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/core-concepts/component-hydration/#hydrate-interactive-components',
+				},
+			],
+		},
+		{
+			name: 'client:only',
+			description:
+				'Start importing the component JS at page load and hydrate when the import completes, similar to client:load. The component will be skipped at build time, useful for components that are entirely dependent on client-side APIs. This is best avoided unless absolutely needed, in most cases it is best to render placeholder content on the server and delay any browser API calls until the component hydrates in the browser.',
+			references: [
+				{
+					name: 'Astro documentation',
+					url: 'https://docs.astro.build/en/core-concepts/component-hydration/#hydrate-interactive-components',
+				},
+			],
+		},
+	],
+});

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -233,5 +233,14 @@ function isNoMarkdownBlockQuoteWithinMarkdown(
  * Some diagnostics have JSX-specific nomenclature. Enhance them for more clarity.
  */
 function enhanceIfNecessary(diagnostic: Diagnostic): Diagnostic {
+	if (diagnostic.code === 2322) {
+		// For the rare case where an user might try to put a client directive on something that is not a component
+		if (diagnostic.message.includes("Property 'client:") && diagnostic.message.includes("to type 'HTMLProps")) {
+			return {
+				...diagnostic,
+				message: 'Client directives are only available on framework components',
+			};
+		}
+	}
 	return diagnostic;
 }

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -233,5 +233,5 @@ function isNoMarkdownBlockQuoteWithinMarkdown(
  * Some diagnostics have JSX-specific nomenclature. Enhance them for more clarity.
  */
 function enhanceIfNecessary(diagnostic: Diagnostic): Diagnostic {
-	return diagnostic
+	return diagnostic;
 }

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -233,41 +233,5 @@ function isNoMarkdownBlockQuoteWithinMarkdown(
  * Some diagnostics have JSX-specific nomenclature. Enhance them for more clarity.
  */
 function enhanceIfNecessary(diagnostic: Diagnostic): Diagnostic {
-	if (diagnostic.code === 2786) {
-		return {
-			...diagnostic,
-			message:
-				'Type definitions are missing for this Svelte Component. ' +
-				// eslint-disable-next-line max-len
-				"It needs a class definition with at least the property '$$prop_def' which should contain a map of input property definitions.\n" +
-				'Example:\n' +
-				'  class ComponentName { $$prop_def: { propertyName: string; } }\n' +
-				'If you are using Svelte 3.31+, use SvelteComponentTyped:\n' +
-				'  import type { SvelteComponentTyped } from "svelte";\n' +
-				'  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\n' +
-				'Underlying error:\n' +
-				diagnostic.message,
-		};
-	}
-
-	if (diagnostic.code === 2607) {
-		return {
-			...diagnostic,
-			message:
-				'Element does not support attributes because ' +
-				'type definitions are missing for this Svelte Component or element cannot be used as such.\n\n' +
-				'Underlying error:\n' +
-				diagnostic.message,
-		};
-	}
-
-	if (diagnostic.code === 1184) {
-		return {
-			...diagnostic,
-			message:
-				diagnostic.message + '\nIf this is a declare statement, move it into <script context="module">..</script>',
-		};
-	}
-
-	return diagnostic;
+	return diagnostic
 }

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -247,6 +247,7 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 			allowNonTsExtensions: true,
 			allowJs: true,
 			jsx: ts.JsxEmit.Preserve,
+			jsxImportSource: undefined,
 			jsxFactory: 'astroHTML',
 			module: ts.ModuleKind.ESNext,
 			target: ts.ScriptTarget.ESNext,

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -1,5 +1,5 @@
 import { AstroDocument } from '../../core/documents';
-import { dirname } from 'path';
+import { dirname, resolve } from 'path';
 import ts from 'typescript';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver';
 import { normalizePath } from '../../utils';
@@ -91,6 +91,14 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 
 	const astroModuleLoader = createAstroModuleLoader(getScriptSnapshot, compilerOptions);
 
+	let languageServerDirectory: string;
+	try {
+		languageServerDirectory = dirname(require.resolve('@astrojs/language-server'));
+	} catch (e) {
+		languageServerDirectory = __dirname;
+	}
+	const astroTSXFile = ts.sys.resolvePath(resolve(languageServerDirectory, '../types/astro-jsx.d.ts'));
+
 	const host: ts.LanguageServiceHost = {
 		getNewLine: () => ts.sys.newLine,
 		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
@@ -106,7 +114,7 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 
 		getProjectVersion: () => projectVersion.toString(),
 		getScriptFileNames: () =>
-			Array.from(new Set([...snapshotManager.getProjectFileNames(), ...snapshotManager.getFileNames()])),
+			Array.from(new Set([...snapshotManager.getProjectFileNames(), ...snapshotManager.getFileNames(), astroTSXFile])),
 		getScriptSnapshot,
 		getScriptVersion: (fileName: string) => getScriptSnapshot(fileName).version.toString(),
 	};
@@ -239,6 +247,7 @@ async function createLanguageService(tsconfigPath: string, docContext: LanguageS
 			allowNonTsExtensions: true,
 			allowJs: true,
 			jsx: ts.JsxEmit.Preserve,
+			jsxFactory: 'astroHTML',
 			module: ts.ModuleKind.ESNext,
 			target: ts.ScriptTarget.ESNext,
 			moduleResolution: ts.ModuleResolutionKind.NodeJs,

--- a/packages/language-server/src/plugins/typescript/snapshots/utils.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/utils.ts
@@ -13,7 +13,6 @@ import { AstroSnapshot, TypeScriptDocumentSnapshot } from './DocumentSnapshot';
 import { toTSX as svelte2tsx } from '@astrojs/svelte-language-integration';
 
 // Utilities to create Snapshots from different contexts
-
 export function createFromDocument(document: AstroDocument) {
 	const { code } = astro2tsx(document.getText());
 
@@ -82,7 +81,7 @@ export function createFromFrameworkFilePath(filePath: string, framework: Framewo
 	if (framework === 'svelte') {
 		code = svelte2tsx(originalText);
 	} else {
-		code = 'export default function() {}';
+		code = 'export default function(props: Record<string, any>): any {<div></div>}';
 	}
 
 	return new TypeScriptDocumentSnapshot(0, filePath, code, ts.ScriptKind.TSX);

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -38,20 +38,16 @@ export function getLastPartOfPath(path: string): string {
 }
 
 /**
- *
- * The language service is case insensitive, and would provide
- * hover info for Svelte components like `Option` which have
- * the same name like a html tag.
+ * Return true if a specific node could be a component.
+ * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
  */
 export function isPossibleComponent(node: Node): boolean {
-	return !!node.tag?.[0].match(/[A-Z]/);
+	return !!node.tag?.[0].match(/[A-Z]/) || !!node.tag?.match(/.+[.][A-Z]/);
 }
 
 /**
- *
- * The language service is case insensitive, and would provide
- * hover info for Svelte components like `Option` which have
- * the same name like a html tag.
+ * Return true if a specific node could be a component with a client directive on it.
+ * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
  */
 export function isPossibleClientComponent(node: Node): boolean {
 	if (isPossibleComponent(node) && node.attributes) {

--- a/packages/language-server/types/astro-jsx.d.ts
+++ b/packages/language-server/types/astro-jsx.d.ts
@@ -11,13 +11,17 @@
  */
 declare namespace astroHTML.JSX {
 	/* html jsx */
-	export type Child = Node | Node[] | string | number;
+	export type Child = Node | Node[] | string | number | boolean | null | undefined | unknown;
 	export type Children = Child | Child[];
 
-	type NativeElement = HTMLElement;
+	interface ElementChildrenAttribute {
+		// eslint-disable-next-line @typescript-eslint/ban-types
+		children: {};
+	}
 
 	interface IntrinsicAttributes extends AstroBuiltinProps, AstroBuiltinAttributes {
 		slot?: string;
+		children?: Children;
 	}
 
 	interface AstroBuiltinProps {
@@ -29,13 +33,17 @@ declare namespace astroHTML.JSX {
 	}
 
 	interface AstroBuiltinAttributes {
-		'class:list'?: Record<string, boolean> | Iterable<string> | Iterable<any> | string;
+		'class:list'?: Record<string, boolean> | Record<any, any> | Iterable<string> | Iterable<any> | string;
+		'set:html'?: any;
+		'set:text'?: any;
 	}
 
-	// TypeScript SVGElement has no `dataset` (Chrome 55+, Firefox 51+).
-	type Element = NativeElement & {
-		dataset: DOMStringMap;
-	};
+	// Usable exclusively on script and style tags
+	interface AstroDefineVars {
+		'define:vars'?: any;
+	}
+
+	type Element = HTMLElement;
 
 	//
 	// Event Handler Types
@@ -75,11 +83,7 @@ declare namespace astroHTML.JSX {
 	// unit-less numbers are listed here (see CSSProperty.js in React)
 
 	interface DOMAttributes<T extends EventTarget> {
-		// jsx-dom specific
-		/* children?: Children;
-      innerText?: string;
-      namespaceURI?: string;
-      ref?: ((e: T) => void) | Ref<T>; */
+		children?: Children;
 
 		// Clipboard Events
 		oncopy?: ClipboardEventHandler<T> | undefined | null;
@@ -461,7 +465,7 @@ declare namespace astroHTML.JSX {
 		contextmenu?: string | undefined | null;
 		controls?: boolean | undefined | null;
 		coords?: string | undefined | null;
-		crossorigin?: string | undefined | null;
+		crossorigin?: string | boolean | undefined | null;
 		currenttime?: number | undefined | null;
 		decoding?: 'async' | 'sync' | 'auto' | undefined | null;
 		data?: string | undefined | null;
@@ -489,7 +493,7 @@ declare namespace astroHTML.JSX {
 		height?: number | string | undefined | null;
 		hidden?: boolean | undefined | null;
 		high?: number | undefined | null;
-		href?: string | undefined | null;
+		href?: string | URL | undefined | null;
 		hreflang?: string | undefined | null;
 		htmlfor?: string | undefined | null;
 		httpequiv?: string | undefined | null;
@@ -983,14 +987,14 @@ declare namespace astroHTML.JSX {
 		ruby: HTMLProps<HTMLElement>;
 		s: HTMLProps<HTMLElement>;
 		samp: HTMLProps<HTMLElement>;
-		script: HTMLProps<HTMLElement>;
+		script: HTMLProps<HTMLElement> & AstroDefineVars;
 		section: HTMLProps<HTMLElement>;
 		select: HTMLProps<HTMLSelectElement>;
 		small: HTMLProps<HTMLElement>;
 		source: HTMLProps<HTMLSourceElement>;
 		span: HTMLProps<HTMLSpanElement>;
 		strong: HTMLProps<HTMLElement>;
-		style: HTMLProps<HTMLStyleElement>;
+		style: HTMLProps<HTMLStyleElement> & AstroDefineVars;
 		sub: HTMLProps<HTMLElement>;
 		summary: HTMLProps<HTMLElement>;
 		sup: HTMLProps<HTMLElement>;

--- a/packages/language-server/types/astro-jsx.d.ts
+++ b/packages/language-server/types/astro-jsx.d.ts
@@ -1,0 +1,1072 @@
+/// <reference lib="dom" />
+/* eslint @typescript-eslint/no-unused-vars: off */
+/**
+ * Adapted from jsx-dom
+ * @see https://github.com/proteriax/jsx-dom/blob/be06937ba16908d87bf8aa4372a3583133e02b8a/index.d.ts
+ *
+ * which was adapted from
+ *
+ * Adapted from React’s TypeScript definition from DefinitelyTyped.
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
+ */
+declare namespace astroHTML.JSX {
+	/* html jsx */
+	export type Child = Node | Node[] | string | number;
+	export type Children = Child | Child[];
+
+	type NativeElement = HTMLElement;
+
+	interface IntrinsicAttributes extends AstroBuiltinProps, AstroBuiltinAttributes {
+		slot?: string;
+	}
+
+	interface AstroBuiltinProps {
+		'client:load'?: boolean;
+		'client:idle'?: boolean;
+		'client:visible'?: boolean;
+		'client:media'?: string;
+		'client:only'?: boolean | string;
+	}
+
+	interface AstroBuiltinAttributes {
+		'class:list'?: Record<string, boolean> | Iterable<string> | Iterable<any> | string;
+	}
+
+	// TypeScript SVGElement has no `dataset` (Chrome 55+, Firefox 51+).
+	type Element = NativeElement & {
+		dataset: DOMStringMap;
+	};
+
+	//
+	// Event Handler Types
+	// ----------------------------------------------------------------------
+	type EventHandler<E extends Event = Event, T extends EventTarget = HTMLElement> = (
+		event: E & { currentTarget: EventTarget & T }
+	) => any;
+
+	type ClipboardEventHandler<T extends EventTarget> = EventHandler<ClipboardEvent, T>;
+	type CompositionEventHandler<T extends EventTarget> = EventHandler<CompositionEvent, T>;
+	type DragEventHandler<T extends EventTarget> = EventHandler<DragEvent, T>;
+	type FocusEventHandler<T extends EventTarget> = EventHandler<FocusEvent, T>;
+	type FormEventHandler<T extends EventTarget> = EventHandler<Event, T>;
+	type ChangeEventHandler<T extends EventTarget> = EventHandler<Event, T>;
+	type KeyboardEventHandler<T extends EventTarget> = EventHandler<KeyboardEvent, T>;
+	type MouseEventHandler<T extends EventTarget> = EventHandler<MouseEvent, T>;
+	type TouchEventHandler<T extends EventTarget> = EventHandler<TouchEvent, T>;
+	type PointerEventHandler<T extends EventTarget> = EventHandler<PointerEvent, T>;
+	type UIEventHandler<T extends EventTarget> = EventHandler<UIEvent, T>;
+	type WheelEventHandler<T extends EventTarget> = EventHandler<WheelEvent, T>;
+	type AnimationEventHandler<T extends EventTarget> = EventHandler<AnimationEvent, T>;
+	type TransitionEventHandler<T extends EventTarget> = EventHandler<TransitionEvent, T>;
+	type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEvent, T>;
+
+	// See CSS 3 CSS-wide keywords https://www.w3.org/TR/css3-values/#common-keywords
+	// See CSS 3 Explicit Defaulting https://www.w3.org/TR/css-cascade-3/#defaulting-keywords
+	// "all CSS properties can accept these values"
+	type CSSWideKeyword = 'initial' | 'inherit' | 'unset';
+
+	// See CSS 3 <percentage> type https://drafts.csswg.org/css-values-3/#percentages
+	type CSSPercentage = string;
+
+	// See CSS 3 <length> type https://drafts.csswg.org/css-values-3/#lengths
+	type CSSLength = number | string;
+
+	// This interface is not complete. Only properties accepting
+	// unit-less numbers are listed here (see CSSProperty.js in React)
+
+	interface DOMAttributes<T extends EventTarget> {
+		// jsx-dom specific
+		/* children?: Children;
+      innerText?: string;
+      namespaceURI?: string;
+      ref?: ((e: T) => void) | Ref<T>; */
+
+		// Clipboard Events
+		oncopy?: ClipboardEventHandler<T> | undefined | null;
+		oncut?: ClipboardEventHandler<T> | undefined | null;
+		onpaste?: ClipboardEventHandler<T> | undefined | null;
+
+		// Composition Events
+		oncompositionend?: CompositionEventHandler<T> | undefined | null;
+		oncompositionstart?: CompositionEventHandler<T> | undefined | null;
+		oncompositionupdate?: CompositionEventHandler<T> | undefined | null;
+
+		// Focus Events
+		onfocus?: FocusEventHandler<T> | undefined | null;
+		onfocusin?: FocusEventHandler<T> | undefined | null;
+		onfocusout?: FocusEventHandler<T> | undefined | null;
+		onblur?: FocusEventHandler<T> | undefined | null;
+
+		// Form Events
+		onchange?: FormEventHandler<T> | undefined | null;
+		oninput?: FormEventHandler<T> | undefined | null;
+		onreset?: FormEventHandler<T> | undefined | null;
+		onsubmit?: EventHandler<SubmitEvent, T> | undefined | null;
+		oninvalid?: EventHandler<Event, T> | undefined | null;
+		onbeforeinput?: EventHandler<InputEvent, T> | undefined | null;
+
+		// Image Events
+		onload?: EventHandler | undefined | null;
+		onerror?: EventHandler | undefined | null; // also a Media Event
+
+		// Detail Events
+		ontoggle?: EventHandler<Event, T> | undefined | null;
+
+		// Keyboard Events
+		onkeydown?: KeyboardEventHandler<T> | undefined | null;
+		onkeypress?: KeyboardEventHandler<T> | undefined | null;
+		onkeyup?: KeyboardEventHandler<T> | undefined | null;
+
+		// Media Events
+		onabort?: EventHandler<Event, T> | undefined | null;
+		oncanplay?: EventHandler<Event, T> | undefined | null;
+		oncanplaythrough?: EventHandler<Event, T> | undefined | null;
+		oncuechange?: EventHandler<Event, T> | undefined | null;
+		ondurationchange?: EventHandler<Event, T> | undefined | null;
+		onemptied?: EventHandler<Event, T> | undefined | null;
+		onencrypted?: EventHandler<Event, T> | undefined | null;
+		onended?: EventHandler<Event, T> | undefined | null;
+		onloadeddata?: EventHandler<Event, T> | undefined | null;
+		onloadedmetadata?: EventHandler<Event, T> | undefined | null;
+		onloadstart?: EventHandler<Event, T> | undefined | null;
+		onpause?: EventHandler<Event, T> | undefined | null;
+		onplay?: EventHandler<Event, T> | undefined | null;
+		onplaying?: EventHandler<Event, T> | undefined | null;
+		onprogress?: EventHandler<Event, T> | undefined | null;
+		onratechange?: EventHandler<Event, T> | undefined | null;
+		onseeked?: EventHandler<Event, T> | undefined | null;
+		onseeking?: EventHandler<Event, T> | undefined | null;
+		onstalled?: EventHandler<Event, T> | undefined | null;
+		onsuspend?: EventHandler<Event, T> | undefined | null;
+		ontimeupdate?: EventHandler<Event, T> | undefined | null;
+		onvolumechange?: EventHandler<Event, T> | undefined | null;
+		onwaiting?: EventHandler<Event, T> | undefined | null;
+
+		// MouseEvents
+		onauxclick?: MouseEventHandler<T> | undefined | null;
+		onclick?: MouseEventHandler<T> | undefined | null;
+		oncontextmenu?: MouseEventHandler<T> | undefined | null;
+		ondblclick?: MouseEventHandler<T> | undefined | null;
+		ondrag?: DragEventHandler<T> | undefined | null;
+		ondragend?: DragEventHandler<T> | undefined | null;
+		ondragenter?: DragEventHandler<T> | undefined | null;
+		ondragexit?: DragEventHandler<T> | undefined | null;
+		ondragleave?: DragEventHandler<T> | undefined | null;
+		ondragover?: DragEventHandler<T> | undefined | null;
+		ondragstart?: DragEventHandler<T> | undefined | null;
+		ondrop?: DragEventHandler<T> | undefined | null;
+		onmousedown?: MouseEventHandler<T> | undefined | null;
+		onmouseenter?: MouseEventHandler<T> | undefined | null;
+		onmouseleave?: MouseEventHandler<T> | undefined | null;
+		onmousemove?: MouseEventHandler<T> | undefined | null;
+		onmouseout?: MouseEventHandler<T> | undefined | null;
+		onmouseover?: MouseEventHandler<T> | undefined | null;
+		onmouseup?: MouseEventHandler<T> | undefined | null;
+
+		// Selection Events
+		onselect?: EventHandler<Event, T> | undefined | null;
+		onselectionchange?: EventHandler<Event, T> | undefined | null;
+		onselectstart?: EventHandler<Event, T> | undefined | null;
+
+		// Touch Events
+		ontouchcancel?: TouchEventHandler<T> | undefined | null;
+		ontouchend?: TouchEventHandler<T> | undefined | null;
+		ontouchmove?: TouchEventHandler<T> | undefined | null;
+		ontouchstart?: TouchEventHandler<T> | undefined | null;
+
+		// Pointer Events
+		ongotpointercapture?: PointerEventHandler<T> | undefined | null;
+		onpointercancel?: PointerEventHandler<T> | undefined | null;
+		onpointerdown?: PointerEventHandler<T> | undefined | null;
+		onpointerenter?: PointerEventHandler<T> | undefined | null;
+		onpointerleave?: PointerEventHandler<T> | undefined | null;
+		onpointermove?: PointerEventHandler<T> | undefined | null;
+		onpointerout?: PointerEventHandler<T> | undefined | null;
+		onpointerover?: PointerEventHandler<T> | undefined | null;
+		onpointerup?: PointerEventHandler<T> | undefined | null;
+		onlostpointercapture?: PointerEventHandler<T> | undefined | null;
+
+		// UI Events
+		onscroll?: UIEventHandler<T> | undefined | null;
+		onresize?: UIEventHandler<T> | undefined | null;
+
+		// Wheel Events
+		onwheel?: WheelEventHandler<T> | undefined | null;
+
+		// Animation Events
+		onanimationstart?: AnimationEventHandler<T> | undefined | null;
+		onanimationend?: AnimationEventHandler<T> | undefined | null;
+		onanimationiteration?: AnimationEventHandler<T> | undefined | null;
+
+		// Transition Events
+		ontransitionstart?: TransitionEventHandler<T> | undefined | null;
+		ontransitionrun?: TransitionEventHandler<T> | undefined | null;
+		ontransitionend?: TransitionEventHandler<T> | undefined | null;
+		ontransitioncancel?: TransitionEventHandler<T> | undefined | null;
+
+		// Message Events
+		onmessage?: MessageEventHandler<T> | undefined | null;
+		onmessageerror?: MessageEventHandler<T> | undefined | null;
+
+		// Global Events
+		oncancel?: EventHandler<Event, T> | undefined | null;
+		onclose?: EventHandler<Event, T> | undefined | null;
+		onfullscreenchange?: EventHandler<Event, T> | undefined | null;
+		onfullscreenerror?: EventHandler<Event, T> | undefined | null;
+	}
+
+	// All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
+	interface AriaAttributes {
+		/** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+		'aria-activedescendant'?: string | undefined | null;
+		/** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+		'aria-atomic'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+		 * presented if they are made.
+		 */
+		'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined | null;
+		/** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+		'aria-busy'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+		 * @see aria-pressed @see aria-selected.
+		 */
+		'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined | null;
+		/**
+		 * Defines the total number of columns in a table, grid, or treegrid.
+		 * @see aria-colindex.
+		 */
+		'aria-colcount'?: number | undefined | null;
+		/**
+		 * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+		 * @see aria-colcount @see aria-colspan.
+		 */
+		'aria-colindex'?: number | undefined | null;
+		/**
+		 * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+		 * @see aria-colindex @see aria-rowspan.
+		 */
+		'aria-colspan'?: number | undefined | null;
+		/**
+		 * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+		 * @see aria-owns.
+		 */
+		'aria-controls'?: string | undefined | null;
+		/** Indicates the element that represents the current item within a container or set of related elements. */
+		'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined | null;
+		/**
+		 * Identifies the element (or elements) that describes the object.
+		 * @see aria-labelledby
+		 */
+		'aria-describedby'?: string | undefined | null;
+		/**
+		 * Identifies the element that provides a detailed, extended description for the object.
+		 * @see aria-describedby.
+		 */
+		'aria-details'?: string | undefined | null;
+		/**
+		 * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+		 * @see aria-hidden @see aria-readonly.
+		 */
+		'aria-disabled'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Indicates what functions can be performed when a dragged object is released on the drop target.
+		 * @deprecated in ARIA 1.1
+		 */
+		'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined | null;
+		/**
+		 * Identifies the element that provides an error message for the object.
+		 * @see aria-invalid @see aria-describedby.
+		 */
+		'aria-errormessage'?: string | undefined | null;
+		/** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+		'aria-expanded'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+		 * allows assistive technology to override the general default of reading in document source order.
+		 */
+		'aria-flowto'?: string | undefined | null;
+		/**
+		 * Indicates an element's "grabbed" state in a drag-and-drop operation.
+		 * @deprecated in ARIA 1.1
+		 */
+		'aria-grabbed'?: boolean | 'false' | 'true' | undefined | null;
+		/** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+		'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined | null;
+		/**
+		 * Indicates whether the element is exposed to an accessibility API.
+		 * @see aria-disabled.
+		 */
+		'aria-hidden'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Indicates the entered value does not conform to the format expected by the application.
+		 * @see aria-errormessage.
+		 */
+		'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined | null;
+		/** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+		'aria-keyshortcuts'?: string | undefined | null;
+		/**
+		 * Defines a string value that labels the current element.
+		 * @see aria-labelledby.
+		 */
+		'aria-label'?: string | undefined | null;
+		/**
+		 * Identifies the element (or elements) that labels the current element.
+		 * @see aria-describedby.
+		 */
+		'aria-labelledby'?: string | undefined | null;
+		/** Defines the hierarchical level of an element within a structure. */
+		'aria-level'?: number | undefined | null;
+		/** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+		'aria-live'?: 'off' | 'assertive' | 'polite' | undefined | null;
+		/** Indicates whether an element is modal when displayed. */
+		'aria-modal'?: boolean | 'false' | 'true' | undefined | null;
+		/** Indicates whether a text box accepts multiple lines of input or only a single line. */
+		'aria-multiline'?: boolean | 'false' | 'true' | undefined | null;
+		/** Indicates that the user may select more than one item from the current selectable descendants. */
+		'aria-multiselectable'?: boolean | 'false' | 'true' | undefined | null;
+		/** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
+		'aria-orientation'?: 'horizontal' | 'vertical' | undefined | null;
+		/**
+		 * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+		 * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+		 * @see aria-controls.
+		 */
+		'aria-owns'?: string | undefined | null;
+		/**
+		 * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+		 * A hint could be a sample value or a brief description of the expected format.
+		 */
+		'aria-placeholder'?: string | undefined | null;
+		/**
+		 * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+		 * @see aria-setsize.
+		 */
+		'aria-posinset'?: number | undefined | null;
+		/**
+		 * Indicates the current "pressed" state of toggle buttons.
+		 * @see aria-checked @see aria-selected.
+		 */
+		'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined | null;
+		/**
+		 * Indicates that the element is not editable, but is otherwise operable.
+		 * @see aria-disabled.
+		 */
+		'aria-readonly'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+		 * @see aria-atomic.
+		 */
+		'aria-relevant'?:
+			| 'additions'
+			| 'additions removals'
+			| 'additions text'
+			| 'all'
+			| 'removals'
+			| 'removals additions'
+			| 'removals text'
+			| 'text'
+			| 'text additions'
+			| 'text removals'
+			| undefined
+			| null;
+		/** Indicates that user input is required on the element before a form may be submitted. */
+		'aria-required'?: boolean | 'false' | 'true' | undefined | null;
+		/** Defines a human-readable, author-localized description for the role of an element. */
+		'aria-roledescription'?: string | undefined | null;
+		/**
+		 * Defines the total number of rows in a table, grid, or treegrid.
+		 * @see aria-rowindex.
+		 */
+		'aria-rowcount'?: number | undefined | null;
+		/**
+		 * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+		 * @see aria-rowcount @see aria-rowspan.
+		 */
+		'aria-rowindex'?: number | undefined | null;
+		/**
+		 * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+		 * @see aria-rowindex @see aria-colspan.
+		 */
+		'aria-rowspan'?: number | undefined | null;
+		/**
+		 * Indicates the current "selected" state of various widgets.
+		 * @see aria-checked @see aria-pressed.
+		 */
+		'aria-selected'?: boolean | 'false' | 'true' | undefined | null;
+		/**
+		 * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+		 * @see aria-posinset.
+		 */
+		'aria-setsize'?: number | undefined | null;
+		/** Indicates if items in a table or grid are sorted in ascending or descending order. */
+		'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined | null;
+		/** Defines the maximum allowed value for a range widget. */
+		'aria-valuemax'?: number | undefined | null;
+		/** Defines the minimum allowed value for a range widget. */
+		'aria-valuemin'?: number | undefined | null;
+		/**
+		 * Defines the current value for a range widget.
+		 * @see aria-valuetext.
+		 */
+		'aria-valuenow'?: number | undefined | null;
+		/** Defines the human readable text alternative of aria-valuenow for a range widget. */
+		'aria-valuetext'?: string | undefined | null;
+	}
+
+	interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T>, AstroBuiltinAttributes {
+		// Standard HTML Attributes
+		class?: string | undefined | null;
+		dataset?: object | undefined | null; // eslint-disable-line
+		accept?: string | undefined | null;
+		acceptcharset?: string | undefined | null;
+		accesskey?: string | undefined | null;
+		action?: string | undefined | null;
+		allow?: string | undefined | null;
+		allowfullscreen?: boolean | undefined | null;
+		allowtransparency?: boolean | undefined | null;
+		allowpaymentrequest?: boolean | undefined | null;
+		alt?: string | undefined | null;
+		as?: string | undefined | null;
+		async?: boolean | undefined | null;
+		autocomplete?: string | undefined | null;
+		autofocus?: boolean | undefined | null;
+		autoplay?: boolean | undefined | null;
+		capture?: 'environment' | 'user' | boolean | undefined | null;
+		cellpadding?: number | string | undefined | null;
+		cellspacing?: number | string | undefined | null;
+		charset?: string | undefined | null;
+		challenge?: string | undefined | null;
+		checked?: boolean | undefined | null;
+		cite?: string | undefined | null;
+		classid?: string | undefined | null;
+		cols?: number | undefined | null;
+		colspan?: number | undefined | null;
+		content?: string | undefined | null;
+		contenteditable?: 'true' | 'false' | boolean | undefined | null;
+
+		// Doesn't work when used as HTML attribute
+		/**
+		 * Elements with the contenteditable attribute support innerHTML and textContent bindings.
+		 */
+		innerHTML?: string | undefined | null;
+		// Doesn't work when used as HTML attribute
+		/**
+		 * Elements with the contenteditable attribute support innerHTML and textContent bindings.
+		 */
+
+		textContent?: string | undefined | null;
+
+		contextmenu?: string | undefined | null;
+		controls?: boolean | undefined | null;
+		coords?: string | undefined | null;
+		crossorigin?: string | undefined | null;
+		currenttime?: number | undefined | null;
+		decoding?: 'async' | 'sync' | 'auto' | undefined | null;
+		data?: string | undefined | null;
+		datetime?: string | undefined | null;
+		default?: boolean | undefined | null;
+		defaultmuted?: boolean | undefined | null;
+		defaultplaybackrate?: number | undefined | null;
+		defer?: boolean | undefined | null;
+		dir?: string | undefined | null;
+		dirname?: string | undefined | null;
+		disabled?: boolean | undefined | null;
+		download?: any | undefined | null;
+		draggable?: boolean | 'true' | 'false' | undefined | null;
+		enctype?: string | undefined | null;
+		enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined | null;
+		for?: string | undefined | null;
+		form?: string | undefined | null;
+		formaction?: string | undefined | null;
+		formenctype?: string | undefined | null;
+		formmethod?: string | undefined | null;
+		formnovalidate?: boolean | undefined | null;
+		formtarget?: string | undefined | null;
+		frameborder?: number | string | undefined | null;
+		headers?: string | undefined | null;
+		height?: number | string | undefined | null;
+		hidden?: boolean | undefined | null;
+		high?: number | undefined | null;
+		href?: string | undefined | null;
+		hreflang?: string | undefined | null;
+		htmlfor?: string | undefined | null;
+		httpequiv?: string | undefined | null;
+		id?: string | undefined | null;
+		inputmode?: string | undefined | null;
+		integrity?: string | undefined | null;
+		is?: string | undefined | null;
+		ismap?: boolean | undefined | null;
+		keyparams?: string | undefined | null;
+		keytype?: string | undefined | null;
+		kind?: string | undefined | null;
+		label?: string | undefined | null;
+		lang?: string | undefined | null;
+		list?: string | undefined | null;
+		loading?: string | undefined | null;
+		loop?: boolean | undefined | null;
+		low?: number | undefined | null;
+		manifest?: string | undefined | null;
+		marginheight?: number | undefined | null;
+		marginwidth?: number | undefined | null;
+		max?: number | string | undefined | null;
+		maxlength?: number | undefined | null;
+		media?: string | undefined | null;
+		mediagroup?: string | undefined | null;
+		method?: string | undefined | null;
+		min?: number | string | undefined | null;
+		minlength?: number | undefined | null;
+		multiple?: boolean | undefined | null;
+		muted?: boolean | undefined | null;
+		name?: string | undefined | null;
+		nonce?: string | undefined | null;
+		novalidate?: boolean | undefined | null;
+		open?: boolean | undefined | null;
+		optimum?: number | undefined | null;
+		part?: string | undefined | null;
+		pattern?: string | undefined | null;
+		placeholder?: string | undefined | null;
+		playsinline?: boolean | undefined | null;
+		poster?: string | undefined | null;
+		preload?: string | undefined | null;
+		radiogroup?: string | undefined | null;
+		readonly?: boolean | undefined | null;
+		referrerpolicy?: string | undefined | null;
+		rel?: string | undefined | null;
+		required?: boolean | undefined | null;
+		reversed?: boolean | undefined | null;
+		role?: string | undefined | null;
+		rows?: number | undefined | null;
+		rowspan?: number | undefined | null;
+		sandbox?: string | undefined | null;
+		scope?: string | undefined | null;
+		scoped?: boolean | undefined | null;
+		scrolling?: string | undefined | null;
+		seamless?: boolean | undefined | null;
+		selected?: boolean | undefined | null;
+		shape?: string | undefined | null;
+		size?: number | undefined | null;
+		sizes?: string | undefined | null;
+		slot?: string | undefined | null;
+		span?: number | undefined | null;
+		spellcheck?: boolean | 'true' | 'false' | undefined | null;
+		src?: string | undefined | null;
+		srcdoc?: string | undefined | null;
+		srclang?: string | undefined | null;
+		srcset?: string | undefined | null;
+		start?: number | undefined | null;
+		step?: number | string | undefined | null;
+		style?: string | undefined | null;
+		summary?: string | undefined | null;
+		tabindex?: number | undefined | null;
+		target?: string | undefined | null;
+		title?: string | undefined | null;
+		type?: string | undefined | null;
+		usemap?: string | undefined | null;
+		value?: any | undefined | null;
+		/**
+		 * a value between 0 and 1
+		 */
+		volume?: number | undefined | null;
+		width?: number | string | undefined | null;
+		wmode?: string | undefined | null;
+		wrap?: string | undefined | null;
+
+		// RDFa Attributes
+		about?: string | undefined | null;
+		datatype?: string | undefined | null;
+		inlist?: any | undefined | null;
+		prefix?: string | undefined | null;
+		property?: string | undefined | null;
+		resource?: string | undefined | null;
+		typeof?: string | undefined | null;
+		vocab?: string | undefined | null;
+
+		// Non-standard Attributes
+		autocapitalize?: string | undefined | null;
+		autocorrect?: string | undefined | null;
+		autosave?: string | undefined | null;
+		color?: string | undefined | null;
+		controlslist?: 'nodownload' | 'nofullscreen' | 'noplaybackrate' | 'noremoteplayback';
+		itemprop?: string | undefined | null;
+		itemscope?: boolean | undefined | null;
+		itemtype?: string | undefined | null;
+		itemid?: string | undefined | null;
+		itemref?: string | undefined | null;
+		results?: number | undefined | null;
+		security?: string | undefined | null;
+		unselectable?: boolean | undefined | null;
+	}
+
+	// this list is "complete" in that it contains every SVG attribute
+	// that React supports, but the types can be improved.
+	// Full list here: https://facebook.github.io/react/docs/dom-elements.html
+	//
+	// The three broad type categories are (in order of restrictiveness):
+	//   - "number | string"
+	//   - "string"
+	//   - union of string literals
+	interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T> {
+		// Attributes which also defined in HTMLAttributes
+		className?: string | undefined | null;
+		class?: string | undefined | null;
+		color?: string | undefined | null;
+		height?: number | string | undefined | null;
+		id?: string | undefined | null;
+		lang?: string | undefined | null;
+		max?: number | string | undefined | null;
+		media?: string | undefined | null;
+		method?: string | undefined | null;
+		min?: number | string | undefined | null;
+		name?: string | undefined | null;
+		style?: string | undefined | null;
+		target?: string | undefined | null;
+		type?: string | undefined | null;
+		width?: number | string | undefined | null;
+
+		// Other HTML properties supported by SVG elements in browsers
+		role?: string | undefined | null;
+		tabindex?: number | undefined | null;
+		crossorigin?: 'anonymous' | 'use-credentials' | '' | undefined | null;
+
+		// SVG Specific attributes
+		'accent-height'?: number | string | undefined | null;
+		accumulate?: 'none' | 'sum' | undefined | null;
+		additive?: 'replace' | 'sum' | undefined | null;
+		'alignment-baseline'?:
+			| 'auto'
+			| 'baseline'
+			| 'before-edge'
+			| 'text-before-edge'
+			| 'middle'
+			| 'central'
+			| 'after-edge'
+			| 'text-after-edge'
+			| 'ideographic'
+			| 'alphabetic'
+			| 'hanging'
+			| 'mathematical'
+			| 'inherit'
+			| undefined
+			| null;
+		allowReorder?: 'no' | 'yes' | undefined | null;
+		alphabetic?: number | string | undefined | null;
+		amplitude?: number | string | undefined | null;
+		'arabic-form'?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined | null;
+		ascent?: number | string | undefined | null;
+		attributeName?: string | undefined | null;
+		attributeType?: string | undefined | null;
+		autoReverse?: number | string | undefined | null;
+		azimuth?: number | string | undefined | null;
+		baseFrequency?: number | string | undefined | null;
+		'baseline-shift'?: number | string | undefined | null;
+		baseProfile?: number | string | undefined | null;
+		bbox?: number | string | undefined | null;
+		begin?: number | string | undefined | null;
+		bias?: number | string | undefined | null;
+		by?: number | string | undefined | null;
+		calcMode?: number | string | undefined | null;
+		'cap-height'?: number | string | undefined | null;
+		clip?: number | string | undefined | null;
+		'clip-path'?: string | undefined | null;
+		clipPathUnits?: number | string | undefined | null;
+		'clip-rule'?: number | string | undefined | null;
+		'color-interpolation'?: number | string | undefined | null;
+		'color-interpolation-filters'?: 'auto' | 'sRGB' | 'linearRGB' | 'inherit' | undefined | null;
+		'color-profile'?: number | string | undefined | null;
+		'color-rendering'?: number | string | undefined | null;
+		contentScriptType?: number | string | undefined | null;
+		contentStyleType?: number | string | undefined | null;
+		cursor?: number | string | undefined | null;
+		cx?: number | string | undefined | null;
+		cy?: number | string | undefined | null;
+		d?: string | undefined | null;
+		decelerate?: number | string | undefined | null;
+		descent?: number | string | undefined | null;
+		diffuseConstant?: number | string | undefined | null;
+		direction?: number | string | undefined | null;
+		display?: number | string | undefined | null;
+		divisor?: number | string | undefined | null;
+		'dominant-baseline'?: number | string | undefined | null;
+		dur?: number | string | undefined | null;
+		dx?: number | string | undefined | null;
+		dy?: number | string | undefined | null;
+		edgeMode?: number | string | undefined | null;
+		elevation?: number | string | undefined | null;
+		'enable-background'?: number | string | undefined | null;
+		end?: number | string | undefined | null;
+		exponent?: number | string | undefined | null;
+		externalResourcesRequired?: number | string | undefined | null;
+		fill?: string | undefined | null;
+		'fill-opacity'?: number | string | undefined | null;
+		'fill-rule'?: 'nonzero' | 'evenodd' | 'inherit' | undefined | null;
+		filter?: string | undefined | null;
+		filterRes?: number | string | undefined | null;
+		filterUnits?: number | string | undefined | null;
+		'flood-color'?: number | string | undefined | null;
+		'flood-opacity'?: number | string | undefined | null;
+		focusable?: number | string | undefined | null;
+		'font-family'?: string | undefined | null;
+		'font-size'?: number | string | undefined | null;
+		'font-size-adjust'?: number | string | undefined | null;
+		'font-stretch'?: number | string | undefined | null;
+		'font-style'?: number | string | undefined | null;
+		'font-variant'?: number | string | undefined | null;
+		'font-weight'?: number | string | undefined | null;
+		format?: number | string | undefined | null;
+		from?: number | string | undefined | null;
+		fx?: number | string | undefined | null;
+		fy?: number | string | undefined | null;
+		g1?: number | string | undefined | null;
+		g2?: number | string | undefined | null;
+		'glyph-name'?: number | string | undefined | null;
+		'glyph-orientation-horizontal'?: number | string | undefined | null;
+		'glyph-orientation-vertical'?: number | string | undefined | null;
+		glyphRef?: number | string | undefined | null;
+		gradientTransform?: string | undefined | null;
+		gradientUnits?: string | undefined | null;
+		hanging?: number | string | undefined | null;
+		href?: string | undefined | null;
+		'horiz-adv-x'?: number | string | undefined | null;
+		'horiz-origin-x'?: number | string | undefined | null;
+		ideographic?: number | string | undefined | null;
+		'image-rendering'?: number | string | undefined | null;
+		in2?: number | string | undefined | null;
+		in?: string | undefined | null;
+		intercept?: number | string | undefined | null;
+		k1?: number | string | undefined | null;
+		k2?: number | string | undefined | null;
+		k3?: number | string | undefined | null;
+		k4?: number | string | undefined | null;
+		k?: number | string | undefined | null;
+		kernelMatrix?: number | string | undefined | null;
+		kernelUnitLength?: number | string | undefined | null;
+		kerning?: number | string | undefined | null;
+		keyPoints?: number | string | undefined | null;
+		keySplines?: number | string | undefined | null;
+		keyTimes?: number | string | undefined | null;
+		lengthAdjust?: number | string | undefined | null;
+		'letter-spacing'?: number | string | undefined | null;
+		'lighting-color'?: number | string | undefined | null;
+		limitingConeAngle?: number | string | undefined | null;
+		local?: number | string | undefined | null;
+		'marker-end'?: string | undefined | null;
+		markerHeight?: number | string | undefined | null;
+		'marker-mid'?: string | undefined | null;
+		'marker-start'?: string | undefined | null;
+		markerUnits?: number | string | undefined | null;
+		markerWidth?: number | string | undefined | null;
+		mask?: string | undefined | null;
+		maskContentUnits?: number | string | undefined | null;
+		maskUnits?: number | string | undefined | null;
+		mathematical?: number | string | undefined | null;
+		mode?: number | string | undefined | null;
+		numOctaves?: number | string | undefined | null;
+		offset?: number | string | undefined | null;
+		opacity?: number | string | undefined | null;
+		operator?: number | string | undefined | null;
+		order?: number | string | undefined | null;
+		orient?: number | string | undefined | null;
+		orientation?: number | string | undefined | null;
+		origin?: number | string | undefined | null;
+		overflow?: number | string | undefined | null;
+		'overline-position'?: number | string | undefined | null;
+		'overline-thickness'?: number | string | undefined | null;
+		'paint-order'?: number | string | undefined | null;
+		'panose-1'?: number | string | undefined | null;
+		path?: string | undefined | null;
+		pathLength?: number | string | undefined | null;
+		patternContentUnits?: string | undefined | null;
+		patternTransform?: number | string | undefined | null;
+		patternUnits?: string | undefined | null;
+		'pointer-events'?: number | string | undefined | null;
+		points?: string | undefined | null;
+		pointsAtX?: number | string | undefined | null;
+		pointsAtY?: number | string | undefined | null;
+		pointsAtZ?: number | string | undefined | null;
+		preserveAlpha?: number | string | undefined | null;
+		preserveAspectRatio?: string | undefined | null;
+		primitiveUnits?: number | string | undefined | null;
+		r?: number | string | undefined | null;
+		radius?: number | string | undefined | null;
+		refX?: number | string | undefined | null;
+		refY?: number | string | undefined | null;
+		'rendering-intent'?: number | string | undefined | null;
+		repeatCount?: number | string | undefined | null;
+		repeatDur?: number | string | undefined | null;
+		requiredExtensions?: number | string | undefined | null;
+		requiredFeatures?: number | string | undefined | null;
+		restart?: number | string | undefined | null;
+		result?: string | undefined | null;
+		rotate?: number | string | undefined | null;
+		rx?: number | string | undefined | null;
+		ry?: number | string | undefined | null;
+		scale?: number | string | undefined | null;
+		seed?: number | string | undefined | null;
+		'shape-rendering'?: number | string | undefined | null;
+		slope?: number | string | undefined | null;
+		spacing?: number | string | undefined | null;
+		specularConstant?: number | string | undefined | null;
+		specularExponent?: number | string | undefined | null;
+		speed?: number | string | undefined | null;
+		spreadMethod?: string | undefined | null;
+		startOffset?: number | string | undefined | null;
+		stdDeviation?: number | string | undefined | null;
+		stemh?: number | string | undefined | null;
+		stemv?: number | string | undefined | null;
+		stitchTiles?: number | string | undefined | null;
+		'stop-color'?: string | undefined | null;
+		'stop-opacity'?: number | string | undefined | null;
+		'strikethrough-position'?: number | string | undefined | null;
+		'strikethrough-thickness'?: number | string | undefined | null;
+		string?: number | string | undefined | null;
+		stroke?: string | undefined | null;
+		'stroke-dasharray'?: string | number | undefined | null;
+		'stroke-dashoffset'?: string | number | undefined | null;
+		'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined | null;
+		'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
+		'stroke-miterlimit'?: string | undefined | null;
+		'stroke-opacity'?: number | string | undefined | null;
+		'stroke-width'?: number | string | undefined | null;
+		surfaceScale?: number | string | undefined | null;
+		systemLanguage?: number | string | undefined | null;
+		tableValues?: number | string | undefined | null;
+		targetX?: number | string | undefined | null;
+		targetY?: number | string | undefined | null;
+		'text-anchor'?: string | undefined | null;
+		'text-decoration'?: number | string | undefined | null;
+		textLength?: number | string | undefined | null;
+		'text-rendering'?: number | string | undefined | null;
+		to?: number | string | undefined | null;
+		transform?: string | undefined | null;
+		u1?: number | string | undefined | null;
+		u2?: number | string | undefined | null;
+		'underline-position'?: number | string | undefined | null;
+		'underline-thickness'?: number | string | undefined | null;
+		unicode?: number | string | undefined | null;
+		'unicode-bidi'?: number | string | undefined | null;
+		'unicode-range'?: number | string | undefined | null;
+		'units-per-em'?: number | string | undefined | null;
+		'v-alphabetic'?: number | string | undefined | null;
+		values?: string | undefined | null;
+		'vector-effect'?: number | string | undefined | null;
+		version?: string | undefined | null;
+		'vert-adv-y'?: number | string | undefined | null;
+		'vert-origin-x'?: number | string | undefined | null;
+		'vert-origin-y'?: number | string | undefined | null;
+		'v-hanging'?: number | string | undefined | null;
+		'v-ideographic'?: number | string | undefined | null;
+		viewBox?: string | undefined | null;
+		viewTarget?: number | string | undefined | null;
+		visibility?: number | string | undefined | null;
+		'v-mathematical'?: number | string | undefined | null;
+		widths?: number | string | undefined | null;
+		'word-spacing'?: number | string | undefined | null;
+		'writing-mode'?: number | string | undefined | null;
+		x1?: number | string | undefined | null;
+		x2?: number | string | undefined | null;
+		x?: number | string | undefined | null;
+		xChannelSelector?: string | undefined | null;
+		'x-height'?: number | string | undefined | null;
+		xlinkActuate?: string | undefined | null;
+		xlinkArcrole?: string | undefined | null;
+		xlinkHref?: string | undefined | null;
+		xlinkRole?: string | undefined | null;
+		xlinkShow?: string | undefined | null;
+		xlinkTitle?: string | undefined | null;
+		xlinkType?: string | undefined | null;
+		xmlBase?: string | undefined | null;
+		xmlLang?: string | undefined | null;
+		xmlns?: string | undefined | null;
+		xmlnsXlink?: string | undefined | null;
+		xmlSpace?: string | undefined | null;
+		y1?: number | string | undefined | null;
+		y2?: number | string | undefined | null;
+		y?: number | string | undefined | null;
+		yChannelSelector?: string | undefined | null;
+		z?: number | string | undefined | null;
+		zoomAndPan?: string | undefined | null;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-empty-interface
+	interface HTMLProps<T extends EventTarget> extends HTMLAttributes<T> {}
+	// eslint-disable-next-line @typescript-eslint/no-empty-interface
+	interface SVGProps<T extends EventTarget> extends SVGAttributes<T> {}
+
+	interface IntrinsicElements {
+		// HTML
+		a: HTMLProps<HTMLAnchorElement>;
+		abbr: HTMLProps<HTMLElement>;
+		address: HTMLProps<HTMLElement>;
+		area: HTMLProps<HTMLAreaElement>;
+		article: HTMLProps<HTMLElement>;
+		aside: HTMLProps<HTMLElement>;
+		audio: HTMLProps<HTMLAudioElement>;
+		b: HTMLProps<HTMLElement>;
+		base: HTMLProps<HTMLBaseElement>;
+		bdi: HTMLProps<HTMLElement>;
+		bdo: HTMLProps<HTMLElement>;
+		big: HTMLProps<HTMLElement>;
+		blockquote: HTMLProps<HTMLElement>;
+		body: HTMLProps<HTMLBodyElement>;
+		br: HTMLProps<HTMLBRElement>;
+		button: HTMLProps<HTMLButtonElement>;
+		canvas: HTMLProps<HTMLCanvasElement>;
+		caption: HTMLProps<HTMLElement>;
+		cite: HTMLProps<HTMLElement>;
+		code: HTMLProps<HTMLElement>;
+		col: HTMLProps<HTMLTableColElement>;
+		colgroup: HTMLProps<HTMLTableColElement>;
+		data: HTMLProps<HTMLElement>;
+		datalist: HTMLProps<HTMLDataListElement>;
+		dd: HTMLProps<HTMLElement>;
+		del: HTMLProps<HTMLElement>;
+		details: HTMLProps<HTMLElement>;
+		dfn: HTMLProps<HTMLElement>;
+		dialog: HTMLProps<HTMLElement>;
+		div: HTMLProps<HTMLDivElement>;
+		dl: HTMLProps<HTMLDListElement>;
+		dt: HTMLProps<HTMLElement>;
+		em: HTMLProps<HTMLElement>;
+		embed: HTMLProps<HTMLEmbedElement>;
+		fieldset: HTMLProps<HTMLFieldSetElement>;
+		figcaption: HTMLProps<HTMLElement>;
+		figure: HTMLProps<HTMLElement>;
+		footer: HTMLProps<HTMLElement>;
+		form: HTMLProps<HTMLFormElement>;
+		h1: HTMLProps<HTMLHeadingElement>;
+		h2: HTMLProps<HTMLHeadingElement>;
+		h3: HTMLProps<HTMLHeadingElement>;
+		h4: HTMLProps<HTMLHeadingElement>;
+		h5: HTMLProps<HTMLHeadingElement>;
+		h6: HTMLProps<HTMLHeadingElement>;
+		head: HTMLProps<HTMLHeadElement>;
+		header: HTMLProps<HTMLElement>;
+		hgroup: HTMLProps<HTMLElement>;
+		hr: HTMLProps<HTMLHRElement>;
+		html: HTMLProps<HTMLHtmlElement>;
+		i: HTMLProps<HTMLElement>;
+		iframe: HTMLProps<HTMLIFrameElement>;
+		img: HTMLProps<HTMLImageElement>;
+		input: HTMLProps<HTMLInputElement>;
+		ins: HTMLProps<HTMLModElement>;
+		kbd: HTMLProps<HTMLElement>;
+		keygen: HTMLProps<HTMLElement>;
+		label: HTMLProps<HTMLLabelElement>;
+		legend: HTMLProps<HTMLLegendElement>;
+		li: HTMLProps<HTMLLIElement>;
+		link: HTMLProps<HTMLLinkElement>;
+		main: HTMLProps<HTMLElement>;
+		map: HTMLProps<HTMLMapElement>;
+		mark: HTMLProps<HTMLElement>;
+		menu: HTMLProps<HTMLElement>;
+		menuitem: HTMLProps<HTMLElement>;
+		meta: HTMLProps<HTMLMetaElement>;
+		meter: HTMLProps<HTMLElement>;
+		nav: HTMLProps<HTMLElement>;
+		noindex: HTMLProps<HTMLElement>;
+		noscript: HTMLProps<HTMLElement>;
+		object: HTMLProps<HTMLObjectElement>;
+		ol: HTMLProps<HTMLOListElement>;
+		optgroup: HTMLProps<HTMLOptGroupElement>;
+		option: HTMLProps<HTMLOptionElement>;
+		output: HTMLProps<HTMLElement>;
+		p: HTMLProps<HTMLParagraphElement>;
+		param: HTMLProps<HTMLParamElement>;
+		picture: HTMLProps<HTMLElement>;
+		pre: HTMLProps<HTMLPreElement>;
+		progress: HTMLProps<HTMLProgressElement>;
+		q: HTMLProps<HTMLQuoteElement>;
+		rp: HTMLProps<HTMLElement>;
+		rt: HTMLProps<HTMLElement>;
+		ruby: HTMLProps<HTMLElement>;
+		s: HTMLProps<HTMLElement>;
+		samp: HTMLProps<HTMLElement>;
+		script: HTMLProps<HTMLElement>;
+		section: HTMLProps<HTMLElement>;
+		select: HTMLProps<HTMLSelectElement>;
+		small: HTMLProps<HTMLElement>;
+		source: HTMLProps<HTMLSourceElement>;
+		span: HTMLProps<HTMLSpanElement>;
+		strong: HTMLProps<HTMLElement>;
+		style: HTMLProps<HTMLStyleElement>;
+		sub: HTMLProps<HTMLElement>;
+		summary: HTMLProps<HTMLElement>;
+		sup: HTMLProps<HTMLElement>;
+		table: HTMLProps<HTMLTableElement>;
+		tbody: HTMLProps<HTMLTableSectionElement>;
+		td: HTMLProps<HTMLTableDataCellElement>;
+		textarea: HTMLProps<HTMLTextAreaElement>;
+		tfoot: HTMLProps<HTMLTableSectionElement>;
+		th: HTMLProps<HTMLTableHeaderCellElement>;
+		thead: HTMLProps<HTMLTableSectionElement>;
+		time: HTMLProps<HTMLElement>;
+		title: HTMLProps<HTMLTitleElement>;
+		tr: HTMLProps<HTMLTableRowElement>;
+		track: HTMLProps<HTMLTrackElement>;
+		u: HTMLProps<HTMLElement>;
+		ul: HTMLProps<HTMLUListElement>;
+		var: HTMLProps<HTMLElement>;
+		video: HTMLProps<HTMLVideoElement>;
+		wbr: HTMLProps<HTMLElement>;
+
+		svg: SVGProps<SVGSVGElement>;
+
+		animate: SVGProps<SVGElement>; // @TODO: It is SVGAnimateElement but not in dom.d.ts for now.
+		circle: SVGProps<SVGCircleElement>;
+		clipPath: SVGProps<SVGClipPathElement>;
+		defs: SVGProps<SVGDefsElement>;
+		desc: SVGProps<SVGDescElement>;
+		ellipse: SVGProps<SVGEllipseElement>;
+		feBlend: SVGProps<SVGFEBlendElement>;
+		feColorMatrix: SVGProps<SVGFEColorMatrixElement>;
+		feComponentTransfer: SVGProps<SVGFEComponentTransferElement>;
+		feComposite: SVGProps<SVGFECompositeElement>;
+		feConvolveMatrix: SVGProps<SVGFEConvolveMatrixElement>;
+		feDiffuseLighting: SVGProps<SVGFEDiffuseLightingElement>;
+		feDisplacementMap: SVGProps<SVGFEDisplacementMapElement>;
+		feDistantLight: SVGProps<SVGFEDistantLightElement>;
+		feFlood: SVGProps<SVGFEFloodElement>;
+		feFuncA: SVGProps<SVGFEFuncAElement>;
+		feFuncB: SVGProps<SVGFEFuncBElement>;
+		feFuncG: SVGProps<SVGFEFuncGElement>;
+		feFuncR: SVGProps<SVGFEFuncRElement>;
+		feGaussianBlur: SVGProps<SVGFEGaussianBlurElement>;
+		feImage: SVGProps<SVGFEImageElement>;
+		feMerge: SVGProps<SVGFEMergeElement>;
+		feMergeNode: SVGProps<SVGFEMergeNodeElement>;
+		feMorphology: SVGProps<SVGFEMorphologyElement>;
+		feOffset: SVGProps<SVGFEOffsetElement>;
+		fePointLight: SVGProps<SVGFEPointLightElement>;
+		feSpecularLighting: SVGProps<SVGFESpecularLightingElement>;
+		feSpotLight: SVGProps<SVGFESpotLightElement>;
+		feTile: SVGProps<SVGFETileElement>;
+		feTurbulence: SVGProps<SVGFETurbulenceElement>;
+		filter: SVGProps<SVGFilterElement>;
+		foreignObject: SVGProps<SVGForeignObjectElement>;
+		g: SVGProps<SVGGElement>;
+		image: SVGProps<SVGImageElement>;
+		line: SVGProps<SVGLineElement>;
+		linearGradient: SVGProps<SVGLinearGradientElement>;
+		marker: SVGProps<SVGMarkerElement>;
+		mask: SVGProps<SVGMaskElement>;
+		metadata: SVGProps<SVGMetadataElement>;
+		path: SVGProps<SVGPathElement>;
+		pattern: SVGProps<SVGPatternElement>;
+		polygon: SVGProps<SVGPolygonElement>;
+		polyline: SVGProps<SVGPolylineElement>;
+		radialGradient: SVGProps<SVGRadialGradientElement>;
+		rect: SVGProps<SVGRectElement>;
+		stop: SVGProps<SVGStopElement>;
+		switch: SVGProps<SVGSwitchElement>;
+		symbol: SVGProps<SVGSymbolElement>;
+		text: SVGProps<SVGTextElement>;
+		textPath: SVGProps<SVGTextPathElement>;
+		tspan: SVGProps<SVGTSpanElement>;
+		use: SVGProps<SVGUseElement>;
+		view: SVGProps<SVGViewElement>;
+
+		[name: string]: { [name: string]: any };
+	}
+}

--- a/packages/svelte-language-integration/src/index.ts
+++ b/packages/svelte-language-integration/src/index.ts
@@ -11,10 +11,13 @@ export function toTSX(code: string): string {
 
 		let Props = render().props;
 
-		export default function(props: typeof Props) {
-			<></>
+		export default function(props: typeof Props): any {
+			<div></div>
 		}
 	`;
+
+	// Remove default class export from Svelte2TSX since we don't use it and instead add our own
+	result = result.replace('export default class', 'export class');
 	} catch(e: any) {
 		return result
 	}

--- a/packages/svelte-language-integration/src/index.ts
+++ b/packages/svelte-language-integration/src/index.ts
@@ -4,7 +4,7 @@ export const languageId = 'svelte';
 export const extension = '.svelte';
 
 export function toTSX(code: string): string {
-	let result = 'export default function() {}';
+	let result = 'export default function(): any {}';
 
 	try {
 		result = `${svelte2tsx(code).code}
@@ -16,10 +16,10 @@ export function toTSX(code: string): string {
 		}
 	`;
 
-	// Remove default class export from Svelte2TSX since we don't use it and instead add our own
-	result = result.replace('export default class', 'export class');
-	} catch(e: any) {
-		return result
+		// Remove default class export from Svelte2TSX since we don't use it and instead add our own
+		result = result.replace('export default class', 'export class');
+	} catch (e: any) {
+		return result;
 	}
 
 	return result;


### PR DESCRIPTION
## Changes

This add a `.d.ts` file describing our TSX output, since our diagnostics are based on those types, this bring a bunch of improvements, such as better support for Astro-specific attributes (client directives etc) on all kinds of components

Additionally, this PR add support for Hover to our HTML plugin, the reason it is done in the same PR is because without it you'd get TSX hover information when hovering HTML tags, which in addition of not being pretty or informative, might confuse users. The hover info provided by `vscode-html-languageservice` is actually pretty nice, I think users will like that a lot: 

![image](https://user-images.githubusercontent.com/3019731/159037038-a605e511-e589-47d3-88a9-a757423b4807.png)

This fixes https://github.com/withastro/language-tools/issues/164, fixes https://github.com/withastro/language-tools/issues/141, fixes https://github.com/withastro/language-tools/issues/217, fixes https://github.com/withastro/language-tools/issues/168 (at least the part where other typings would poison our output, the rest of that issue is not related to the extension itself, but after tihs PR we'll be able to provide better defaults in our starters without worrying about poisoning issues)

## Testing

Added tests for HTML hover info, the rest was tested manually for now

## Docs

Basic documentation was added for hover information on Astro-specific stuff however, it could use further work. I plan to collab with the docs team on this to make sure we provide info that is similarly worded to the documentation
