### PR TITLE
Add support for folding CSS in style tags

### DIFF
--- a/packages/language-server/src/core/documents/DocumentMapper.ts
+++ b/packages/language-server/src/core/documents/DocumentMapper.ts
@@ -12,6 +12,7 @@ import {
 	SelectionRange,
 	TextEdit,
 	InsertReplaceEdit,
+	FoldingRange,
 } from 'vscode-languageserver';
 import { TagInformation, offsetAt, positionAt } from './utils';
 import { SourceMapConsumer } from 'source-map';
@@ -329,6 +330,28 @@ export function mapCodeActionToOriginal(fragment: DocumentMapper, codeAction: Co
 			),
 		},
 		codeAction.kind
+	);
+}
+
+export function mapFoldingRangeToParent(fragment: DocumentMapper, foldingRange: FoldingRange): FoldingRange {
+	// Despite FoldingRange asking for a start and end line and a start and end character, FoldingRanges
+	// don't use the Range type, instead asking for 4 number. Not sure why, but it's not convenient
+	const range = mapRangeToOriginal(
+		fragment,
+		Range.create(
+			foldingRange.startLine,
+			foldingRange.startCharacter || 0,
+			foldingRange.endLine,
+			foldingRange.endCharacter || 0
+		)
+	);
+
+	return FoldingRange.create(
+		range.start.line,
+		range.end.line,
+		foldingRange.startCharacter ? range.start.character : undefined,
+		foldingRange.endCharacter ? range.end.character : undefined,
+		foldingRange.kind
 	);
 }
 

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -139,6 +139,64 @@ describe('CSS Plugin', () => {
 		});
 	});
 
+	describe('provides folding ranges', () => {
+		it('for css/scss/less', () => {
+			const { plugin, document } = setup(`
+				<style>
+					h1 {
+						color: red
+					}
+				</style>
+				<style lang="scss">
+					$primary-color: #333;
+
+					body {
+						color: $primary-color
+					}
+				</style>
+				<style lang="less">
+					@primary-color: #333;
+
+					body {
+						color: @primary-color
+					}
+				</style>
+			`);
+
+			const foldingRanges = plugin.getFoldingRanges(document);
+
+			expect(foldingRanges).to.deep.equal([
+				{
+					startLine: 2,
+					endLine: 3,
+				},
+				{
+					endLine: 10,
+					startLine: 9,
+				},
+				{
+					endLine: 17,
+					startLine: 16,
+				},
+			]);
+		});
+
+		it('not for unsupported language', () => {
+			const { plugin, document } = setup(`
+				<style lang="sass">
+					$primary-color: #333
+
+					body
+						color: $primary-color
+				</style>
+			`);
+
+			const foldingRanges = plugin.getFoldingRanges(document);
+
+			expect(foldingRanges).to.be.empty;
+		});
+	});
+
 	describe('provides document symbols', () => {
 		it('for normal CSS', () => {
 			const { plugin, document } = setup('<style>h1 {color: red;}</style>');
@@ -174,6 +232,27 @@ describe('CSS Plugin', () => {
 					location: { uri: 'file:///hello.astro', range: Range.create(0, 38, 0, 55) },
 				},
 			]);
+		});
+
+		it('should not provide document symbols if feature is disabled', () => {
+			const { plugin, document, configManager } = setup('<style>h1 {color: red;}</style>');
+
+			// Disable documentSymbols
+			configManager.updateConfig(<any>{
+				css: {
+					documentSymbols: {
+						enabled: false,
+					},
+				},
+			});
+
+			const symbols = plugin.getDocumentSymbols(document);
+
+			expect(
+				configManager.enabled(`css.documentSymbols.enabled`),
+				'Expected documentSymbols to be disabled in configManager'
+			).to.be.false;
+			expect(symbols, 'Expected symbols to be empty').to.be.empty;
 		});
 	});
 

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -109,6 +109,25 @@ describe('HTML Plugin', () => {
 		});
 	});
 
+	describe('provides folding ranges', () => {
+		it('for html', () => {
+			const { plugin, document } = setup(`
+				<div>
+					<p>Astro</p>
+				</div>
+			`);
+
+			const foldingRanges = plugin.getFoldingRanges(document);
+
+			expect(foldingRanges).to.deep.equal([
+				{
+					startLine: 1,
+					endLine: 2,
+				},
+			]);
+		});
+	});
+
 	describe('provides document symbols', () => {
 		it('for html', () => {
 			const { plugin, document } = setup('<div><p>Astro</p></div>');
@@ -129,6 +148,27 @@ describe('HTML Plugin', () => {
 					kind: 8,
 				},
 			]);
+		});
+
+		it('should not provide document symbols if feature is disabled', () => {
+			const { plugin, document, configManager } = setup('<div><p>Astro</p></div>');
+
+			// Disable documentSymbols
+			configManager.updateConfig(<any>{
+				html: {
+					documentSymbols: {
+						enabled: false,
+					},
+				},
+			});
+
+			const symbols = plugin.getDocumentSymbols(document);
+
+			expect(
+				configManager.enabled(`html.documentSymbols.enabled`),
+				'Expected documentSymbols to be disabled in configManager'
+			).to.be.false;
+			expect(symbols, 'Expected symbols to be empty').to.be.empty;
 		});
 	});
 });


### PR DESCRIPTION
## Changes

Add support for folding CSS, easy enough! Much like other features powered by the VSCode's CSS language service, this only supports CSS, SCSS and LESS

![image](https://user-images.githubusercontent.com/3019731/160424635-f9c8abdd-1615-4dd0-9f5d-227428aaf728.png)

With this change, the only thing left to be able to fold is JavaScript inside the frontmatter and script tags. That one will be a bit more complicated :sweat_smile: 

## Testing

Added tests for this, also added some missing tests for documentSymbols and foldingRanges in HTML while I was there

## Docs

No docs needed
