### PR TITLE
Misc improvements to Astro plugin completions

### DIFF
--- a/.changeset/grumpy-pigs-raise.md
+++ b/.changeset/grumpy-pigs-raise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Improve props completions on components

--- a/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { createEnvironment } from '../../../utils';
 import { CompletionsProviderImpl } from '../../../../src/plugins/astro/features/CompletionsProvider';
 import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
-import { Position, Range } from 'vscode-languageserver-types';
+import { InsertTextFormat, Position, Range } from 'vscode-languageserver-types';
 import { CompletionContext, CompletionTriggerKind } from 'vscode-languageserver-protocol';
 
 describe('Astro Plugin#CompletionsProvider', () => {
@@ -51,7 +51,9 @@ describe('Astro Plugin#CompletionsProvider', () => {
 		expect(completions.items).to.deep.equal([
 			{
 				label: 'name',
-				insertText: 'name',
+				detail: 'string',
+				insertText: 'name="$1"',
+				insertTextFormat: InsertTextFormat.Snippet,
 				commitCharacters: [],
 				sortText: '_',
 			},
@@ -65,7 +67,9 @@ describe('Astro Plugin#CompletionsProvider', () => {
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
-			insertText: 'name',
+			detail: 'any',
+			insertText: 'name={$1}',
+			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
 			sortText: '_',
 		});
@@ -78,7 +82,9 @@ describe('Astro Plugin#CompletionsProvider', () => {
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
-			insertText: 'name',
+			detail: 'any',
+			insertText: 'name={$1}',
+			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
 			sortText: '_',
 		});
@@ -91,7 +97,9 @@ describe('Astro Plugin#CompletionsProvider', () => {
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
-			insertText: 'name',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
 			sortText: '_',
 		});


### PR DESCRIPTION
## Changes

Misc improvements to the completions provided by the Astro plugins to better match the TypeScript plugin after https://github.com/withastro/language-tools/pull/253

Depending on the type of the prop, we now give a different insertText. We also show the type on the right hand side of the completion, which is neat

![image](https://user-images.githubusercontent.com/3019731/163883432-176d14aa-5039-4d1d-89e8-916625ace181.png)

## Testing

No tests needed, we don't have dedicated tests for this but our current tests cover this

## Docs

No docs needed
