### PR TITLE
Ignore "Can't return outside of a function body" diagnostic

### DIFF
--- a/.changeset/unlucky-llamas-promise.md
+++ b/.changeset/unlucky-llamas-promise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix error when returning a response from the frontmatter

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -62,6 +62,7 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
 					isNoCantEndWithTS(diag) &&
 					isNoSpreadExpected(diag) &&
 					isNoCantResolveJSONModule(diag) &&
+					isNoCantReturnOutsideFunction(diag) &&
 					isNoMarkdownBlockQuoteWithinMarkdown(sourceFile, markdownBoundaries, diag)
 				);
 			})
@@ -172,6 +173,12 @@ function isNoCantEndWithTS(diagnostic: Diagnostic) {
 
 function isNoSpreadExpected(diagnostic: Diagnostic) {
 	return diagnostic.code !== 1005;
+}
+
+// This is technically a valid diagnostic, but due to how we format our TSX, the frontmatter is at top-level so we have
+// to ignore this. It wasn't a problem before because users didn't need to return things but they can now with SSR
+function isNoCantReturnOutsideFunction(diagnostic: Diagnostic) {
+	return diagnostic.code !== 1108;
 }
 
 function isWithinBoundaries(boundaries: BoundaryTuple[], start: number): boolean {

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -69,6 +69,30 @@ describe('TypeScript Plugin', () => {
 		});
 	});
 
+	describe('provide diagnostics', async () => {
+		it('return diagnostics', async () => {
+			const { plugin, document } = setup('diagnostics/basic.astro');
+
+			const diagnostics = await plugin.getDiagnostics(document);
+			expect(diagnostics).to.not.be.empty;
+		});
+
+		it('should not provide diagnostics if feature is disabled', async () => {
+			const { plugin, document, configManager } = setup('diagnostics/basic.astro');
+
+			configManager.updateConfig(<any>{
+				typescript: {
+					diagnostics: {
+						enabled: false,
+					},
+				},
+			});
+
+			const diagnostics = await plugin.getDiagnostics(document);
+			expect(diagnostics).to.be.empty;
+		});
+	});
+
 	describe('provide semantic tokens', async () => {
 		it('return semantic tokens for full document', async () => {
 			const { plugin, document } = setup('semanticTokens/frontmatter.astro');

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { Range } from 'vscode-languageserver-types';
+import { createEnvironment } from '../../../utils';
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import { DiagnosticsProviderImpl } from '../../../../src/plugins/typescript/features/DiagnosticsProvider';
+
+describe('TypeScript Plugin#DiagnosticsProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'diagnostics');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new DiagnosticsProviderImpl(languageServiceManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('gets Astro types', async () => {
+		const { provider, document } = setup('astroTypes.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.be.empty;
+	});
+
+	it('gets Astro JSX definitions', async () => {
+		const { provider, document } = setup('astroJSXDefinitions.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.deep.equal([
+			{
+				code: 2322,
+				message:
+					"Type '{ astroIsAmazing: true; }' is not assignable to type 'HTMLProps<HTMLDivElement>'.\n  Property 'astroIsAmazing' does not exist on type 'HTMLProps<HTMLDivElement>'.",
+				range: Range.create(0, 5, 0, 19),
+				severity: 1,
+				source: 'ts',
+				tags: [],
+			},
+		]);
+	});
+
+	it('provide deprecated and unused hints', async () => {
+		const { provider, document } = setup('hints.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.deep.equal([
+			{
+				code: 6385,
+				message: "'deprecated' is deprecated.",
+				range: Range.create(3, 0, 3, 10),
+				severity: 4,
+				source: 'ts',
+				tags: [2],
+			},
+			{
+				code: 6133,
+				message: "'hello' is declared but its value is never read.",
+				range: Range.create(4, 6, 4, 11),
+				severity: 4,
+				source: 'ts',
+				tags: [1],
+			},
+		]);
+	});
+
+	it('support return in frontmatter', async () => {
+		const { provider, document } = setup('ssrReturn.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.be.empty;
+	});
+
+	describe('Astro2TSX', async () => {
+		it('correctly convert HTML comments', async () => {
+			const { provider, document } = setup('multipleComments.astro');
+
+			const diagnostics = await provider.getDiagnostics(document);
+			expect(diagnostics).to.be.empty;
+		});
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/astroJSXDefinitions.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/astroJSXDefinitions.astro
@@ -1,0 +1,1 @@
+<div astroIsAmazing></div>

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/astroTypes.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/astroTypes.astro
@@ -1,0 +1,6 @@
+---
+	const AstroGlobal = Astro
+	console.log(AstroGlobal)
+---
+
+<Fragment></Fragment>

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/basic.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/basic.astro
@@ -1,0 +1,3 @@
+---
+const hello: string = 1
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/hints.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/hints.astro
@@ -1,0 +1,6 @@
+---
+	/** @deprecated */
+const deprecated = "Astro"
+deprecated;
+const hello = "Astro"
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/multipleComments.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/multipleComments.astro
@@ -1,0 +1,9 @@
+<html>
+  <body class="is-preload">
+    <!-- Wrapper -->
+    <div id="wrapper">
+      <!-- Main -->
+      <div id="main"></div>
+    </div>
+  </body>
+</html>

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/slots.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/slots.astro
@@ -1,0 +1,1 @@
+{Astro.slots.a && <span>testing</span>}

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/ssrReturn.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/ssrReturn.astro
@@ -1,0 +1,6 @@
+---
+	return new Response(null, {
+		status: 404,
+		statusText: 'Not found'
+  });
+---

--- a/packages/language-server/test/utils.ts
+++ b/packages/language-server/test/utils.ts
@@ -12,11 +12,11 @@ import { pathToUrl } from '../src/utils';
  * @returns
  */
 export function createEnvironment(filePath: string, baseDir: string, pathPrefix?: string) {
-	const fixtureDir = join(__dirname, 'plugins', baseDir, 'fixtures', pathPrefix ?? '');
+	const fixtureDir = join(__dirname, 'plugins', baseDir, 'fixtures');
 
 	const docManager = new DocumentManager((astroDocument) => new AstroDocument(astroDocument.uri, astroDocument.text));
 	const configManager = new ConfigManager();
-	const document = openDocument(filePath, fixtureDir, docManager);
+	const document = openDocument(filePath, join(fixtureDir, pathPrefix ?? ''), docManager);
 
 	return { document, docManager, configManager, fixturesDir: pathToUrl(fixtureDir) };
 }


### PR DESCRIPTION
## Changes

Ignore the "Can't return outside of a function body" diagnostic. While it is technically a valid diagnostic, unfortunately due to how our TSX is formed, the frontmatter is at the top level and thus any return there will create this issue

This wasn't a problem before as we never returned from the frontmatter but now with the addition of SSR, this is something that users might do

## Caveeat

There's still an issue where unconditional returns will result in TypeScript telling us the entire template is unreachable code, which is currently right, as returning a Response does not return the template. However in the future this will change if we were to support returning in the frontmatter while still using the template

Hopefully by then, we'll have a different TSX output :sweat_smile:

## Testing

Tested manually

## Docs

No docs needed
