### PR TITLE
Improve completions for components

### DIFF
--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -1,12 +1,18 @@
 import { newHTMLDataProvider } from 'vscode-html-languageservice';
 
-export const astroAttributes = newHTMLDataProvider('astro-attributes', {
+export const classListAttribute = newHTMLDataProvider('class-list', {
 	version: 1,
 	globalAttributes: [
 		{
 			name: 'class:list',
 			description: 'Utility to provide a list of class',
 		},
+	],
+});
+
+export const astroAttributes = newHTMLDataProvider('astro-attributes', {
+	version: 1,
+	globalAttributes: [
 		{
 			name: 'set:html',
 			description: 'Inject unescaped HTML into this tag',
@@ -75,6 +81,7 @@ export const astroDirectives = newHTMLDataProvider('astro-directives', {
 		{
 			name: 'client:load',
 			description: 'Start importing the component JS at page load. Hydrate the component when import completes.',
+			valueSet: 'v',
 			references: [
 				{
 					name: 'Astro documentation',
@@ -86,6 +93,7 @@ export const astroDirectives = newHTMLDataProvider('astro-directives', {
 			name: 'client:idle',
 			description:
 				'Start importing the component JS as soon as main thread is free (uses requestIdleCallback()). Hydrate the component when import completes.',
+			valueSet: 'v',
 			references: [
 				{
 					name: 'Astro documentation',
@@ -97,6 +105,7 @@ export const astroDirectives = newHTMLDataProvider('astro-directives', {
 			name: 'client:visible',
 			description:
 				'Start importing the component JS as soon as the element enters the viewport (uses IntersectionObserver). Hydrate the component when import completes. Useful for content lower down on the page.',
+			valueSet: 'v',
 			references: [
 				{
 					name: 'Astro documentation',
@@ -119,6 +128,7 @@ export const astroDirectives = newHTMLDataProvider('astro-directives', {
 			name: 'client:only',
 			description:
 				'Start importing the component JS at page load and hydrate when the import completes, similar to client:load. The component will be skipped at build time, useful for components that are entirely dependent on client-side APIs. This is best avoided unless absolutely needed, in most cases it is best to render placeholder content on the server and delay any browser API calls until the component hydrates in the browser.',
+			valueSet: 'v',
 			references: [
 				{
 					name: 'Astro documentation',

--- a/packages/language-server/src/plugins/html/utils.ts
+++ b/packages/language-server/src/plugins/html/utils.ts
@@ -1,0 +1,9 @@
+import { CompletionItem } from 'vscode-languageserver-types';
+
+/**
+ * The VS Code HTML language service provides a completion for data attributes that is independent from
+ * data providers, which mean that you can't disable it, so this function removes them from a completionList
+ */
+export function removeDataAttrCompletion(items: CompletionItem[]) {
+	return items.filter((item) => !item.label.startsWith('data-'));
+}

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -45,21 +45,6 @@ export function isPossibleComponent(node: Node): boolean {
 	return !!node.tag?.[0].match(/[A-Z]/) || !!node.tag?.match(/.+[.][A-Z]/);
 }
 
-/**
- * Return true if a specific node could be a component with a client directive on it.
- * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
- */
-export function isPossibleClientComponent(node: Node): boolean {
-	if (isPossibleComponent(node) && node.attributes) {
-		for (let [name] of Object.entries(node.attributes)) {
-			if (name.startsWith('client:')) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
 /** Flattens an array */
 export function flatten<T>(arr: T[][]): T[] {
 	return arr.reduce((all, item) => [...all, ...item], []);


### PR DESCRIPTION
## Changes

This initially started as only a fix for https://github.com/withastro/language-tools/issues/234 but I kept seeing issues with completions on component and wanted them all fixed in one go :sweat_smile:

### JSX frameworks completions fixes

Previously, you'd only get completions for props on JSX-based components if they were defined using an interface. Without diving too much in TypeScript stuff, it was basically because we got the props from the defined type of the props object instead of from the object itself (TypeScript is complicated.)

This is now fixed and we provide completions for props no matter how they're defined (as long as it's a function component, at least)

### Client directives completions

Client directives completions always existed but they required you to type `client:` and only then you would get completions which isn't very good for usability or feature discovery

Since the HTML language service now (since https://github.com/withastro/language-tools/pull/216) know what client directives are, we can instead provide completions through there. We can't do this in the HTML plugin however because we need to only provide those completions on appropriate components (aka, not Astro ones) which require TS so we do this in the Astro plugin

### Result

Tada!

![image](https://user-images.githubusercontent.com/3019731/160494902-f77aa71d-0a4f-4640-9b30-8fd64c7e8e96.png)

Props are always shown first unless something matches better (ex: typing c on that screenshot would instead show the client directives first)


## Testing

Tested manually

## Docs

No docs needed
