### PR TITLE
Transform Markdown tags to template literal

### DIFF
--- a/.changeset/lucky-pans-stare.md
+++ b/.changeset/lucky-pans-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Make TypeScript ignore content of Markdown tags

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -47,9 +47,13 @@ export default function (content: string): Astro2TSXResult {
 		.replace(/<\s*!--([^-->]*)(.*?)-->/gs, (whole) => {
 			return `{/*${whole}*/}`;
 		})
-		// Turn styles into internal strings
+		// Turn styles tags into internal strings
 		.replace(/<\s*style([^>]*)>(.*?)<\s*\/\s*style>/gs, (_whole, attrs, children) => {
 			return `<style${attrs}>{\`${escapeTemplateLiteralContent(children)}\`}</style>`;
+		})
+		// Turn Markdown tags into internal strings
+		.replace(/<\s*Markdown([^>]*)>(.*?)<\s*\/\s*Markdown>/gs, (_whole, attrs, children) => {
+			return `<Markdown${attrs}>{\`${escapeTemplateLiteralContent(children)}\`}</Markdown>`;
 		})
 		// Turn scripts into function calls
 		.replace(/<\s*script([^\/>]*)>(.*?)<\s*\/\s*script>/gs, (_whole, attrs, children, offset) => {

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -78,5 +78,12 @@ describe('TypeScript Plugin#DiagnosticsProvider', () => {
 			const diagnostics = await provider.getDiagnostics(document);
 			expect(diagnostics).to.be.empty;
 		});
+
+		it('transform markdown into a template literal', async () => {
+			const { provider, document } = setup('noMarkdown.astro');
+
+			const diagnostics = await provider.getDiagnostics(document);
+			expect(diagnostics).to.be.empty;
+		});
 	});
 });

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/noMarkdown.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/noMarkdown.astro
@@ -1,0 +1,7 @@
+---
+import { Markdown } from "astro/components"
+---
+
+<Markdown>
+{ myVariable }
+</Markdown>


### PR DESCRIPTION
## Changes

Makes it so our TSX transformer transform Markdown tags into template literal, like it does for style tags

This is necessary because otherwise, TypeScript interpret the content of Markdown as JSX and print some errors, try to provide hover info etc. This is not a perfect solution as some users might actually want JSX in their Markdown but it's hard for TypeScript to understand what is wanted JSX and what is not so I think this is for the best 

I alternatively tried to just ignore diagnostics in Markdown tags but I felt like having to add a "isNotInMarkdown" condition to every single TypeScript feature would get annoying and redundant when we could do this

This PR includes a slight refactor to our diagnostic provider in the typescript plugin, removing a few svelte-ism and adding comments to ignored diagnostics

## Testing

Test added

## Docs

No docs needed