### PR TITLE
Disable CSS completions and hover info in unclosed style tags

### DIFF
--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -11,6 +11,7 @@ export interface TagInformation {
 	startPos: Position;
 	endPos: Position;
 	container: { start: number; end: number };
+	closed: boolean;
 }
 
 export function* walk(node: Node): Generator<Node, void, unknown> {
@@ -60,6 +61,8 @@ function extractTags(text: string, tag: 'script' | 'style' | 'template', html?: 
 			startPos,
 			endPos,
 			container,
+			// vscode-html-languageservice types does not contain this, despite it existing. Annoying
+			closed: (matchedNode as any).closed,
 		};
 	}
 }

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -57,6 +57,13 @@ export class CSSPlugin implements Plugin {
 
 		const styleTag = this.getStyleTagForPosition(document, position);
 
+		// We technically can return results even for open tags, however, a lot of the info returned is not valid
+		// Since most editors will automatically close the tag before the user start working in them, this shouldn't be a problem
+		if (styleTag && !styleTag.closed) {
+			return null;
+		}
+
+		// If we don't have a style tag at this position, we might be in a style property instead, let's check
 		if (!styleTag) {
 			const attributeContext = getAttributeContextAtPosition(document, position);
 
@@ -114,7 +121,10 @@ export class CSSPlugin implements Plugin {
 
 		const styleTag = this.getStyleTagForPosition(document, position);
 
-		// If we don't have a style tag at this position, we might be in a style property instead, let's check
+		if (styleTag && !styleTag.closed) {
+			return null;
+		}
+
 		if (!styleTag) {
 			const attributeContext = getAttributeContextAtPosition(document, position);
 			if (!attributeContext) {

--- a/packages/language-server/src/plugins/css/features/astro-selectors.ts
+++ b/packages/language-server/src/plugins/css/features/astro-selectors.ts
@@ -3,8 +3,7 @@ import { IPseudoClassData } from 'vscode-css-languageservice';
 export const pseudoClass: IPseudoClassData[] = [
 	{
 		name: ':global()',
-		description: `[astro] :global modifier
-Apply styles to a selector globally`,
+		description: 'Apply styles to a selector globally',
 		references: [
 			{
 				name: 'Astro documentation',

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -63,6 +63,16 @@ describe('CSS Plugin', () => {
 			expect(globalCompletion, 'Expected completions to contain :global modifier').to.not.be.null;
 		});
 
+		it('should not provide completions for unclosed style tags', () => {
+			const { plugin, document } = setup('<style>');
+
+			const completions = plugin.getCompletions(document, Position.create(0, 7), {
+				triggerCharacter: '.',
+			} as CompletionContext);
+
+			expect(completions).to.be.null;
+		});
+
 		it('should not provide completions if feature is disabled', () => {
 			const { plugin, document, configManager } = setup('<style></style>');
 
@@ -118,6 +128,14 @@ describe('CSS Plugin', () => {
 				},
 				range: Range.create(0, 12, 0, 22),
 			});
+		});
+
+		it('should not provide hover info for unclosed style tags', () => {
+			const { plugin, document } = setup('<style>h1 {color:blue;}');
+
+			const hoverInfo = plugin.doHover(document, Position.create(0, 8));
+
+			expect(hoverInfo).to.be.null;
 		});
 
 		it('should not provide hover info if feature is disabled', () => {


### PR DESCRIPTION
## Changes

We cannot reliably give CSS completions and hover info for unclosed style tags because if the HTML parser doesn't find an ending tag, it assume that the entire file is part of the tag (which is expected). This leads to completions and hover info providing invalid info (thinking that HTML tags are CSS stuff etc)

I'm not sure if this is really a needed fix because a fair assumption about editor tooling is that usually, if you give it wrong input, it gives you wrong output, but I figured that we had the power to avoid this here and that we might as well. Either way, you get an error from TypeScript telling you to close the tag, so :woman_shrugging: 

## Caveats

I do not think that it's the case because nowadays editors will autoclose tags for you but I wouldn't be surprised if [someone](https://xkcd.com/1172/) relied on this for completions. It wasn't really possible to rely on it in my opinion because the completions didn't really work but, you never know

## Testing

Added tests for this

## Docs

No docs needed
