### PR TITLE
Add support for global attribute in style tag to language server

### DIFF
--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -70,6 +70,16 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 						},
 					],
 				},
+				{
+					name: 'global',
+					description: 'Opts-out of automatic CSS scoping, all contents will be globally scoped',
+					references: [
+						{
+							name: 'Astro documentation',
+							url: 'https://docs.astro.build/en/guides/styling/#global-styles',
+						},
+					],
+				},
 			],
 		},
 	],

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -73,6 +73,7 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 				{
 					name: 'global',
 					description: 'Opts-out of automatic CSS scoping, all contents will be available globally',
+					valueSet: 'v',
 					references: [
 						{
 							name: 'Astro documentation',

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -72,7 +72,7 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 				},
 				{
 					name: 'global',
-					description: 'Opts-out of automatic CSS scoping, all contents will be globally scoped',
+					description: 'Opts-out of automatic CSS scoping, all contents will be available globally',
 					references: [
 						{
 							name: 'Astro documentation',

--- a/packages/language-server/types/astro-jsx.d.ts
+++ b/packages/language-server/types/astro-jsx.d.ts
@@ -42,6 +42,11 @@ declare namespace astroHTML.JSX {
 	interface AstroDefineVars {
 		'define:vars'?: any;
 	}
+	
+	// Usable exclusively on style tags
+	interface AstroStyleGlobal {
+		'global'?: boolean;
+	}
 
 	type Element = HTMLElement;
 
@@ -995,7 +1000,7 @@ declare namespace astroHTML.JSX {
 		source: HTMLProps<HTMLSourceElement>;
 		span: HTMLProps<HTMLSpanElement>;
 		strong: HTMLProps<HTMLElement>;
-		style: HTMLProps<HTMLStyleElement> & AstroDefineVars;
+		style: HTMLProps<HTMLStyleElement> & AstroDefineVars & AstroStyleGlobal;
 		sub: HTMLProps<HTMLElement>;
 		summary: HTMLProps<HTMLElement>;
 		sup: HTMLProps<HTMLElement>;


### PR DESCRIPTION
## Changes

Adds support for `<style global>` to the language server.

## Testing

There are currently no tests for specific tag attributes.

## Docs

Documents the use of `global` in IDEs. I'd be happy for suggestions how the proposed wording might be improved.
