### PR TITLE
[WIP] Add Markdownlint support

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -22,6 +22,7 @@
     "@astrojs/svelte-language-integration": "^0.1.2",
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",
+    "markdownlint": "^0.25.1",
     "source-map": "^0.7.3",
     "typescript": "~4.6.2",
     "vscode-css-languageservice": "^5.1.13",

--- a/packages/language-server/src/core/documents/AstroDocument.ts
+++ b/packages/language-server/src/core/documents/AstroDocument.ts
@@ -3,13 +3,14 @@ import { urlToPath } from '../../utils';
 import { WritableDocument } from './DocumentBase';
 import { AstroMetadata, parseAstro } from './parseAstro';
 import { parseHtml } from './parseHtml';
-import { extractStyleTags, TagInformation } from './utils';
+import { extractMarkdownTag, extractStyleTags, TagInformation } from './utils';
 
 export class AstroDocument extends WritableDocument {
 	languageId = 'astro';
 	astroMeta!: AstroMetadata;
 	html!: HTMLDocument;
 	styleTags!: TagInformation[];
+	markdownTags!: TagInformation[];
 
 	constructor(public url: string, public content: string) {
 		super();
@@ -21,6 +22,7 @@ export class AstroDocument extends WritableDocument {
 		this.astroMeta = parseAstro(this.content);
 		this.html = parseHtml(this.content);
 		this.styleTags = extractStyleTags(this.content, this.html);
+		this.markdownTags = extractMarkdownTag(this.content, this.html);
 	}
 
 	setText(text: string): void {

--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -28,7 +28,7 @@ export function* walk(node: Node): Generator<Node, void, unknown> {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
-function extractTags(text: string, tag: 'script' | 'style' | 'template', html?: HTMLDocument): TagInformation[] {
+function extractTags(text: string, tag: 'script' | 'style' | 'Markdown', html?: HTMLDocument): TagInformation[] {
 	const rootNodes = html?.roots || parseHtml(text).roots;
 	const matchedNodes = rootNodes.filter((node) => node.tag === tag);
 
@@ -67,8 +67,18 @@ function extractTags(text: string, tag: 'script' | 'style' | 'template', html?: 
 	}
 }
 
-export function extractStyleTags(source: string, html?: HTMLDocument): TagInformation[] {
+export function extractStyleTags(source: string, html: HTMLDocument): TagInformation[] {
 	const styles = extractTags(source, 'style', html);
+
+	if (!styles.length) {
+		return [];
+	}
+
+	return styles;
+}
+
+export function extractMarkdownTag(source: string, html?: HTMLDocument): TagInformation[] {
+	const styles = extractTags(source, 'Markdown', html);
 
 	if (!styles.length) {
 		return [];

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -20,6 +20,8 @@ import {
 	WorkspaceEdit,
 	SymbolInformation,
 	SemanticTokens,
+	CodeAction,
+	CodeActionContext,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { flatten } from 'lodash';
@@ -104,6 +106,23 @@ export class PluginHost {
 		const document = this.getDocument(textDocument.uri);
 
 		return this.execute<string | null>('doTagComplete', [document, position], ExecuteMode.FirstNonNull);
+	}
+
+	async getCodeActions(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		context: CodeActionContext,
+		cancellationToken: CancellationToken
+	): Promise<CodeAction[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(
+			await this.execute<CodeAction[]>(
+				'getCodeActions',
+				[document, range, context, cancellationToken],
+				ExecuteMode.Collect
+			)
+		);
 	}
 
 	async getFoldingRanges(textDocument: TextDocumentIdentifier): Promise<FoldingRange[] | null> {

--- a/packages/language-server/src/plugins/astro/features/MarkdownLintSupport.ts
+++ b/packages/language-server/src/plugins/astro/features/MarkdownLintSupport.ts
@@ -1,0 +1,199 @@
+import {
+	CodeAction,
+	CodeActionContext,
+	CodeActionKind,
+	Command,
+	Diagnostic,
+	DiagnosticSeverity,
+	Position,
+	Range,
+	TextDocumentEdit,
+	TextEdit,
+	WorkspaceEdit,
+} from 'vscode-languageserver-types';
+import { AstroDocument, TagInformation } from '../../../core/documents';
+import type { CodeActionsProvider, DiagnosticsProvider, Resolvable } from '../../interfaces';
+import { sync as markdownlint, LintResults, FixInfo } from 'markdownlint';
+import { flatten } from 'lodash';
+
+interface DiagnosticData {
+	fixInfo: FixInfo;
+	ruleUrl: string;
+}
+
+export class MarkdownLintSupport implements DiagnosticsProvider, CodeActionsProvider {
+	getCodeActions(document: AstroDocument, range: Range, context: CodeActionContext): Resolvable<CodeAction[]> {
+		// Adapted from https://github.com/DavidAnson/vscode-markdownlint/blob/522848a8cfe336bbc58056689e1a09f7dc8564f5/extension.js#L618
+		const mdlintDiagnostics = context.diagnostics.filter((diagnostic) => diagnostic.source === 'markdownlint');
+
+		const actions: CodeAction[] = [];
+		mdlintDiagnostics.forEach((diagnostic) => {
+			const ruleNameAlias = diagnostic.message.split(':')[0];
+			const diagnosticData = diagnostic.data as DiagnosticData;
+
+			if (diagnosticData.fixInfo) {
+				const fixTitle = 'Fix this violation of ' + ruleNameAlias;
+				const fixInfo = diagnosticData.fixInfo as FixInfo;
+
+				const lineNumber = fixInfo.lineNumber || diagnostic.range.start.line + 1;
+				const fixedText = applyFix(document.lines[lineNumber], fixInfo);
+
+				// Unlike in a Markdown file, our line might not really start at 0 due to indentation
+				const dedentRange = Range.create(Position.create(range.start.line, 0), range.end);
+
+				let textEdit = TextEdit.replace(dedentRange, fixedText!);
+
+				// If fixedText is not a string, it means we got a delete quickfix on our hands
+				if (typeof fixedText !== 'string') {
+					let deleteRange = range;
+					if (lineNumber === 1) {
+						if (document.lineCount > 1) {
+							const nextLine = document.lines[range.end.line + 1];
+							deleteRange.end = Position.create(range.end.line + 1, nextLine.length);
+						}
+					} else {
+						const previousLine = document.lines[range.end.line - 1];
+						deleteRange.start = Position.create(range.end.line - 1, previousLine.length);
+					}
+
+					textEdit = TextEdit.del(deleteRange);
+				}
+
+				const edit: WorkspaceEdit = {
+					documentChanges: [
+						TextDocumentEdit.create(
+							{
+								version: document.version,
+								uri: document.uri,
+							},
+							[textEdit]
+						),
+					],
+				};
+
+				const action = CodeAction.create(fixTitle, edit, CodeActionKind.QuickFix);
+
+				action.diagnostics = [diagnostic];
+				action.isPreferred = true;
+
+				addToActions(action);
+			}
+
+			// Add info command
+			const infoTitle = 'More information about ' + ruleNameAlias;
+			const infoAction = CodeAction.create(
+				infoTitle,
+				{
+					title: infoTitle,
+					command: 'vscode.open',
+					arguments: [diagnosticData.ruleUrl],
+				} as Command,
+				CodeActionKind.QuickFix
+			);
+			infoAction.diagnostics = [diagnostic];
+			addToActions(infoAction);
+		});
+
+		if (mdlintDiagnostics.length > 0) {
+			// Add config command
+			const configTitle = 'Details about configuring markdownlint rules';
+			const configAction = CodeAction.create(
+				configTitle,
+				{
+					title: configTitle,
+					command: 'vscode.open',
+					arguments: ['https://github.com/DavidAnson/vscode-markdownlint#configure'],
+				} as Command,
+				CodeActionKind.QuickFix
+			);
+
+			addToActions(configAction);
+		}
+
+		return actions;
+
+		function applyFix(line: string, fixInfo: FixInfo) {
+			const { editColumn, deleteCount, insertText } = normalizeFixInfo(fixInfo);
+			const editIndex = editColumn - 1;
+			return fixInfo.deleteCount === -1
+				? null
+				: line.slice(0, editIndex) + insertText.replace(/\n/g, '\n') + line.slice(editIndex + deleteCount);
+		}
+
+		/**
+		 * Normalizes the fields of a FixInfo instance.
+		 *
+		 * @param {Object} fixInfo RuleOnErrorFixInfo instance.
+		 * @param {number} [lineNumber] Line number.
+		 * @returns {Object} Normalized RuleOnErrorFixInfo instance.
+		 */
+		function normalizeFixInfo(fixInfo: FixInfo): any {
+			return {
+				lineNumber: fixInfo.lineNumber || undefined,
+				editColumn: fixInfo.editColumn || 1,
+				deleteCount: fixInfo.deleteCount || 0,
+				insertText: fixInfo.insertText || '',
+			};
+		}
+
+		function addToActions(action: CodeAction) {
+			if (!context.only || context.only.includes(action.kind ?? '')) {
+				actions.push(action);
+			}
+		}
+	}
+
+	getDiagnostics(document: AstroDocument): Resolvable<Diagnostic[]> {
+		const markdownTags = document.markdownTags;
+
+		const result = {};
+
+		markdownTags.forEach((markdownTag, index) => {
+			const lint = markdownlint({ strings: { [index]: markdownTag.content }, resultVersion: 3 });
+			Object.assign(result, lint);
+		});
+
+		return this.mdLintToDiagnostic(document, result, markdownTags);
+	}
+
+	mdLintToDiagnostic(document: AstroDocument, lint: LintResults, markdownTags: TagInformation[]): Diagnostic[] {
+		const diagnostics = Object.entries(lint).map(([key, results]) => {
+			const offset = markdownTags[parseInt(key)].startPos.line;
+
+			return results.map((result) => {
+				// Adapted from https://github.com/DavidAnson/vscode-markdownlint/blob/522848a8cfe336bbc58056689e1a09f7dc8564f5/extension.js#L556
+
+				let message = result.ruleNames.join('/') + ': ' + result.ruleDescription;
+				if (result.errorDetail) {
+					message += ' [' + result.errorDetail + ']';
+				}
+
+				const line = offset + result.lineNumber - 1;
+				const lineLength = document.lines[line].length;
+
+				const diagnostic = Diagnostic.create(
+					Range.create(line, document.lines[line].search(/\S|$/), line, lineLength),
+					message,
+					DiagnosticSeverity.Warning,
+					result.ruleNames[0],
+					'markdownlint'
+				);
+
+				// Add link to markdownlint's documentation for the code
+				diagnostic.codeDescription = {
+					href: result.ruleInformation,
+				};
+
+				if (result.fixInfo && result.fixInfo.lineNumber) {
+					result.fixInfo.lineNumber = line;
+				}
+
+				diagnostic.data = { fixInfo: result.fixInfo || undefined, ruleUrl: result.ruleInformation } as DiagnosticData;
+
+				return diagnostic;
+			});
+		});
+
+		return flatten(diagnostics);
+	}
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -77,6 +77,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 				foldingRangeProvider: true,
 				definitionProvider: true,
 				renameProvider: true,
+				codeActionProvider: true,
 				completionProvider: {
 					resolveProvider: true,
 					triggerCharacters: [
@@ -166,7 +167,12 @@ export function startLanguageServer(connection: vscode.Connection) {
 	connection.onHover((params: vscode.HoverParams) => pluginHost.doHover(params.textDocument, params.position));
 
 	connection.onDefinition((evt) => pluginHost.getDefinitions(evt.textDocument, evt.position));
+
 	connection.onFoldingRanges((evt) => pluginHost.getFoldingRanges(evt.textDocument));
+
+	connection.onCodeAction((evt, cancellationToken) =>
+		pluginHost.getCodeActions(evt.textDocument, evt.range, evt.context, cancellationToken)
+	);
 
 	connection.onCompletion(async (evt) => {
 		const promise = pluginHost.getCompletions(evt.textDocument, evt.position, evt.context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,6 +1814,11 @@ entities@^3.0.1:
   resolved "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+
 eol@^0.9.1:
   version "0.9.1"
   resolved "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz"
@@ -3285,6 +3290,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 listenercount@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz"
@@ -3411,10 +3423,28 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+markdown-it@12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-table@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz"
   integrity sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==
+
+markdownlint@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.25.1.tgz#df04536607ebeeda5ccd5e4f38138823ed623788"
+  integrity sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==
+  dependencies:
+    markdown-it "12.3.2"
 
 mdast-util-definitions@^5.0.0:
   version "5.1.0"
@@ -3565,7 +3595,7 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   resolved "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz"
   integrity sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==
 
-mdurl@^1.0.0:
+mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
@@ -5468,6 +5498,11 @@ typescript@*, typescript@^4.5.4, typescript@~4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Changes

> Caution: I'm doing this PR as "Erika the person doing a fun weekend project" and not as "Erika the Astro employee doing a serious, approved endeavor", this could very much never get merged if we deem that it's outside what we want to support / we prefer doing it another way

This adds support for linting Markdown component block using [markdownlint](https://github.com/DavidAnson/markdownlint). 

Unlike other tools such as stylelint, Prettier or ESLint, markdownlint does not support formats other than the one it was intended for (`.md`) nor is it possible to write custom parsers for it nor does [its VS Code extension support linting Markdown blocks in other files](https://github.com/DavidAnson/vscode-markdownlint/issues/25)

So, my first thought was that we needed to reimplement some parts of their VS Code extension into our language-server so I went ahead with that, but it turns out that we don't need that many code changes apart from a few things such as support for indented text

So, I'm thinking that instead of doing all this, we could probably contribute to markdownlint (at least its VS Code extension) and add support for linting blocks that are detected as `markdown` by VS Code (which is the case of our Markdown component)? Probably? However, that'll be for another fun weekend

## Result

![image](https://user-images.githubusercontent.com/3019731/162666016-763d652e-5e09-476c-afa5-2cbf08ef3e2b.png)


## Testing

WIP

## Docs

WIP
