### PR TITLE
fix: handle the case when server settings are not provided

### DIFF
--- a/.changeset/four-laws-occur.md
+++ b/.changeset/four-laws-occur.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixed bug where nonexistent server settings would result in a crash

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -68,8 +68,14 @@ export function startLanguageServer(connection: vscode.Connection) {
 		}
 
 		// Update language-server config with what the user supplied to us at launch
-		configManager.updateConfig(params.initializationOptions.configuration.astro);
-		configManager.updateEmmetConfig(params.initializationOptions.configuration.emmet);
+		let astroConfiguration = params.initializationOptions?.configuration?.astro;
+		if (astroConfiguration) {
+			configManager.updateConfig(astroConfiguration);
+		}
+		let emmetConfiguration = params.initializationOptions?.configuration?.emmet;
+		if (emmetConfiguration) {
+			configManager.updateEmmetConfig(emmetConfiguration);
+		}
 
 		return {
 			capabilities: {


### PR DESCRIPTION
## Changes

If server settings were not provided to the Astro LS, it would crash with:
```
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Request initialize failed with message: Cannot read properties of undefined (reading 'astro')"}}
```
This fixes this issue by adding a null check to the server settings.

(I ran into this issue with my configuration of Neovim LSP.)

## Testing

Does this need tests at all?

I'm not exactly sure how to go about testing this, anyway, since `configManager` isn't even used in `LanguageServiceManager`.

## Docs

It's just a bug fix, no docs necessary.