### PR TITLE
Fixed `<Markdown />` syntax

### DIFF
--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -465,34 +465,38 @@
       ]
     },
     "astro:markdown": {
-      "begin": "(<)(Markdown)(>)",
+      "begin": "(<)(Markdown)",
+      "end": "(</)(Markdown)\\s*(>)|(/>)",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.definition.tag.begin.html"
+          "name": "punctuation.definition.tag.begin.astro"
         },
         "2": {
-          "name": "entity.name.tag.html"
-        },
-        "3": {
-          "name": "punctuation.definition.tag.end.html"
+          "name": "entity.name.tag.astro support.class.component.astro"
         }
       },
-      "end": "(</)(Markdown)(>)",
       "endCaptures": {
         "1": {
-          "name": "punctuation.definition.tag.begin.html"
+          "name": "punctuation.definition.tag.begin.astro"
         },
         "2": {
-          "name": "entity.name.tag.html"
+          "name": "entity.name.tag.astro support.class.component.astro"
         },
         "3": {
-          "name": "punctuation.definition.tag.end.html"
+          "name": "punctuation.definition.tag.end.astro"
+        },
+        "4": {
+          "name": "punctuation.definition.tag.end.astro"
         }
       },
       "patterns": [
         {
-          "include": "text.html.markdown"
-        }
+          "begin": "(?<=>)(?!</)",
+          "end": "(?=</)",
+          "contentName": "text.html.markdown",
+          "patterns": [{ "include": "text.html.markdown" }]
+        },
+        { "include": "#html:tag-attributes" }
       ]
     },
     "frontmatter": {


### PR DESCRIPTION
## Changes

Fixed Astro syntax to detect correctly `<Markdown />` component

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
