### PR TITLE
Add support for inlay hints

### DIFF
--- a/.changeset/quiet-olives-appear.md
+++ b/.changeset/quiet-olives-appear.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': minor
+'astro-vscode': minor
+---
+
+Updated language server to latest version of LSP, added support for Inlay Hints

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -23,13 +23,13 @@
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
-    "typescript": "~4.6.2",
+    "typescript": "~4.6.4",
     "vscode-css-languageservice": "^5.1.13",
     "vscode-html-languageservice": "^4.2.2",
-    "vscode-languageserver": "7.0.0",
-    "vscode-languageserver-protocol": "^3.16.0",
+    "vscode-languageserver": "^8.0.0",
+    "vscode-languageserver-protocol": "^3.17.0",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.16.0",
+    "vscode-languageserver-types": "^3.17.0",
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -153,6 +153,7 @@ export class ConfigManager {
 
 	async getTSInlayHintsPreferences(document: TextDocument): Promise<InlayHintsOptions> {
 		const config = (await this.getConfig<any>('typescript', document.uri)) ?? {};
+
 		const tsPreferences = this.getTSPreferences(document);
 
 		return {
@@ -184,10 +185,17 @@ export class ConfigManager {
 
 	/**
 	 * Updating the global config should only be done in cases where the client doesn't support `workspace/configuration`
-	 * or inside of tests
+	 * or inside of tests.
+	 *
+	 * The `outsideAstro` parameter can be set to true to change configurations in the global scope.
+	 * For example, to change TypeScript settings
 	 */
-	updateGlobalConfig(config: DeepPartial<LSConfig>) {
-		this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
+	updateGlobalConfig(config: DeepPartial<LSConfig> | any, outsideAstro?: boolean) {
+		if (outsideAstro) {
+			this.globalConfig = merge({}, this.globalConfig, config);
+		} else {
+			this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
+		}
 	}
 }
 

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -22,6 +22,7 @@ import {
 	SemanticTokens,
 	CodeActionContext,
 	CodeAction,
+	InlayHint,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { flatten } from 'lodash';
@@ -222,6 +223,16 @@ export class PluginHost {
 		const document = this.getDocument(textDocument.uri);
 
 		return flatten(await this.execute<ColorInformation[]>('getDocumentColors', [document], ExecuteMode.Collect));
+	}
+
+	async getInlayHints(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		cancellationToken: CancellationToken
+	): Promise<InlayHint[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(await this.execute<InlayHint[]>('getInlayHints', [document, range], ExecuteMode.FirstNonNull));
 	}
 
 	async getColorPresentations(

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -13,6 +13,7 @@ import {
 	FoldingRange,
 	FormattingOptions,
 	Hover,
+	InlayHint,
 	LinkedEditingRanges,
 	Position,
 	Range,
@@ -103,6 +104,10 @@ export interface UpdateImportsProvider {
 	updateImports(fileRename: FileRename): Resolvable<WorkspaceEdit | null>;
 }
 
+export interface InlayHintsProvider {
+	getInlayHints(document: TextDocument, range: Range): Resolvable<InlayHint[]>;
+}
+
 export interface RenameProvider {
 	rename(document: TextDocument, position: Position, newName: string): Resolvable<WorkspaceEdit | null>;
 	prepareRename(document: TextDocument, position: Position): Resolvable<Range | null>;
@@ -164,6 +169,7 @@ type ProviderBase = DiagnosticsProvider &
 	SelectionRangeProvider &
 	OnWatchFileChangesProvider &
 	LinkedEditingRangesProvider &
+	InlayHintsProvider &
 	UpdateNonAstroFile;
 
 export type LSProvider = ProviderBase;

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -9,6 +9,7 @@ import {
 	FileChangeType,
 	FoldingRange,
 	Hover,
+	InlayHint,
 	Position,
 	Range,
 	SemanticTokens,
@@ -32,6 +33,7 @@ import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
 import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import { DefinitionsProviderImpl } from './features/DefinitionsProvider';
+import { InlayHintProviderImpl } from './features/InlayHintsProvider';
 
 export class TypeScriptPlugin implements Plugin {
 	__name = 'typescript';
@@ -46,6 +48,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly signatureHelpProvider: SignatureHelpProviderImpl;
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
+	private readonly inlayHintsProvider: InlayHintProviderImpl;
 	private readonly semanticTokensProvider: SemanticTokensProviderImpl;
 	private readonly foldingRangesProvider: FoldingRangesProviderImpl;
 
@@ -61,6 +64,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
 		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
+		this.inlayHintsProvider = new InlayHintProviderImpl(this.languageServiceManager);
 		this.foldingRangesProvider = new FoldingRangesProviderImpl(this.languageServiceManager);
 	}
 
@@ -167,6 +171,10 @@ export class TypeScriptPlugin implements Plugin {
 		cancellationToken?: CancellationToken
 	): Promise<AppCompletionItem<CompletionItemData>> {
 		return this.completionProvider.resolveCompletion(document, completionItem, cancellationToken);
+	}
+
+	async getInlayHints(document: AstroDocument, range: Range): Promise<InlayHint[]> {
+		return this.inlayHintsProvider.getInlayHints(document, range);
 	}
 
 	async getDefinitions(document: AstroDocument, position: Position): Promise<DefinitionLink[]> {

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -33,7 +33,7 @@ import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
 import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import { DefinitionsProviderImpl } from './features/DefinitionsProvider';
-import { InlayHintProviderImpl } from './features/InlayHintsProvider';
+import { InlayHintsProviderImpl } from './features/InlayHintsProvider';
 
 export class TypeScriptPlugin implements Plugin {
 	__name = 'typescript';
@@ -48,7 +48,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly signatureHelpProvider: SignatureHelpProviderImpl;
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
-	private readonly inlayHintsProvider: InlayHintProviderImpl;
+	private readonly inlayHintsProvider: InlayHintsProviderImpl;
 	private readonly semanticTokensProvider: SemanticTokensProviderImpl;
 	private readonly foldingRangesProvider: FoldingRangesProviderImpl;
 
@@ -64,7 +64,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
 		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
-		this.inlayHintsProvider = new InlayHintProviderImpl(this.languageServiceManager, this.configManager);
+		this.inlayHintsProvider = new InlayHintsProviderImpl(this.languageServiceManager, this.configManager);
 		this.foldingRangesProvider = new FoldingRangesProviderImpl(this.languageServiceManager);
 	}
 

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -64,7 +64,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
 		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
-		this.inlayHintsProvider = new InlayHintProviderImpl(this.languageServiceManager);
+		this.inlayHintsProvider = new InlayHintProviderImpl(this.languageServiceManager, this.configManager);
 		this.foldingRangesProvider = new FoldingRangesProviderImpl(this.languageServiceManager);
 	}
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -255,6 +255,10 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 		if (detail) {
 			const { detail: itemDetail, documentation: itemDocumentation } = this.getCompletionDocument(detail);
 
+			if (data.originalItem.source) {
+				item.labelDetails = { description: data.originalItem.source };
+			}
+
 			item.detail = itemDetail;
 			item.documentation = itemDocumentation;
 		}
@@ -343,9 +347,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			}
 		}
 
-		// Label details are currently unsupported, however, they'll be supported in the next version of LSP
 		if (comp.sourceDisplay) {
-			(item as any).labelDetails = { description: ts.displayPartsToString(comp.sourceDisplay) };
+			item.labelDetails = { description: ts.displayPartsToString(comp.sourceDisplay) };
 		}
 
 		item.commitCharacters = getCommitCharactersForScriptElement(comp.kind);

--- a/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
@@ -1,0 +1,44 @@
+import { InlayHint } from 'vscode-languageserver';
+import { AstroDocument } from '../../../core/documents';
+import { InlayHintsProvider } from '../../interfaces';
+import { LanguageServiceManager } from '../LanguageServiceManager';
+import { toVirtualAstroFilePath } from '../utils';
+import { InlayHintKind, Range } from 'vscode-languageserver-types';
+import ts from 'typescript';
+
+export class InlayHintProviderImpl implements InlayHintsProvider {
+	constructor(private languageServiceManager: LanguageServiceManager) {}
+
+	async getInlayHints(document: AstroDocument, range: Range): Promise<InlayHint[]> {
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+		const fragment = await tsDoc.createFragment();
+
+		const start = fragment.offsetAt(fragment.getGeneratedPosition(range.start));
+		const end = fragment.offsetAt(fragment.getGeneratedPosition(range.end));
+
+		const inlayHints = lang.provideInlayHints(
+			filePath,
+			{ start, length: end - start },
+			{ includeInlayParameterNameHints: 'all' } // TODO: Replace with actual JavaScript / TypeScript settings
+		);
+
+		return inlayHints.map((hint) => {
+			const result = InlayHint.create(
+				fragment.getOriginalPosition(fragment.positionAt(hint.position)),
+				hint.text,
+				hint.kind === ts.InlayHintKind.Type
+					? InlayHintKind.Type
+					: hint.kind === ts.InlayHintKind.Parameter
+					? InlayHintKind.Parameter
+					: undefined
+			);
+
+			result.paddingLeft = hint.whitespaceBefore;
+			result.paddingRight = hint.whitespaceAfter;
+
+			return result;
+		});
+	}
+}

--- a/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
@@ -7,7 +7,7 @@ import { InlayHintKind, Range } from 'vscode-languageserver-types';
 import ts from 'typescript';
 import { ConfigManager } from '../../../core/config';
 
-export class InlayHintProviderImpl implements InlayHintsProvider {
+export class InlayHintsProviderImpl implements InlayHintsProvider {
 	constructor(private languageServiceManager: LanguageServiceManager, private configManager: ConfigManager) {}
 
 	async getInlayHints(document: AstroDocument, range: Range): Promise<InlayHint[]> {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode-languageserver';
 import {
 	CodeActionKind,
 	DidChangeConfigurationNotification,
+	InlayHintRequest,
 	MessageType,
 	SemanticTokensRangeRequest,
 	SemanticTokensRequest,
@@ -134,6 +135,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 					range: true,
 					full: true,
 				},
+				inlayHintProvider: true,
 				signatureHelpProvider: {
 					triggerCharacters: ['(', ',', '<'],
 					retriggerCharacters: [')'],
@@ -227,6 +229,10 @@ export function startLanguageServer(connection: vscode.Connection) {
 	connection.onDocumentColor((params: vscode.DocumentColorParams) => pluginHost.getDocumentColors(params.textDocument));
 	connection.onColorPresentation((params: vscode.ColorPresentationParams) =>
 		pluginHost.getColorPresentations(params.textDocument, params.range, params.color)
+	);
+
+	connection.onRequest(InlayHintRequest.type, (params: vscode.InlayHintParams, cancellationToken) =>
+		pluginHost.getInlayHints(params.textDocument, params.range, cancellationToken)
 	);
 
 	connection.onRequest(TagCloseRequest, (evt: any) => pluginHost.doTagComplete(evt.textDocument, evt.position));

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -179,6 +179,31 @@ describe('TypeScript Plugin', () => {
 		});
 	});
 
+	describe('provide inlay hints', async () => {
+		it('return inlay hints', async () => {
+			const { plugin, document, configManager } = setup('inlayHints/basic.astro');
+
+			configManager.updateGlobalConfig(
+				{
+					typescript: {
+						inlayHints: {
+							parameterNames: {
+								enabled: 'all',
+							},
+							parameterTypes: {
+								enabled: 'all',
+							},
+						},
+					},
+				},
+				true
+			);
+
+			const inlayHints = await plugin.getInlayHints(document, Range.create(0, 0, 7, 0));
+			expect(inlayHints).to.not.be.empty;
+		});
+	});
+
 	describe('provide folding ranges', async () => {
 		it('return folding ranges', async () => {
 			const { plugin, document } = setup('foldingRanges/frontmatter.astro');

--- a/packages/language-server/test/plugins/typescript/features/InlayHintsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/InlayHintsProvider.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import { Hover, InlayHintKind, Position, Range } from 'vscode-languageserver-types';
+import { InlayHintsProviderImpl } from '../../../../src/plugins/typescript/features/InlayHintsProvider';
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import { createEnvironment } from '../../../utils';
+
+describe('TypeScript Plugin#InlayHintsProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'inlayHints');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new InlayHintsProviderImpl(languageServiceManager, env.configManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('provide inlay hints when enabled', async () => {
+		const { provider, document, configManager } = setup('basic.astro');
+
+		configManager.updateGlobalConfig(
+			{
+				typescript: {
+					inlayHints: {
+						parameterNames: {
+							enabled: 'all',
+						},
+						parameterTypes: {
+							enabled: 'all',
+						},
+					},
+				},
+			},
+			true
+		);
+
+		const inlayHints = await provider.getInlayHints(document, Range.create(0, 0, 7, 0));
+
+		expect(inlayHints).to.deep.equal([
+			{
+				kind: InlayHintKind.Type,
+				label: ': any',
+				paddingLeft: true,
+				paddingRight: undefined,
+				position: Position.create(1, 22),
+			},
+			{
+				kind: InlayHintKind.Parameter,
+				label: 'params:',
+				paddingLeft: undefined,
+				paddingRight: true,
+				position: Position.create(5, 7),
+			},
+		]);
+	});
+
+	it('provide inlay hints inside script tags', async () => {
+		const { provider, document, configManager } = setup('scriptTag.astro');
+
+		configManager.updateGlobalConfig(
+			{
+				typescript: {
+					inlayHints: {
+						parameterNames: {
+							enabled: 'all',
+						},
+						parameterTypes: {
+							enabled: 'all',
+						},
+					},
+				},
+			},
+			true
+		);
+
+		const inlayHints = await provider.getInlayHints(document, Range.create(0, 0, 7, 0));
+
+		expect(inlayHints).to.deep.equal([
+			{
+				kind: InlayHintKind.Type,
+				label: ': any',
+				paddingLeft: true,
+				paddingRight: undefined,
+				position: Position.create(1, 22),
+			},
+			{
+				kind: InlayHintKind.Parameter,
+				label: 'params:',
+				paddingLeft: undefined,
+				paddingRight: true,
+				position: Position.create(5, 7),
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/inlayHints/basic.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/inlayHints/basic.astro
@@ -1,0 +1,7 @@
+---
+	function hello(params) {
+
+	}
+
+	hello({})
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/inlayHints/scriptTag.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/inlayHints/scriptTag.astro
@@ -1,0 +1,7 @@
+<script>
+	function hello(params) {
+
+	}
+
+	hello({})
+</script>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@astrojs/language-server": "0.16.1",
     "@astrojs/ts-plugin": "0.2.1",
-    "vscode-languageclient": "~7.0.0"
+    "vscode-languageclient": "^8.0.0"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -41,10 +41,9 @@ export async function activate(context: ExtensionContext) {
 	};
 
 	client = createLanguageServer(serverOptions, clientOptions);
-	context.subscriptions.push(client.start());
 
 	client
-		.onReady()
+		.start()
 		.then(() => {
 			const tagRequestor = (document: TextDocument, position: Position) => {
 				const param = client.code2ProtocolConverter.asTextDocumentPositionParams(document, position);
@@ -105,8 +104,7 @@ export async function activate(context: ExtensionContext) {
 		await client.stop();
 
 		client = createLanguageServer(serverOptions, clientOptions);
-		context.subscriptions.push(client.start());
-		await client.onReady();
+		await client.start();
 
 		if (showNotification) {
 			window.showInformationMessage('Astro language server restarted.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,7 +4839,7 @@ semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.5:
+semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -5487,7 +5487,7 @@ typescript@*, typescript@~4.6.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
-typescript@^4.6.0:
+typescript@^4.6.0, typescript@~4.6.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
@@ -5753,14 +5753,19 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-languageclient@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-jsonrpc@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0.tgz#43cca5b81d46ddffb8608de9d43faaa8c0eb616b"
+  integrity sha512-gc16lr5REIvxqCLQ9Bwf0fQMCnX5eSFoXeXymSXh80HXUtk7E3TWqT/QduFmWK6PSjruWpwc9X2mmpD1WBcS2g==
+
+vscode-languageclient@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.0.tgz#f2e342b5f0a6bc9d0e8ffadff1e99f7695de08f2"
+  integrity sha512-4/jsbWE2G609rkJ36uZTrXEsoCmZjhTOpIw1La3ILEnHclhtHe4X/nZp8WGrTKvT/jh/sGhJqWzLPnTcoiQO3g==
   dependencies:
     minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.0"
 
 vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   version "3.16.0"
@@ -5769,6 +5774,14 @@ vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   dependencies:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
+
+vscode-languageserver-protocol@3.17.0, vscode-languageserver-protocol@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0.tgz#9fa8d366a57b7f5bca4f0bbe5ff9deeba9a1a03a"
+  integrity sha512-SizljNNWWcgKCoXFL8xvzQptzH599YUVmde7wS/ESxgRRzAiIf6jR7i+CoiLU6G/6ySG351MNSvc8z33ncmLNQ==
+  dependencies:
+    vscode-jsonrpc "8.0.0"
+    vscode-languageserver-types "3.17.0"
 
 vscode-languageserver-textdocument@^1.0.1, vscode-languageserver-textdocument@^1.0.3:
   version "1.0.4"
@@ -5780,12 +5793,24 @@ vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.15.1, vscode-
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
+vscode-languageserver-types@3.17.0, vscode-languageserver-types@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0.tgz#98f27a8855152897c9dde6127cb778ce70c7c239"
+  integrity sha512-ECJg27DKWEfkIUuNyjMydPsl5Lu7XX1xmwEpZ61I4oeK1qFNbfp3tSZUVmeMPPgnNjasd1rrb3on9jbSe5g3nQ==
+
 vscode-languageserver@7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz"
   integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
   dependencies:
     vscode-languageserver-protocol "3.16.0"
+
+vscode-languageserver@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.0.tgz#e8dee1548e2f5a777ded56e3ec890d452e5c1b2b"
+  integrity sha512-qa2ue4cFHJN2nyLCe4P9WG6R7c+KfVox/6q90aJFc5oZb9sE2VjijDwxq0u9oWNScn/7QpESUvGE8OEHTuktXw==
+  dependencies:
+    vscode-languageserver-protocol "3.17.0"
 
 vscode-nls@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Changes

This adds support for [inlay hints](https://code.visualstudio.com/docs/languages/typescript#_inlay-hints)! This requires upgrading the versions of a few things as inlay hints support was only added in the latest version of the LSP. Those versions are stable, as they've been through a lot of testing (and are already in use by other extensions)

![image](https://user-images.githubusercontent.com/3019731/165799503-9acf4fa4-ac5c-45ca-8ae6-882702e0af03.png)

## Testing

Tests added

## Docs

No docs needed, inlayHints are enabled using the same configuration they're enabled with in TypeScript files
