### PR TITLE
Add support for folding ranges for JavaScript

### DIFF
--- a/.changeset/chatty-kiwis-applaud.md
+++ b/.changeset/chatty-kiwis-applaud.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for folding JavaScript

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -47,7 +47,7 @@ export interface HoverProvider {
 	doHover(document: TextDocument, position: Position): Resolvable<Hover | null>;
 }
 
-export interface FoldingRangeProvider {
+export interface FoldingRangesProvider {
 	getFoldingRanges(document: TextDocument): Resolvable<FoldingRange[] | null>;
 }
 
@@ -150,7 +150,7 @@ type ProviderBase = DiagnosticsProvider &
 	CompletionsProvider &
 	DefinitionsProvider &
 	FormattingProvider &
-	FoldingRangeProvider &
+	FoldingRangesProvider &
 	TagCompleteProvider &
 	DocumentColorsProvider &
 	ColorPresentationsProvider &

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -5,6 +5,7 @@ import {
 	DefinitionLink,
 	Diagnostic,
 	FileChangeType,
+	FoldingRange,
 	Hover,
 	LocationLink,
 	Position,
@@ -36,6 +37,7 @@ import {
 } from './utils';
 import { DocumentSymbolsProviderImpl } from './features/DocumentSymbolsProvider';
 import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
+import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
 
 type BetterTS = typeof ts & {
 	getTouchingPropertyName(sourceFile: SourceFile, pos: number): Node;
@@ -53,6 +55,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
 	private readonly semanticTokensProvider: SemanticTokensProviderImpl;
+	private readonly foldingRangesProvider: FoldingRangesProviderImpl;
 
 	constructor(docManager: DocumentManager, configManager: ConfigManager, workspaceUris: string[]) {
 		this.configManager = configManager;
@@ -64,6 +67,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
 		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
+		this.foldingRangesProvider = new FoldingRangesProviderImpl(this.languageServiceManager);
 	}
 
 	async doHover(document: AstroDocument, position: Position): Promise<Hover | null> {
@@ -102,6 +106,10 @@ export class TypeScriptPlugin implements Plugin {
 		});
 
 		return edit;
+	}
+
+	async getFoldingRanges(document: AstroDocument): Promise<FoldingRange[] | null> {
+		return this.foldingRangesProvider.getFoldingRanges(document);
 	}
 
 	async getSemanticTokens(

--- a/packages/language-server/src/plugins/typescript/features/FoldingRangesProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/FoldingRangesProvider.ts
@@ -1,0 +1,74 @@
+import ts from 'typescript';
+import { FoldingRange, FoldingRangeKind, Position } from 'vscode-languageserver';
+import { AstroDocument } from '../../../core/documents';
+import { FoldingRangesProvider } from '../../interfaces';
+import { LanguageServiceManager } from '../LanguageServiceManager';
+import { toVirtualAstroFilePath } from '../utils';
+
+export class FoldingRangesProviderImpl implements FoldingRangesProvider {
+	constructor(private readonly languageServiceManager: LanguageServiceManager) {}
+
+	async getFoldingRanges(document: AstroDocument): Promise<FoldingRange[] | null> {
+		const html = document.html;
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+
+		const outliningSpans = lang.getOutliningSpans(filePath);
+
+		const foldingRanges: FoldingRange[] = [];
+
+		for (const span of outliningSpans) {
+			const node = html.findNodeAt(span.textSpan.start);
+
+			// Due to how our TSX output transform those tags into function calls or template literals
+			// TypeScript thinks of those as outlining spans, which is fine but we don't want folding ranges for those
+			if (node.tag === 'script' || node.tag === 'Markdown' || node.tag === 'style') {
+				continue;
+			}
+
+			const start = document.positionAt(span.textSpan.start);
+			const end = adjustFoldingEnd(start, document.positionAt(span.textSpan.start + span.textSpan.length), document);
+
+			// When using this method for generating folding ranges, TypeScript tend to return some
+			// one line / one character ones that we should be able to safely ignore
+			if (start.line === end.line && start.character === end.character) {
+				continue;
+			}
+
+			foldingRanges.push(
+				FoldingRange.create(start.line, end.line, start.character, end.character, transformFoldingRangeKind(span.kind))
+			);
+		}
+
+		return foldingRanges;
+	}
+}
+
+function transformFoldingRangeKind(tsKind: ts.OutliningSpanKind) {
+	switch (tsKind) {
+		case ts.OutliningSpanKind.Comment:
+			return FoldingRangeKind.Comment;
+		case ts.OutliningSpanKind.Imports:
+			return FoldingRangeKind.Imports;
+		case ts.OutliningSpanKind.Region:
+			return FoldingRangeKind.Region;
+	}
+}
+
+// https://github.com/microsoft/vscode/blob/bed61166fb604e519e82e4d1d1ed839bc45d65f8/extensions/typescript-language-features/src/languageFeatures/folding.ts#L61-L73
+function adjustFoldingEnd(start: Position, end: Position, document: AstroDocument) {
+	// workaround for #47240
+	if (end.character > 0) {
+		const foldEndCharacter = document.getText({
+			start: { line: end.line, character: end.character - 1 },
+			end,
+		});
+		if (['}', ']', ')', '`'].includes(foldEndCharacter)) {
+			const endOffset = Math.max(document.offsetAt({ line: end.line, character: 0 }) - 1, document.offsetAt(start));
+			return document.positionAt(endOffset);
+		}
+	}
+
+	return end;
+}

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -124,4 +124,13 @@ describe('TypeScript Plugin', () => {
 			expect(semanticTokens).to.be.null;
 		});
 	});
+
+	describe('provide folding ranges', async () => {
+		it('return folding ranges', async () => {
+			const { plugin, document } = setup('foldingRanges/frontmatter.astro');
+
+			const foldingRanges = await plugin.getFoldingRanges(document);
+			expect(foldingRanges).to.not.be.empty;
+		});
+	});
 });

--- a/packages/language-server/test/plugins/typescript/features/FoldingRangesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FoldingRangesProvider.test.ts
@@ -1,0 +1,49 @@
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import { createEnvironment } from '../../../utils';
+import { FoldingRangesProviderImpl } from '../../../../src/plugins/typescript/features/FoldingRangesProvider';
+import { expect } from 'chai';
+
+describe('TypeScript Plugin#FoldingRangesProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'foldingRanges');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new FoldingRangesProviderImpl(languageServiceManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('provide folding ranges in frontmatter', async () => {
+		const { provider, document } = setup('frontmatter.astro');
+
+		const foldingRanges = await provider.getFoldingRanges(document);
+
+		expect(foldingRanges).to.deep.equal([
+			{
+				endCharacter: 0,
+				endLine: 7,
+				startCharacter: 34,
+				startLine: 1,
+			},
+		]);
+	});
+
+	it('does not provide folding ranges for ignored tags', async () => {
+		const { provider, document } = setup('excludedtags.astro');
+
+		const foldingRanges = await provider.getFoldingRanges(document);
+
+		// TypeScript return folding ranges for JSX tags, hence why it still returns something
+		// Those get ignored during normal usage since we prefer leaving that to our HTML plugin
+		expect(foldingRanges).to.deep.equal([
+			{
+				endCharacter: 6,
+				endLine: 8,
+				startCharacter: 0,
+				startLine: 4,
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/foldingRanges/excludedtags.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/foldingRanges/excludedtags.astro
@@ -1,0 +1,17 @@
+---
+	import { Markdown } from "astro/components"
+---
+
+<script>
+	console.log('Hello')
+</script>
+
+<Markdown>
+	# Markdown
+</Markdown>
+
+<style>
+	h1 {
+		color: red
+	}
+</style>

--- a/packages/language-server/test/plugins/typescript/fixtures/foldingRanges/frontmatter.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/foldingRanges/frontmatter.astro
@@ -1,0 +1,10 @@
+---
+	function MyLongFoldableFunction() {
+		console.log('Hello')
+
+
+
+
+
+	}
+---


### PR DESCRIPTION
## Changes

Add support for folding JavaScript, with this everything is now fold-able (HTML, CSS, JavaScript and frontmatter)!

Support include frontmatter and expressions. Folding inside of script tags is currently not supported (require https://github.com/withastro/language-tools/issues/230)

![image](https://user-images.githubusercontent.com/3019731/163061008-78f54ead-59c9-441c-bc77-347bcd38b2bd.png)

## Testing

Tests added

## Docs

No docs needed (no settings needed as we don't support disabling folding ranges (there's not much point to disabling them..)
