### PR TITLE
Add support for semantic tokens

### DIFF
--- a/.changeset/small-boats-cough.md
+++ b/.changeset/small-boats-cough.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for semantic tokens

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -19,6 +19,7 @@ import {
 	TextDocumentIdentifier,
 	WorkspaceEdit,
 	SymbolInformation,
+	SemanticTokens,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { flatten } from 'lodash';
@@ -123,6 +124,16 @@ export class PluginHost {
 
 		return flatten(
 			await this.execute<SymbolInformation[]>('getDocumentSymbols', [document, cancellationToken], ExecuteMode.Collect)
+		);
+	}
+
+	async getSemanticTokens(textDocument: TextDocumentIdentifier, range?: Range, cancellationToken?: CancellationToken) {
+		const document = this.getDocument(textDocument.uri);
+
+		return await this.execute<SemanticTokens>(
+			'getSemanticTokens',
+			[document, range, cancellationToken],
+			ExecuteMode.FirstNonNull
 		);
 	}
 

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -8,6 +8,8 @@ import {
 	Hover,
 	LocationLink,
 	Position,
+	Range,
+	SemanticTokens,
 	SignatureHelp,
 	SignatureHelpContext,
 	SymbolInformation,
@@ -33,6 +35,7 @@ import {
 	toVirtualAstroFilePath,
 } from './utils';
 import { DocumentSymbolsProviderImpl } from './features/DocumentSymbolsProvider';
+import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 
 type BetterTS = typeof ts & {
 	getTouchingPropertyName(sourceFile: SourceFile, pos: number): Node;
@@ -49,6 +52,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly signatureHelpProvider: SignatureHelpProviderImpl;
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
+	private readonly semanticTokensProvider: SemanticTokensProviderImpl;
 
 	constructor(docManager: DocumentManager, configManager: ConfigManager, workspaceUris: string[]) {
 		this.configManager = configManager;
@@ -59,6 +63,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.signatureHelpProvider = new SignatureHelpProviderImpl(this.languageServiceManager);
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
+		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
 	}
 
 	async doHover(document: AstroDocument, position: Position): Promise<Hover | null> {
@@ -97,6 +102,14 @@ export class TypeScriptPlugin implements Plugin {
 		});
 
 		return edit;
+	}
+
+	async getSemanticTokens(
+		textDocument: AstroDocument,
+		range?: Range,
+		cancellationToken?: CancellationToken
+	): Promise<SemanticTokens | null> {
+		return this.semanticTokensProvider.getSemanticTokens(textDocument, range, cancellationToken);
 	}
 
 	async getDocumentSymbols(document: AstroDocument): Promise<SymbolInformation[]> {

--- a/packages/language-server/src/plugins/typescript/features/SemanticTokenProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/SemanticTokenProvider.ts
@@ -1,0 +1,112 @@
+import ts from 'typescript';
+import { CancellationToken, Range, SemanticTokens, SemanticTokensBuilder } from 'vscode-languageserver';
+import { AstroDocument, mapRangeToOriginal } from '../../../core/documents';
+import { SemanticTokensProvider } from '../../interfaces';
+import { LanguageServiceManager } from '../LanguageServiceManager';
+import { AstroSnapshotFragment } from '../snapshots/DocumentSnapshot';
+import { toVirtualAstroFilePath } from '../utils';
+
+export class SemanticTokensProviderImpl implements SemanticTokensProvider {
+	constructor(private languageServiceManager: LanguageServiceManager) {}
+
+	async getSemanticTokens(
+		document: AstroDocument,
+		range?: Range,
+		cancellationToken?: CancellationToken
+	): Promise<SemanticTokens | null> {
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+		const fragment = (await tsDoc.createFragment()) as AstroSnapshotFragment;
+
+		if (cancellationToken?.isCancellationRequested) {
+			return null;
+		}
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+		const start = range ? fragment.offsetAt(fragment.getGeneratedPosition(range.start)) : 0;
+
+		const { spans } = lang.getEncodedSemanticClassifications(
+			filePath,
+			{
+				start,
+				length: range ? fragment.offsetAt(fragment.getGeneratedPosition(range.end)) - start : fragment.text.length,
+			},
+			ts.SemanticClassificationFormat.TwentyTwenty
+		);
+
+		const tokens: [number, number, number, number, number][] = [];
+
+		let i = 0;
+		while (i < spans.length) {
+			const offset = spans[i++];
+			const generatedLength = spans[i++];
+			const classification = spans[i++];
+
+			const originalPosition = this.mapToOrigin(document, fragment, offset, generatedLength);
+			if (!originalPosition) {
+				continue;
+			}
+
+			const [line, character, length] = originalPosition;
+
+			const classificationType = this.getTokenTypeFromClassification(classification);
+			if (classificationType < 0) {
+				continue;
+			}
+
+			const modifier = this.getTokenModifierFromClassification(classification);
+
+			tokens.push([line, character, length, classificationType, modifier]);
+		}
+
+		const sorted = tokens.sort((a, b) => {
+			const [lineA, charA] = a;
+			const [lineB, charB] = b;
+
+			return lineA - lineB || charA - charB;
+		});
+
+		const builder = new SemanticTokensBuilder();
+		sorted.forEach((tokenData) => builder.push(...tokenData));
+		const build = builder.build();
+
+		return build;
+	}
+
+	private mapToOrigin(
+		document: AstroDocument,
+		fragment: AstroSnapshotFragment,
+		generatedOffset: number,
+		generatedLength: number
+	): [line: number, character: number, length: number, start: number] | undefined {
+		const range = {
+			start: fragment.positionAt(generatedOffset),
+			end: fragment.positionAt(generatedOffset + generatedLength),
+		};
+		const { start: startPosition, end: endPosition } = mapRangeToOriginal(fragment, range);
+
+		if (startPosition.line < 0 || endPosition.line < 0) {
+			return;
+		}
+
+		const startOffset = document.offsetAt(startPosition);
+		const endOffset = document.offsetAt(endPosition);
+
+		return [startPosition.line, startPosition.character, endOffset - startOffset, startOffset];
+	}
+
+	/**
+	 *  TSClassification = (TokenType + 1) << TokenEncodingConsts.typeOffset + TokenModifier
+	 */
+	private getTokenTypeFromClassification(tsClassification: number): number {
+		return (tsClassification >> TokenEncodingConsts.typeOffset) - 1;
+	}
+
+	private getTokenModifierFromClassification(tsClassification: number) {
+		return tsClassification & TokenEncodingConsts.modifierMask;
+	}
+}
+
+const enum TokenEncodingConsts {
+	typeOffset = 8,
+	modifierMask = 255,
+}

--- a/packages/language-server/src/plugins/typescript/snapshots/utils.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/utils.ts
@@ -1,5 +1,4 @@
 import ts from 'typescript';
-import { TextDocument } from 'vscode-languageserver-textdocument';
 import { AstroDocument } from '../../../core/documents';
 import astro2tsx from '../astro2tsx';
 import {
@@ -7,7 +6,6 @@ import {
 	getFrameworkFromFilePath,
 	isAstroFilePath,
 	isFrameworkFilePath,
-	isVirtualFrameworkFilePath,
 } from '../utils';
 import { AstroSnapshot, TypeScriptDocumentSnapshot } from './DocumentSnapshot';
 import { toTSX as svelte2tsx } from '@astrojs/svelte-language-integration';

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -1,9 +1,81 @@
 import ts from 'typescript';
 import { dirname, extname } from 'path';
 import { pathToUrl } from '../../utils';
-import { CompletionItemKind, DiagnosticSeverity, Position, Range, SymbolKind } from 'vscode-languageserver';
+import {
+	CompletionItemKind,
+	DiagnosticSeverity,
+	Position,
+	Range,
+	SymbolKind,
+	SemanticTokenModifiers,
+	SemanticTokenTypes,
+	SemanticTokensLegend,
+} from 'vscode-languageserver';
 import { mapRangeToOriginal } from '../../core/documents';
 import { SnapshotFragment } from './snapshots/DocumentSnapshot';
+
+export const enum TokenType {
+	class,
+	enum,
+	interface,
+	namespace,
+	typeParameter,
+	type,
+	parameter,
+	variable,
+	enumMember,
+	property,
+	function,
+	method,
+}
+
+export const enum TokenModifier {
+	declaration,
+	static,
+	async,
+	readonly,
+	defaultLibrary,
+	local,
+}
+
+export function getSemanticTokenLegend(): SemanticTokensLegend {
+	const tokenModifiers: string[] = [];
+
+	(
+		[
+			[TokenModifier.declaration, SemanticTokenModifiers.declaration],
+			[TokenModifier.static, SemanticTokenModifiers.static],
+			[TokenModifier.async, SemanticTokenModifiers.async],
+			[TokenModifier.readonly, SemanticTokenModifiers.readonly],
+			[TokenModifier.defaultLibrary, SemanticTokenModifiers.defaultLibrary],
+			[TokenModifier.local, 'local'],
+		] as const
+	).forEach(([tsModifier, legend]) => (tokenModifiers[tsModifier] = legend));
+
+	const tokenTypes: string[] = [];
+
+	(
+		[
+			[TokenType.class, SemanticTokenTypes.class],
+			[TokenType.enum, SemanticTokenTypes.enum],
+			[TokenType.interface, SemanticTokenTypes.interface],
+			[TokenType.namespace, SemanticTokenTypes.namespace],
+			[TokenType.typeParameter, SemanticTokenTypes.typeParameter],
+			[TokenType.type, SemanticTokenTypes.type],
+			[TokenType.parameter, SemanticTokenTypes.parameter],
+			[TokenType.variable, SemanticTokenTypes.variable],
+			[TokenType.enumMember, SemanticTokenTypes.enumMember],
+			[TokenType.property, SemanticTokenTypes.property],
+			[TokenType.function, SemanticTokenTypes.function],
+			[TokenType.method, SemanticTokenTypes.method],
+		] as const
+	).forEach(([tokenType, legend]) => (tokenTypes[tokenType] = legend));
+
+	return {
+		tokenModifiers,
+		tokenTypes,
+	};
+}
 
 export function symbolKindFromString(kind: string): SymbolKind {
 	switch (kind) {


### PR DESCRIPTION
## Changes

This adds support for semantic tokens, they allow editors to provide additional coloring based on context. For instance, a mutable variable could now have a different coloring than a immutable one, or a method could have different coloring than a function

![image](https://user-images.githubusercontent.com/3019731/160156778-2a14d476-8fc0-4f92-a9ac-72d17af3b154.png)

By default in VS Code it is only enabled if your theme support it (`editor.semanticHighlighting.enabled` is set to `"configuredByTheme"`), thankfully many themes now support it, including the default one. For more info on semantic highlighting, see [this page](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide)

This fixes https://github.com/withastro/language-tools/issues/15

## Caveeats

This suffer from the following issue https://github.com/withastro/language-tools/issues/230, in the way that if something in a script tag has the same name as something in the frontmatter, it'll use the semantic highlighting of the frontmatter thing

I don't consider that it is this issue responsibility to fix it, the PR that'll do https://github.com/withastro/language-tools/issues/230 will provide a fix for semantic tokens

## Testing

Tested manually

## Docs

No docs needed
