### PR TITLE
Implement TypeScript code actions

### DIFF
--- a/.changeset/kind-turkeys-remain.md
+++ b/.changeset/kind-turkeys-remain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': minor
+---
+
+Add support for code actions

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -20,6 +20,8 @@ import {
 	WorkspaceEdit,
 	SymbolInformation,
 	SemanticTokens,
+	CodeActionContext,
+	CodeAction,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { flatten } from 'lodash';
@@ -135,6 +137,23 @@ export class PluginHost {
 		return this.execute<Hover>('doHover', [document, position], ExecuteMode.FirstNonNull);
 	}
 
+	async getCodeActions(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		context: CodeActionContext,
+		cancellationToken: CancellationToken
+	): Promise<CodeAction[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(
+			await this.execute<CodeAction[]>(
+				'getCodeActions',
+				[document, range, context, cancellationToken],
+				ExecuteMode.Collect
+			)
+		);
+	}
+
 	async doTagComplete(textDocument: TextDocumentIdentifier, position: Position): Promise<string | null> {
 		const document = this.getDocument(textDocument.uri);
 
@@ -146,7 +165,7 @@ export class PluginHost {
 
 		const foldingRanges = flatten(
 			await this.execute<FoldingRange[]>('getFoldingRanges', [document], ExecuteMode.Collect)
-		).filter((completion) => completion != null);
+		);
 
 		return foldingRanges;
 	}

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -1,5 +1,5 @@
 import { flatten } from 'lodash';
-import ts, { CodeFixAction, FileTextChanges } from 'typescript';
+import ts, { CodeFixAction } from 'typescript';
 import { CancellationToken } from 'vscode-languageserver';
 import {
 	CodeAction,
@@ -7,7 +7,6 @@ import {
 	CodeActionKind,
 	Diagnostic,
 	OptionalVersionedTextDocumentIdentifier,
-	Position,
 	Range,
 	TextDocumentEdit,
 	TextEdit,
@@ -23,7 +22,6 @@ import { findContainingNode } from './utils';
 
 // These are VS Code specific CodeActionKind so they're not in the language server protocol
 export const sortImportKind = `${CodeActionKind.Source}.sortImports`;
-export const missingImportsKind = `${CodeActionKind.Source}.addMissingImports.ts`;
 
 export class CodeActionsProviderImpl implements CodeActionsProvider {
 	constructor(private languageServiceManager: LanguageServiceManager) {}
@@ -117,8 +115,6 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 		}
 	}
 
-	// The way TypeScript looks for import quick fixes is by looking for symbols with the same name
-	// This is all fine and nice for most things but our components purposely uses
 	private getComponentQuickFix(
 		start: number,
 		end: number,
@@ -147,6 +143,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 
 		const tagName = node.tagName;
 
+		// Unlike quick fixes, completions will be able to find the component, so let's use those to get it
 		const completion = lang.getCompletionsAtPosition(filePath, tagName.getEnd(), completionOptions);
 
 		if (!completion) {

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -1,0 +1,228 @@
+import { flatten } from 'lodash';
+import ts, { CodeFixAction, FileTextChanges } from 'typescript';
+import { CancellationToken } from 'vscode-languageserver';
+import {
+	CodeAction,
+	CodeActionContext,
+	CodeActionKind,
+	Diagnostic,
+	OptionalVersionedTextDocumentIdentifier,
+	Position,
+	Range,
+	TextDocumentEdit,
+	TextEdit,
+} from 'vscode-languageserver-types';
+import { AstroDocument, getLineAtPosition, mapRangeToOriginal } from '../../../core/documents';
+import { modifyLines } from '../../../utils';
+import { CodeActionsProvider } from '../../interfaces';
+import { LanguageServiceManager } from '../LanguageServiceManager';
+import { AstroSnapshotFragment } from '../snapshots/DocumentSnapshot';
+import { checkEndOfFileCodeInsert, convertRange, removeAstroComponentSuffix, toVirtualAstroFilePath } from '../utils';
+import { codeActionChangeToTextEdit, completionOptions } from './CompletionsProvider';
+import { findContainingNode } from './utils';
+
+// These are VS Code specific CodeActionKind so they're not in the language server protocol
+export const sortImportKind = `${CodeActionKind.Source}.sortImports`;
+export const missingImportsKind = `${CodeActionKind.Source}.addMissingImports.ts`;
+
+export class CodeActionsProviderImpl implements CodeActionsProvider {
+	constructor(private languageServiceManager: LanguageServiceManager) {}
+
+	async getCodeActions(
+		document: AstroDocument,
+		range: Range,
+		context: CodeActionContext,
+		cancellationToken?: CancellationToken
+	): Promise<CodeAction[]> {
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+		const fragment = await tsDoc.createFragment();
+
+		const start = fragment.offsetAt(fragment.getGeneratedPosition(range.start));
+		const end = fragment.offsetAt(fragment.getGeneratedPosition(range.end));
+
+		let result: CodeAction[] = [];
+
+		if (cancellationToken?.isCancellationRequested) {
+			return [];
+		}
+
+		if (context.only?.[0] === CodeActionKind.SourceOrganizeImports) {
+			return await this.organizeSortImports(document, false, cancellationToken);
+		}
+
+		// The difference between Sort Imports and Organize Imports is that Sort Imports won't do anything destructive.
+		// For example, it won't remove unused imports whereas Organize Imports will
+		if (context.only?.[0] === sortImportKind) {
+			return await this.organizeSortImports(document, true, cancellationToken);
+		}
+
+		if (context.only?.[0] === CodeActionKind.Source) {
+			return [
+				...(await this.organizeSortImports(document, true, cancellationToken)),
+				...(await this.organizeSortImports(document, false, cancellationToken)),
+			];
+		}
+
+		if (context.diagnostics.length && (!context.only || context.only.includes(CodeActionKind.QuickFix))) {
+			const errorCodes = context.diagnostics
+				.map((diag) => Number(diag.code))
+				// We currently cannot support quick fix for unreachable code properly due to the way our TSX output is structured
+				.filter((code) => code !== 7027);
+
+			let codeFixes = errorCodes.includes(2304) ? this.getComponentQuickFix(start, end, lang, filePath) : undefined;
+			codeFixes = codeFixes ?? lang.getCodeFixesAtPosition(filePath, start, end, errorCodes, {}, {});
+
+			const codeActions = codeFixes.map((fix) =>
+				codeFixToCodeAction(fix, context.diagnostics, context.only ? CodeActionKind.QuickFix : CodeActionKind.Empty)
+			);
+
+			result.push(...codeActions);
+		}
+
+		return result;
+
+		function codeFixToCodeAction(codeFix: CodeFixAction, diagnostics: Diagnostic[], kind: CodeActionKind): CodeAction {
+			const documentChanges = codeFix.changes.map((change) => {
+				return TextDocumentEdit.create(
+					OptionalVersionedTextDocumentIdentifier.create(document.getURL(), null),
+					change.textChanges.map((edit) => {
+						let originalRange = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
+
+						if (codeFix.fixName === 'import') {
+							return codeActionChangeToTextEdit(document, fragment as AstroSnapshotFragment, edit);
+						}
+
+						if (codeFix.fixName === 'fixMissingFunctionDeclaration') {
+							originalRange = checkEndOfFileCodeInsert(originalRange, document);
+						}
+
+						return TextEdit.replace(originalRange, edit.newText);
+					})
+				);
+			});
+
+			const codeAction = CodeAction.create(
+				codeFix.description,
+				{
+					documentChanges,
+				},
+				kind
+			);
+
+			codeAction.diagnostics = diagnostics;
+
+			return codeAction;
+		}
+	}
+
+	// The way TypeScript looks for import quick fixes is by looking for symbols with the same name
+	// This is all fine and nice for most things but our components purposely uses
+	private getComponentQuickFix(
+		start: number,
+		end: number,
+		lang: ts.LanguageService,
+		filePath: string
+	): readonly ts.CodeFixAction[] | undefined {
+		const sourceFile = lang.getProgram()?.getSourceFile(filePath);
+
+		if (!sourceFile) {
+			return;
+		}
+
+		const node = findContainingNode(
+			sourceFile,
+			{
+				start,
+				length: end - start,
+			},
+			(n): n is ts.JsxOpeningLikeElement | ts.JsxClosingElement =>
+				ts.isJsxClosingElement(n) || ts.isJsxOpeningLikeElement(n)
+		);
+
+		if (!node) {
+			return;
+		}
+
+		const tagName = node.tagName;
+
+		const completion = lang.getCompletionsAtPosition(filePath, tagName.getEnd(), completionOptions);
+
+		if (!completion) {
+			return;
+		}
+
+		const name = tagName.getText();
+		const suffixedName = name + '__AstroComponent_';
+
+		const toFix = (c: ts.CompletionEntry) =>
+			lang.getCompletionEntryDetails(filePath, end, c.name, {}, c.source, {}, c.data)?.codeActions?.map((a) => ({
+				...a,
+				description: removeAstroComponentSuffix(a.description),
+				fixName: 'import',
+			})) ?? [];
+
+		return flatten(completion.entries.filter((c) => c.name === name || c.name === suffixedName).map(toFix));
+	}
+
+	private async organizeSortImports(
+		document: AstroDocument,
+		skipDestructiveCodeActions = false,
+		cancellationToken: CancellationToken | undefined
+	): Promise<CodeAction[]> {
+		if (document.astroMeta.frontmatter.state !== 'closed') {
+			return [];
+		}
+
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+		const fragment = await tsDoc.createFragment();
+
+		if (cancellationToken?.isCancellationRequested) {
+			return [];
+		}
+
+		const changes = lang.organizeImports({ fileName: filePath, type: 'file', skipDestructiveCodeActions }, {}, {});
+
+		const documentChanges = changes.map((change) => {
+			return TextDocumentEdit.create(
+				OptionalVersionedTextDocumentIdentifier.create(document.url, null),
+				change.textChanges.map((edit) => {
+					const range = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
+
+					return TextEdit.replace(range, this.fixIndentationOfImports(edit.newText, range, document));
+				})
+			);
+		});
+
+		return [
+			CodeAction.create(
+				skipDestructiveCodeActions ? 'Sort Imports' : 'Organize Imports',
+				{
+					documentChanges,
+				},
+				skipDestructiveCodeActions ? sortImportKind : CodeActionKind.SourceOrganizeImports
+			),
+		];
+	}
+
+	// "Organize Imports" will have edits that delete all imports by return empty edits
+	// and one edit which contains all the organized imports. Fix indentation
+	// of that one by prepending all lines with the indentation of the first line.
+	private fixIndentationOfImports(edit: string, range: Range, document: AstroDocument): string {
+		if (!edit || range.start.character === 0) {
+			return edit;
+		}
+
+		const existingLine = getLineAtPosition(range.start, document.getText());
+		const leadingChars = existingLine.substring(0, range.start.character);
+
+		if (leadingChars.trim() !== '') {
+			return edit;
+		}
+
+		return modifyLines(edit, (line, idx) => (idx === 0 || !line ? line : leadingChars + line));
+	}
+}

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -301,6 +301,19 @@ export function ensureFrontmatterInsert(resultRange: Range, document: AstroDocum
 	return resultRange;
 }
 
+// Some code actions ill insert code at the end of the generated TSX file, so we'll manually
+// redirect it to the end of the frontmatter instead
+export function checkEndOfFileCodeInsert(resultRange: Range, document: AstroDocument) {
+	if (resultRange.start.line > document.lineCount) {
+		if (document.astroMeta.frontmatter.state === 'closed') {
+			const position = document.positionAt(document.astroMeta.frontmatter.endOffset!);
+			return Range.create(position, position);
+		}
+	}
+
+	return resultRange;
+}
+
 export function removeAstroComponentSuffix(name: string) {
 	return name.replace(/(\w+)__AstroComponent_/, '$1');
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -1,14 +1,11 @@
 import * as vscode from 'vscode-languageserver';
 import {
-	ApplyWorkspaceEditParams,
-	ApplyWorkspaceEditRequest,
 	CodeActionKind,
 	MessageType,
 	SemanticTokensRangeRequest,
 	SemanticTokensRequest,
 	ShowMessageNotification,
 	TextDocumentIdentifier,
-	WorkspaceEdit,
 } from 'vscode-languageserver';
 import { ConfigManager } from './core/config/ConfigManager';
 import { DocumentManager } from './core/documents/DocumentManager';
@@ -22,7 +19,7 @@ import { TypeScriptPlugin } from './plugins';
 import { debounceThrottle, getUserAstroVersion, urlToPath } from './utils';
 import { AstroDocument } from './core/documents';
 import { getSemanticTokenLegend } from './plugins/typescript/utils';
-import { missingImportsKind, sortImportKind } from './plugins/typescript/features/CodeActionsProvider';
+import { sortImportKind } from './plugins/typescript/features/CodeActionsProvider';
 
 const TagCloseRequest: vscode.RequestType<vscode.TextDocumentPositionParams, string | null, any> =
 	new vscode.RequestType('html/tag');
@@ -94,7 +91,6 @@ export function startLanguageServer(connection: vscode.Connection) {
 						CodeActionKind.SourceOrganizeImports,
 						// VS Code specific
 						sortImportKind,
-						missingImportsKind,
 					],
 				},
 				completionProvider: {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -1,10 +1,14 @@
 import * as vscode from 'vscode-languageserver';
 import {
+	ApplyWorkspaceEditParams,
+	ApplyWorkspaceEditRequest,
+	CodeActionKind,
 	MessageType,
 	SemanticTokensRangeRequest,
 	SemanticTokensRequest,
 	ShowMessageNotification,
 	TextDocumentIdentifier,
+	WorkspaceEdit,
 } from 'vscode-languageserver';
 import { ConfigManager } from './core/config/ConfigManager';
 import { DocumentManager } from './core/documents/DocumentManager';
@@ -18,6 +22,7 @@ import { TypeScriptPlugin } from './plugins';
 import { debounceThrottle, getUserAstroVersion, urlToPath } from './utils';
 import { AstroDocument } from './core/documents';
 import { getSemanticTokenLegend } from './plugins/typescript/utils';
+import { missingImportsKind, sortImportKind } from './plugins/typescript/features/CodeActionsProvider';
 
 const TagCloseRequest: vscode.RequestType<vscode.TextDocumentPositionParams, string | null, any> =
 	new vscode.RequestType('html/tag');
@@ -73,10 +78,25 @@ export function startLanguageServer(connection: vscode.Connection) {
 
 		return {
 			capabilities: {
-				textDocumentSync: vscode.TextDocumentSyncKind.Incremental,
+				textDocumentSync: {
+					openClose: true,
+					change: vscode.TextDocumentSyncKind.Incremental,
+					save: {
+						includeText: true,
+					},
+				},
 				foldingRangeProvider: true,
 				definitionProvider: true,
 				renameProvider: true,
+				codeActionProvider: {
+					codeActionKinds: [
+						CodeActionKind.QuickFix,
+						CodeActionKind.SourceOrganizeImports,
+						// VS Code specific
+						sortImportKind,
+						missingImportsKind,
+					],
+				},
 				completionProvider: {
 					resolveProvider: true,
 					triggerCharacters: [
@@ -166,7 +186,12 @@ export function startLanguageServer(connection: vscode.Connection) {
 	connection.onHover((params: vscode.HoverParams) => pluginHost.doHover(params.textDocument, params.position));
 
 	connection.onDefinition((evt) => pluginHost.getDefinitions(evt.textDocument, evt.position));
+
 	connection.onFoldingRanges((evt) => pluginHost.getFoldingRanges(evt.textDocument));
+
+	connection.onCodeAction((evt, cancellationToken) =>
+		pluginHost.getCodeActions(evt.textDocument, evt.range, evt.context, cancellationToken)
+	);
 
 	connection.onCompletion(async (evt) => {
 		const promise = pluginHost.getCompletions(evt.textDocument, evt.position, evt.context);

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -49,6 +49,22 @@ export function toPascalCase(string: string) {
 }
 
 /**
+ * Function to modify each line of a text, preserving the line break style (`\n` or `\r\n`)
+ */
+export function modifyLines(text: string, replacementFn: (line: string, lineIdx: number) => string): string {
+	let idx = 0;
+	return text
+		.split('\r\n')
+		.map((l1) =>
+			l1
+				.split('\n')
+				.map((line) => replacementFn(line, idx++))
+				.join('\n')
+		)
+		.join('\r\n');
+}
+
+/**
  * Return true if a specific node could be a component.
  * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
  */

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -1,0 +1,182 @@
+import { expect } from 'chai';
+import { CodeActionKind, Position, Range } from 'vscode-languageserver-types';
+import {
+	CodeActionsProviderImpl,
+	sortImportKind,
+} from '../../../../src/plugins/typescript/features/CodeActionsProvider';
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import { createEnvironment } from '../../../utils';
+
+describe('TypeScript Plugin#CodeActionsProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'codeActions');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new CodeActionsProviderImpl(languageServiceManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('provide simple quick fixes', async () => {
+		const { provider, document } = setup('basic.astro');
+
+		const codeActions = await provider.getCodeActions(document, Range.create(2, 23, 2, 33), {
+			diagnostics: [
+				{
+					code: 2551,
+					message: '',
+					range: Range.create(2, 23, 2, 33),
+					source: 'ts',
+				},
+			],
+			only: [CodeActionKind.QuickFix],
+		});
+
+		delete codeActions[0].diagnostics;
+
+		expect(codeActions).to.deep.equal([
+			{
+				edit: {
+					documentChanges: [
+						{
+							edits: [
+								{
+									newText: 'toString',
+									range: Range.create(2, 22, 2, 30),
+								},
+							],
+							textDocument: {
+								uri: document.getURL(),
+								version: null,
+							},
+						},
+					],
+				},
+				kind: CodeActionKind.QuickFix,
+				title: "Change spelling to 'toString'",
+			},
+		]);
+	});
+
+	it('organize imports', async () => {
+		const { provider, document } = setup('sortOrganizeImports.astro');
+
+		const codeActions = await provider.getCodeActions(
+			document,
+			Range.create(Position.create(6, 0), Position.create(6, 0)),
+			{
+				diagnostics: [],
+				only: [CodeActionKind.SourceOrganizeImports],
+			}
+		);
+
+		expect(codeActions).to.deep.equal([
+			{
+				edit: {
+					documentChanges: [
+						{
+							edits: [
+								{
+									newText: '',
+									range: Range.create(2, 0, 3, 0),
+								},
+							],
+							textDocument: {
+								uri: document.getURL(),
+								version: null,
+							},
+						},
+					],
+				},
+				kind: CodeActionKind.SourceOrganizeImports,
+				title: 'Organize Imports',
+			},
+		]);
+	});
+
+	it('sort imports', async () => {
+		const { provider, document } = setup('sortOrganizeImports.astro');
+
+		const codeActions = await provider.getCodeActions(
+			document,
+			Range.create(Position.create(6, 0), Position.create(6, 0)),
+			{
+				diagnostics: [],
+				only: [sortImportKind],
+			}
+		);
+
+		expect(codeActions).to.deep.equal([
+			{
+				edit: {
+					documentChanges: [
+						{
+							edits: [
+								{
+									newText:
+										"import Basic from './basic.astro';\n\timport QuickFixImportComponent from './quickFixImportComponent.astro';\n",
+									range: Range.create(1, 1, 2, 0),
+								},
+								{
+									newText: '',
+									range: Range.create(2, 0, 3, 0),
+								},
+							],
+							textDocument: {
+								uri: document.getURL(),
+								version: null,
+							},
+						},
+					],
+				},
+				kind: sortImportKind,
+				title: 'Sort Imports',
+			},
+		]);
+	});
+
+	it('provide component import quick fix', async () => {
+		const { provider, document } = setup('quickFixImportComponent.astro');
+
+		const range = Range.create(Position.create(0, 1), Position.create(0, 1));
+		const codeActions = await provider.getCodeActions(document, range, {
+			diagnostics: [
+				{
+					code: 2304,
+					message: "Cannot find name 'MySuperAstroComponent'",
+					range,
+					source: 'ts',
+				},
+			],
+			only: [CodeActionKind.QuickFix],
+		});
+
+		codeActions.forEach((action) => delete action.diagnostics);
+
+		expect(codeActions).to.deep.equal([
+			{
+				edit: {
+					documentChanges: [
+						{
+							edits: [
+								{
+									newText:
+										'---\nimport MySuperAstroComponent from "./components/MySuperAstroComponent.astro";\n\n---\n\n',
+									range: Range.create(0, 0, 0, 0),
+								},
+							],
+							textDocument: {
+								uri: document.getURL(),
+								version: null,
+							},
+						},
+					],
+				},
+				kind: 'quickfix',
+				title: 'Add import from "./components/MySuperAstroComponent.astro"',
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
@@ -69,9 +69,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 		const { additionalTextEdits, detail } = await provider.resolveCompletion(document, item!);
 
 		expect(detail).to.equal('./imports/component.astro');
-		expect(additionalTextEdits[0].newText).to.equal(
-			`${newLine}import Component from './imports/component.astro';${newLine}`
-		);
+		expect(additionalTextEdits[0].newText).to.equal(`import Component from './imports/component.astro';${newLine}`);
 	});
 
 	it('resolve completion without auto import if component import already exists', async () => {

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/basic.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/basic.astro
@@ -1,0 +1,4 @@
+---
+	const MyNumber = 3
+	console.log(MyNumber.toStrang())
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/quickFixImportComponent.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/quickFixImportComponent.astro
@@ -1,0 +1,1 @@
+<MySuperAstroComponent></MySuperAstroComponent>

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/sortOrganizeImports.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/sortOrganizeImports.astro
@@ -1,0 +1,6 @@
+---
+	import QuickFixImportComponent from './quickFixImportComponent.astro';
+	import Basic from './basic.astro';
+---
+
+<QuickFixImportComponent></QuickFixImportComponent>


### PR DESCRIPTION
## Changes

This adds support for TypeScript code actions! Code actions are what powers features such as "Quick fixes" and "Source actions" in the editor.

![image](https://user-images.githubusercontent.com/3019731/164544455-04168476-b6cb-445c-991e-f0053089ae01.png)

This works everywhere in the file, frontmatter, jsx expressions, template etc. It also support the Organize Imports and Sort Imports actions

This PR also fix an issue where the first completion that add an import would mistakenly add it on the wrong line (due to the shape of our TSX output)

This fix https://github.com/withastro/language-tools/issues/143

## Caveats

I decided against implementing some code actions that are available in TypeScript, at least for this first implementation. Notably, I did not implement refactors and the fix all code action. 

- Refactors in TypeScript are not too good, even in `ts` files some patterns will break them. Other frameworks either don't implement them or they generate broken code :woman_shrugging: 

- The Fix All action in `ts` files, unlike what one might think, does not actually fix all problems and instead fixes a very limited subset of problems that are not necessarily common problems inside Astro files

- "Remove unused code" isn't supported at the moment. Due to the shape of our TSX output, it tends to mistake some used code for unused and remove code greedily. I'm not sure how to both have this and import completions working at the same time with our current TSX output

## Testing

Added tests for this

## Docs

No docs needed
