### PR TITLE
Fix Emmet settings not being loaded, add Emmet support in CSS

### DIFF
--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -158,10 +158,37 @@ export class CSSPlugin implements Plugin {
 		const cssLang = extractLanguage(cssDocument);
 		const langService = getLanguageService(cssLang);
 
-		const emmetResults: CompletionList = {
-			isIncomplete: true,
+		let emmetResults: CompletionList = {
+			isIncomplete: false,
 			items: [],
 		};
+
+		langService.setCompletionParticipants([
+			{
+				onCssProperty: (context) => {
+					if (context?.propertyName) {
+						emmetResults =
+							getEmmetCompletions(
+								cssDocument,
+								cssDocument.getGeneratedPosition(position),
+								getLanguage(cssLang),
+								this.configManager.getEmmetConfig()
+							) || emmetResults;
+					}
+				},
+				onCssPropertyValue: (context) => {
+					if (context?.propertyValue) {
+						emmetResults =
+							getEmmetCompletions(
+								cssDocument,
+								cssDocument.getGeneratedPosition(position),
+								getLanguage(cssLang),
+								this.configManager.getEmmetConfig()
+							) || emmetResults;
+					}
+				},
+			},
+		]);
 
 		const results = langService.doComplete(
 			cssDocument,

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -63,6 +63,25 @@ describe('CSS Plugin', () => {
 			expect(globalCompletion, 'Expected completions to contain :global modifier').to.not.be.null;
 		});
 
+		it('Emmet completions', () => {
+			const { plugin, document } = setup('<style>h1 {p2}</style>');
+
+			const completions = plugin.getCompletions(document, Position.create(0, 13));
+			const emmetCompletion = completions?.items.find((item) => item.detail === 'Emmet Abbreviation');
+
+			expect(emmetCompletion).to.deep.equal({
+				label: 'padding: 2px;',
+				textEdit: {
+					newText: 'padding: 2px;',
+					range: Range.create(0, 11, 0, 13),
+				},
+				documentation: 'padding: 2px;',
+				insertTextFormat: 2,
+				detail: 'Emmet Abbreviation',
+				filterText: 'p2',
+			});
+		});
+
 		it('should not provide completions for unclosed style tags', () => {
 			const { plugin, document } = setup('<style>');
 

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -29,7 +29,7 @@ export async function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'astro' }],
 		synchronize: {
-			configurationSection: ['astro', 'javascript', 'typescript', 'prettier'],
+			configurationSection: ['astro', 'javascript', 'typescript', 'prettier', 'emmet'],
 			fileEvents: workspace.createFileSystemWatcher('{**/*.js,**/*.ts}', false, false, false),
 		},
 		initializationOptions: {


### PR DESCRIPTION
## Changes

We never told VS Code that we want the Emmet config which meant that we never got VS Code's default settings which allows for extended completions (things like `a:link` and others) :sweat: 

This PR also adds support for Emmet in CSS, giving us Emmet support everywhere now! :partying_face:

![image](https://user-images.githubusercontent.com/3019731/164744958-5d47e080-2de3-42fe-be4d-502fb5155cc7.png)

![image](https://user-images.githubusercontent.com/3019731/164745802-ac8cd68f-ab19-486b-8d4f-8c4320958dc3.png)

This fix https://github.com/withastro/language-tools/issues/9

## Caveats

The support in CSS has some minors issues due to upstream issues but since those issues seems to shows up in every single VS Code extension that depend on the official VS Code Emmet helper, I figured it was alright

The issues are fairly minor in the grand scheme of things, being things like completions showing when they shouldn't and completions with `+` not working properly (which also happens in the official Emmet extension bundled with VS Code and was marked as wontfix in the helper)

## Testing

Added test that we get Emmet completions in CSS

We can't really test that we load the Emmet config properly from VS Code due to it being something that get passed to us when initializing the server and if VS Code stopped passing things to us, we'd have bigger problems than Emmet not working :sweat_smile:

(We should however test that while initializing the server we actually do populate the config correctly from what's passed to us, but it's a bit outside the scope of this PR as it require building a test suite for the whole initializing part of the server)

## Docs

No docs needed
