### PR TITLE
Add support for getting CSS hover info

### DIFF
--- a/.changeset/chatty-garlics-jog.md
+++ b/.changeset/chatty-garlics-jog.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add CSS hover info

--- a/packages/language-server/src/plugins/css/features/astro-selectors.ts
+++ b/packages/language-server/src/plugins/css/features/astro-selectors.ts
@@ -4,10 +4,10 @@ export const pseudoClass: IPseudoClassData[] = [
 	{
 		name: ':global()',
 		description: `[astro] :global modifier
-Applying styles to a selector globally`,
+Apply styles to a selector globally`,
 		references: [
 			{
-				name: 'Astro Docs',
+				name: 'Astro documentation',
 				url: 'https://docs.astro.build/en/guides/styling/#global-styles-within-style-tag',
 			},
 		],

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -1,12 +1,12 @@
-import { config, expect } from 'chai';
+import { expect } from 'chai';
 import { ConfigManager } from '../../../src/core/config';
 import { CSSPlugin } from '../../../src/plugins';
-import { Position } from 'vscode-languageserver-types';
+import { Hover, Position, Range } from 'vscode-languageserver-types';
 import { CompletionContext } from 'vscode-languageserver-protocol';
 import { AstroDocument, DocumentManager } from '../../../src/core/documents';
 
 describe('CSS Plugin', () => {
-	function setup(content) {
+	function setup(content: string) {
 		const document = new AstroDocument('file:///hello.astro', content);
 		const docManager = new DocumentManager(() => document);
 		const configManager = new ConfigManager();
@@ -17,7 +17,7 @@ describe('CSS Plugin', () => {
 	}
 
 	describe('provide completions', () => {
-		it('for normal css', () => {
+		it('in style tags', () => {
 			const { plugin, document } = setup('<style></style>');
 
 			const completions = plugin.getCompletions(document, Position.create(0, 7), {
@@ -25,7 +25,23 @@ describe('CSS Plugin', () => {
 			} as CompletionContext);
 
 			expect(completions.items, 'Expected completions to be an array').to.be.an('array');
-			expect(completions, 'Expected completions to not be empty').to.not.be.undefined;
+			expect(completions, 'Expected completions to not be empty').to.not.be.null;
+		});
+
+		it('in multiple style tags', () => {
+			const { plugin, document } = setup('<style></style><style></style>');
+
+			const completions1 = plugin.getCompletions(document, Position.create(0, 7), {
+				triggerCharacter: '.',
+			} as CompletionContext);
+			const completions2 = plugin.getCompletions(document, Position.create(0, 22), {
+				triggerCharacter: '.',
+			} as CompletionContext);
+
+			expect(completions1.items, 'Expected completions1 to be an array').to.be.an('array');
+			expect(completions1, 'Expected completions1 to not be empty').to.not.be.null;
+			expect(completions2.items, 'Expected completions2 to be an array').to.be.an('array');
+			expect(completions2, 'Expected completions2 to not be empty').to.not.be.null;
 		});
 
 		it('for :global modifier', () => {
@@ -36,7 +52,7 @@ describe('CSS Plugin', () => {
 			} as CompletionContext);
 			const globalCompletion = completions?.items.find((item) => item.label === ':global()');
 
-			expect(globalCompletion, 'Expected completions to contain :global modifier').to.not.be.undefined;
+			expect(globalCompletion, 'Expected completions to contain :global modifier').to.not.be.null;
 		});
 
 		it('should not provide completions if feature is disabled', () => {
@@ -61,65 +77,90 @@ describe('CSS Plugin', () => {
 		});
 	});
 
-	describe('provide document colors', () => {
-		it('for normal css', () => {
+	describe('provide hover info', () => {
+		it('in style tags', () => {
 			const { plugin, document } = setup('<style>h1 {color:blue;}</style>');
 
-			const colors = plugin.getColorPresentations(
-				document,
-				{
-					start: { line: 0, character: 17 },
-					end: { line: 0, character: 21 },
+			expect(plugin.doHover(document, Position.create(0, 8))).to.deep.equal(<Hover>{
+				contents: [
+					{ language: 'html', value: '<h1>' },
+					'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)',
+				],
+				range: Range.create(0, 7, 0, 9),
+			});
+
+			expect(plugin.doHover(document, Position.create(0, 12))).to.deep.equal(<Hover>{
+				contents: {
+					kind: 'markdown',
+					value:
+						"Sets the color of an element's text\n\nSyntax: &lt;color&gt;\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color)",
 				},
-				{ alpha: 1, blue: 255, green: 0, red: 0 }
-			);
+				range: Range.create(0, 11, 0, 21),
+			});
+		});
+
+		it('in style attributes', () => {
+			const { plugin, document } = setup('<div style="color: red"></div>');
+
+			expect(plugin.doHover(document, Position.create(0, 13))).to.deep.equal(<Hover>{
+				contents: {
+					kind: 'markdown',
+					value:
+						"Sets the color of an element's text\n\nSyntax: &lt;color&gt;\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color)",
+				},
+				range: Range.create(0, 12, 0, 22),
+			});
+		});
+
+		it('should not provide hover info if feature is disabled', () => {
+			const { plugin, document, configManager } = setup('<style>h1 {}</style>');
+
+			// Disable hover info
+			configManager.updateConfig(<any>{
+				css: {
+					hover: {
+						enabled: false,
+					},
+				},
+			});
+
+			const hoverInfo = plugin.doHover(document, Position.create(0, 8));
+
+			expect(configManager.enabled(`css.hover.enabled`), 'Expected hover to be disabled in configManager').to.be.false;
+			expect(hoverInfo, 'Expected hoverInfo to be null').to.be.null;
+		});
+	});
+
+	describe('provide document colors', () => {
+		it('for normal css', () => {
+			const { plugin, document } = setup('<style>h1 {color:blue;}</>');
+
+			const colors = plugin.getColorPresentations(document, Range.create(0, 17, 0, 21), {
+				alpha: 1,
+				blue: 255,
+				green: 0,
+				red: 0,
+			});
 
 			expect(colors).to.deep.equal([
 				{
 					label: 'rgb(0, 0, 65025)',
 					textEdit: {
-						range: {
-							end: {
-								character: 21,
-								line: 0,
-							},
-							start: {
-								character: 17,
-								line: 0,
-							},
-						},
+						range: Range.create(0, 17, 0, 21),
 						newText: 'rgb(0, 0, 65025)',
 					},
 				},
 				{
 					label: '#00000fe01',
 					textEdit: {
-						range: {
-							end: {
-								character: 21,
-								line: 0,
-							},
-							start: {
-								character: 17,
-								line: 0,
-							},
-						},
+						range: Range.create(0, 17, 0, 21),
 						newText: '#00000fe01',
 					},
 				},
 				{
 					label: 'hsl(240, -101%, 12750%)',
 					textEdit: {
-						range: {
-							end: {
-								character: 21,
-								line: 0,
-							},
-							start: {
-								character: 17,
-								line: 0,
-							},
-						},
+						range: Range.create(0, 17, 0, 21),
 						newText: 'hsl(240, -101%, 12750%)',
 					},
 				},
@@ -127,19 +168,31 @@ describe('CSS Plugin', () => {
 					label: 'hwb(240 0% -25400%)',
 					textEdit: {
 						newText: 'hwb(240 0% -25400%)',
-						range: {
-							end: {
-								character: 21,
-								line: 0,
-							},
-							start: {
-								character: 17,
-								line: 0,
-							},
-						},
+						range: Range.create(0, 17, 0, 21),
 					},
 				},
 			]);
+		});
+
+		it('should not provide document colors if feature is disabled', () => {
+			const { plugin, document, configManager } = setup('<style>h1 {color: blue;}</style>');
+
+			// Disable document colors
+			configManager.updateConfig(<any>{
+				css: {
+					documentColors: {
+						enabled: false,
+					},
+				},
+			});
+
+			const documentColors = plugin.getDocumentColors(document);
+
+			expect(
+				configManager.enabled(`css.documentColors.enabled`),
+				'Expected documentColors to be disabled in configManager'
+			).to.be.false;
+			expect(documentColors, 'Expected documentColors to be null').to.be.empty;
 		});
 	});
 });


### PR DESCRIPTION
## Changes

This adds support for hover info in style tags and style attributes. Similarly to what was added for HTML in https://github.com/withastro/language-tools/pull/216

It looks like this:
![image](https://user-images.githubusercontent.com/3019731/159366439-6b7aa773-db52-47d3-8dbf-e006597d0eee.png)
![image](https://user-images.githubusercontent.com/3019731/159366499-f5a57175-ecf6-4e31-8888-154acfd8fb49.png)

This is done through `vscode-css-languageservice`, which ensure consistency with how it is done in normal `.html` and `.css` files in VS Code

This close https://github.com/withastro/language-tools/issues/218

## Testing

Added tests for this feature in addition of manual testing. Additional minor tests for other CSS features were also added in this PR to ensure consistency in how features are tested

## Docs

No docs needed
