### PR TITLE
Overhaul Config Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "turbo": "^1.0.0",
     "prettier": "^2.2.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.6.0"
   },
   "engines": {
     "node": "^14.16.0 || >=16.0.0"

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -1,43 +1,29 @@
 import { get, merge } from 'lodash';
 import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
-import { LSConfig } from './interfaces';
+import { LSConfig, LSCSSConfig, LSHTMLConfig, LSTypescriptConfig } from './interfaces';
+import { Connection, DidChangeConfigurationParams } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { FormatCodeSettings, TsConfigSourceFile, UserPreferences } from 'typescript';
 
 const defaultLSConfig: LSConfig = {
-	astro: {
-		enabled: true,
-		diagnostics: { enabled: true },
-		rename: { enabled: true },
-		format: { enabled: true },
-		completions: { enabled: true },
-		hover: { enabled: true },
-		codeActions: { enabled: true },
-		selectionRange: { enabled: true },
-	},
 	typescript: {
 		enabled: true,
 		diagnostics: { enabled: true },
 		hover: { enabled: true },
 		completions: { enabled: true },
 		definitions: { enabled: true },
-		findReferences: { enabled: true },
 		documentSymbols: { enabled: true },
 		codeActions: { enabled: true },
 		rename: { enabled: true },
-		selectionRange: { enabled: true },
 		signatureHelp: { enabled: true },
 		semanticTokens: { enabled: true },
-		implementation: { enabled: true },
-		typeDefinition: { enabled: true },
 	},
 	css: {
 		enabled: true,
-		diagnostics: { enabled: true },
 		hover: { enabled: true },
 		completions: { enabled: true, emmet: true },
 		documentColors: { enabled: true },
-		colorPresentations: { enabled: true },
 		documentSymbols: { enabled: true },
-		selectionRange: { enabled: true },
 	},
 	html: {
 		enabled: true,
@@ -45,8 +31,6 @@ const defaultLSConfig: LSConfig = {
 		completions: { enabled: true, emmet: true },
 		tagComplete: { enabled: true },
 		documentSymbols: { enabled: true },
-		renameTags: { enabled: true },
-		linkedEditing: { enabled: true },
 	},
 };
 
@@ -62,24 +46,70 @@ type DeepPartial<T> = T extends Record<string, unknown>
  * For more info on this, see the [internal docs](../../../../../docs/internal/language-server/config.md)
  */
 export class ConfigManager {
-	private config: LSConfig = defaultLSConfig;
-	private emmetConfig: VSCodeEmmetConfig = {};
+	private config = defaultLSConfig;
+	private documentSettings: Record<string, Record<string, Promise<any>>> = {};
 
 	private isTrusted = true;
 
-	updateConfig(config: DeepPartial<LSConfig>): void {
-		// Ideally we shouldn't need the merge here because all updates should be valid and complete configs.
-		// But since those configs come from the client they might be out of synch with the valid config:
-		// We might at some point in the future forget to synch config settings in all packages after updating the config.
-		this.config = merge({}, defaultLSConfig, this.config, config);
+	private connection: Connection;
+
+	constructor(connection: Connection) {
+		this.connection = connection;
 	}
 
-	updateEmmetConfig(config: VSCodeEmmetConfig) {
-		this.emmetConfig = config || {};
+	updateConfig() {
+		// Reset all cached document settings
+		this.documentSettings = {};
 	}
 
-	getEmmetConfig(): VSCodeEmmetConfig {
-		return this.emmetConfig;
+	removeDocument(scopeUri: string) {
+		delete this.documentSettings[scopeUri];
+	}
+
+	async getConfig<T>(section: string, scopeUri: string): Promise<Awaited<T>> {
+		if (!this.documentSettings[scopeUri]) {
+			this.documentSettings[scopeUri] = {};
+		}
+
+		if (!this.documentSettings[scopeUri][section]) {
+			this.documentSettings[scopeUri][section] = await this.connection.workspace.getConfiguration({
+				scopeUri,
+				section,
+			});
+		}
+
+		return this.documentSettings[scopeUri][section];
+	}
+
+	async getEmmetConfig(document: TextDocument): Promise<VSCodeEmmetConfig> {
+		const emmetConfig = (await this.getConfig<VSCodeEmmetConfig>('emmet', document.uri)) ?? {};
+
+		return emmetConfig;
+	}
+
+	async getTSFormatConfig(document: TextDocument): Promise<FormatCodeSettings> {
+		const formatConfig = (await this.getConfig<FormatCodeSettings>('typescript.format', document.uri)) ?? {};
+
+		return formatConfig;
+	}
+
+	async getTSPreferences(document: TextDocument): Promise<UserPreferences> {
+		const config = (await this.getConfig<any>('typescript', document.uri)) ?? {};
+		const preferences = config['preferences'];
+
+		return {
+			quotePreference: getQuoteStylePreference(preferences),
+			importModuleSpecifierPreference: getImportModuleSpecifierPreference(preferences),
+			importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(preferences),
+			allowTextChangesInNewFiles: document.uri.startsWith('file://'),
+			providePrefixAndSuffixTextForRename:
+				(preferences.renameShorthandProperties ?? true) === false ? false : preferences.useAliasesForRenames ?? true,
+			includeAutomaticOptionalChainCompletions: config.suggest?.includeAutomaticOptionalChainCompletions ?? true,
+			includeCompletionsForImportStatements: config.suggest?.includeCompletionsForImportStatements ?? true,
+			includeCompletionsWithSnippetText: config.suggest?.includeCompletionsWithSnippetText ?? true,
+			includeCompletionsForModuleExports: config.suggest?.autoImports ?? true,
+			allowIncompleteCompletions: true,
+		};
 	}
 
 	/**
@@ -90,6 +120,16 @@ export class ConfigManager {
 		return !!this.get(key);
 	}
 
+	async isEnabled(
+		document: TextDocument,
+		plugin: keyof LSConfig,
+		feature?: keyof LSTypescriptConfig | keyof LSCSSConfig | keyof LSHTMLConfig
+	) {
+		const config = await this.getConfig<any>('astro', document.uri);
+
+		return feature ? config[plugin][feature]['enabled'] : config[plugin]['enabled'];
+	}
+
 	/**
 	 * Get a specific setting value
 	 * @param key a string which is a path. Example: 'astro.diagnostics.enable'.
@@ -97,11 +137,41 @@ export class ConfigManager {
 	get<T>(key: string): T {
 		return get(this.config, key);
 	}
+}
 
-	/**
-	 * Get the entire user configuration
-	 */
-	getFullConfig(): Readonly<LSConfig> {
-		return this.config;
+function getQuoteStylePreference(config: any) {
+	switch (config.quoteStyle as string) {
+		case 'single':
+			return 'single';
+		case 'double':
+			return 'double';
+		default:
+			return 'auto';
+	}
+}
+
+function getImportModuleSpecifierPreference(config: any) {
+	switch (config.importModuleSpecifier as string) {
+		case 'project-relative':
+			return 'project-relative';
+		case 'relative':
+			return 'relative';
+		case 'non-relative':
+			return 'non-relative';
+		default:
+			return undefined;
+	}
+}
+
+function getImportModuleSpecifierEndingPreference(config: any) {
+	switch (config.importModuleSpecifierEnding as string) {
+		case 'minimal':
+			return 'minimal';
+		case 'index':
+			return 'index';
+		case 'js':
+			return 'js';
+		default:
+			return 'auto';
 	}
 }

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -3,9 +3,9 @@ import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { LSConfig, LSCSSConfig, LSHTMLConfig, LSTypescriptConfig } from './interfaces';
 import { Connection, DidChangeConfigurationParams } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { FormatCodeSettings, TsConfigSourceFile, UserPreferences } from 'typescript';
+import { FormatCodeSettings, SemicolonPreference, TsConfigSourceFile, UserPreferences } from 'typescript';
 
-const defaultLSConfig: LSConfig = {
+export const defaultLSConfig: LSConfig = {
 	typescript: {
 		enabled: true,
 		diagnostics: { enabled: true },
@@ -46,14 +46,14 @@ type DeepPartial<T> = T extends Record<string, unknown>
  * For more info on this, see the [internal docs](../../../../../docs/internal/language-server/config.md)
  */
 export class ConfigManager {
-	private config = defaultLSConfig;
+	private globalConfig: Record<string, any> = { astro: defaultLSConfig };
 	private documentSettings: Record<string, Record<string, Promise<any>>> = {};
 
 	private isTrusted = true;
 
-	private connection: Connection;
+	private connection: Connection | undefined;
 
-	constructor(connection: Connection) {
+	constructor(connection?: Connection) {
 		this.connection = connection;
 	}
 
@@ -66,7 +66,11 @@ export class ConfigManager {
 		delete this.documentSettings[scopeUri];
 	}
 
-	async getConfig<T>(section: string, scopeUri: string): Promise<Awaited<T>> {
+	async getConfig<T>(section: string, scopeUri: string): Promise<T> {
+		if (!this.connection) {
+			return this.globalConfig[section];
+		}
+
 		if (!this.documentSettings[scopeUri]) {
 			this.documentSettings[scopeUri] = {};
 		}
@@ -90,12 +94,40 @@ export class ConfigManager {
 	async getTSFormatConfig(document: TextDocument): Promise<FormatCodeSettings> {
 		const formatConfig = (await this.getConfig<FormatCodeSettings>('typescript.format', document.uri)) ?? {};
 
-		return formatConfig;
+		return {
+			// We can use \n here since the editor normalizes later on to its line endings.
+			newLineCharacter: '\n',
+			insertSpaceAfterCommaDelimiter: formatConfig.insertSpaceAfterCommaDelimiter ?? true,
+			insertSpaceAfterConstructor: formatConfig.insertSpaceAfterConstructor ?? false,
+			insertSpaceAfterSemicolonInForStatements: formatConfig.insertSpaceAfterSemicolonInForStatements ?? true,
+			insertSpaceBeforeAndAfterBinaryOperators: formatConfig.insertSpaceBeforeAndAfterBinaryOperators ?? true,
+			insertSpaceAfterKeywordsInControlFlowStatements:
+				formatConfig.insertSpaceAfterKeywordsInControlFlowStatements ?? true,
+			insertSpaceAfterFunctionKeywordForAnonymousFunctions:
+				formatConfig.insertSpaceAfterFunctionKeywordForAnonymousFunctions ?? true,
+			insertSpaceBeforeFunctionParenthesis: formatConfig.insertSpaceBeforeFunctionParenthesis ?? false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis ?? false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets ?? false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces ?? true,
+			insertSpaceAfterOpeningAndBeforeClosingEmptyBraces:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces ?? true,
+			insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces ?? false,
+			insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces:
+				formatConfig.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces ?? false,
+			insertSpaceAfterTypeAssertion: formatConfig.insertSpaceAfterTypeAssertion ?? false,
+			placeOpenBraceOnNewLineForFunctions: formatConfig.placeOpenBraceOnNewLineForFunctions ?? false,
+			placeOpenBraceOnNewLineForControlBlocks: formatConfig.placeOpenBraceOnNewLineForControlBlocks ?? false,
+			semicolons: formatConfig.semicolons ?? SemicolonPreference.Ignore,
+		};
 	}
 
 	async getTSPreferences(document: TextDocument): Promise<UserPreferences> {
 		const config = (await this.getConfig<any>('typescript', document.uri)) ?? {};
-		const preferences = config['preferences'];
+		const preferences = (await this.getConfig<any>('typescript.preferences', document.uri)) ?? {};
 
 		return {
 			quotePreference: getQuoteStylePreference(preferences),
@@ -109,33 +141,29 @@ export class ConfigManager {
 			includeCompletionsWithSnippetText: config.suggest?.includeCompletionsWithSnippetText ?? true,
 			includeCompletionsForModuleExports: config.suggest?.autoImports ?? true,
 			allowIncompleteCompletions: true,
+			includeCompletionsWithInsertText: true,
 		};
 	}
 
 	/**
-	 * Whether or not specified setting is enabled
-	 * @param key a string which is a path. Example: 'astro.diagnostics.enabled'.
+	 * Return true if a plugin and an optional feature is enabled
 	 */
-	enabled(key: string): boolean {
-		return !!this.get(key);
-	}
-
 	async isEnabled(
 		document: TextDocument,
 		plugin: keyof LSConfig,
 		feature?: keyof LSTypescriptConfig | keyof LSCSSConfig | keyof LSHTMLConfig
-	) {
+	): Promise<boolean> {
 		const config = await this.getConfig<any>('astro', document.uri);
 
-		return feature ? config[plugin][feature]['enabled'] : config[plugin]['enabled'];
+		return feature ? config[plugin].enabled && config[plugin][feature].enabled : config[plugin].enabled;
 	}
 
 	/**
-	 * Get a specific setting value
-	 * @param key a string which is a path. Example: 'astro.diagnostics.enable'.
+	 * Updating the global config should only be done in cases where the client doesn't support `workspace/configuration`
+	 * or inside of tests
 	 */
-	get<T>(key: string): T {
-		return get(this.config, key);
+	updateGlobalConfig(config: DeepPartial<LSConfig>) {
+		this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
 	}
 }
 

--- a/packages/language-server/src/core/config/interfaces.ts
+++ b/packages/language-server/src/core/config/interfaces.ts
@@ -3,35 +3,9 @@
  * Make sure that this is kept in sync with the `package.json` of the VS Code extension
  */
 export interface LSConfig {
-	astro: LSAstroConfig;
 	typescript: LSTypescriptConfig;
 	html: LSHTMLConfig;
 	css: LSCSSConfig;
-}
-
-export interface LSAstroConfig {
-	enabled: boolean;
-	diagnostics: {
-		enabled: boolean;
-	};
-	format: {
-		enabled: boolean;
-	};
-	rename: {
-		enabled: boolean;
-	};
-	completions: {
-		enabled: boolean;
-	};
-	hover: {
-		enabled: boolean;
-	};
-	codeActions: {
-		enabled: boolean;
-	};
-	selectionRange: {
-		enabled: boolean;
-	};
 }
 
 export interface LSTypescriptConfig {
@@ -48,9 +22,6 @@ export interface LSTypescriptConfig {
 	completions: {
 		enabled: boolean;
 	};
-	findReferences: {
-		enabled: boolean;
-	};
 	definitions: {
 		enabled: boolean;
 	};
@@ -60,19 +31,10 @@ export interface LSTypescriptConfig {
 	rename: {
 		enabled: boolean;
 	};
-	selectionRange: {
-		enabled: boolean;
-	};
 	signatureHelp: {
 		enabled: boolean;
 	};
 	semanticTokens: {
-		enabled: boolean;
-	};
-	implementation: {
-		enabled: boolean;
-	};
-	typeDefinition: {
 		enabled: boolean;
 	};
 }
@@ -92,19 +54,10 @@ export interface LSHTMLConfig {
 	documentSymbols: {
 		enabled: boolean;
 	};
-	renameTags: {
-		enabled: boolean;
-	};
-	linkedEditing: {
-		enabled: boolean;
-	};
 }
 
 export interface LSCSSConfig {
 	enabled: boolean;
-	diagnostics: {
-		enabled: boolean;
-	};
 	hover: {
 		enabled: boolean;
 	};
@@ -115,13 +68,7 @@ export interface LSCSSConfig {
 	documentColors: {
 		enabled: boolean;
 	};
-	colorPresentations: {
-		enabled: boolean;
-	};
 	documentSymbols: {
-		enabled: boolean;
-	};
-	selectionRange: {
 		enabled: boolean;
 	};
 }

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -42,6 +42,7 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 		{
 			name: 'is:raw',
 			description: 'Instructs the Astro compiler to treat any children of this element as text',
+			valueSet: 'v',
 			references: [
 				{
 					name: 'Astro reference',

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -65,8 +65,8 @@ export class TypeScriptPlugin implements Plugin {
 		this.configManager = configManager;
 		this.languageServiceManager = new LanguageServiceManager(docManager, workspaceUris, configManager);
 
-		this.codeActionsProvider = new CodeActionsProviderImpl(this.languageServiceManager);
-		this.completionProvider = new CompletionsProviderImpl(this.languageServiceManager);
+		this.codeActionsProvider = new CodeActionsProviderImpl(this.languageServiceManager, this.configManager);
+		this.completionProvider = new CompletionsProviderImpl(this.languageServiceManager, this.configManager);
 		this.hoverProvider = new HoverProviderImpl(this.languageServiceManager);
 		this.signatureHelpProvider = new SignatureHelpProviderImpl(this.languageServiceManager);
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -76,7 +76,7 @@ export class TypeScriptPlugin implements Plugin {
 	}
 
 	async doHover(document: AstroDocument, position: Position): Promise<Hover | null> {
-		if (!this.featureEnabled('hover')) {
+		if (!(await this.featureEnabled(document, 'hover'))) {
 			return null;
 		}
 
@@ -118,19 +118,19 @@ export class TypeScriptPlugin implements Plugin {
 	}
 
 	async getSemanticTokens(
-		textDocument: AstroDocument,
+		document: AstroDocument,
 		range?: Range,
 		cancellationToken?: CancellationToken
 	): Promise<SemanticTokens | null> {
-		if (!this.featureEnabled('semanticTokens')) {
+		if (!(await this.featureEnabled(document, 'semanticTokens'))) {
 			return null;
 		}
 
-		return this.semanticTokensProvider.getSemanticTokens(textDocument, range, cancellationToken);
+		return this.semanticTokensProvider.getSemanticTokens(document, range, cancellationToken);
 	}
 
 	async getDocumentSymbols(document: AstroDocument): Promise<SymbolInformation[]> {
-		if (!this.featureEnabled('documentSymbols')) {
+		if (!(await this.featureEnabled(document, 'documentSymbols'))) {
 			return [];
 		}
 
@@ -145,7 +145,7 @@ export class TypeScriptPlugin implements Plugin {
 		context: CodeActionContext,
 		cancellationToken?: CancellationToken
 	): Promise<CodeAction[]> {
-		if (!this.featureEnabled('codeActions')) {
+		if (!(await this.featureEnabled(document, 'codeActions'))) {
 			return [];
 		}
 
@@ -158,7 +158,7 @@ export class TypeScriptPlugin implements Plugin {
 		completionContext?: CompletionContext,
 		cancellationToken?: CancellationToken
 	): Promise<AppCompletionList<CompletionItemData> | null> {
-		if (!this.featureEnabled('completions')) {
+		if (!(await this.featureEnabled(document, 'completions'))) {
 			return null;
 		}
 
@@ -228,7 +228,7 @@ export class TypeScriptPlugin implements Plugin {
 	}
 
 	async getDiagnostics(document: AstroDocument, cancellationToken?: CancellationToken): Promise<Diagnostic[]> {
-		if (!this.featureEnabled('diagnostics')) {
+		if (!(await this.featureEnabled(document, 'diagnostics'))) {
 			return [];
 		}
 
@@ -315,9 +315,10 @@ export class TypeScriptPlugin implements Plugin {
 		}
 	}
 
-	private featureEnabled(feature: keyof LSTypescriptConfig) {
+	private async featureEnabled(document: AstroDocument, feature: keyof LSTypescriptConfig) {
 		return (
-			this.configManager.enabled('typescript.enabled') && this.configManager.enabled(`typescript.${feature}.enabled`)
+			(await this.configManager.isEnabled(document, 'typescript')) &&
+			(await this.configManager.isEnabled(document, 'typescript', feature))
 		);
 	}
 }

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -30,17 +30,18 @@ import { getRegExpMatches, isNotNullOrUndefined } from '../../../utils';
 import { flatten } from 'lodash';
 import { getMarkdownDocumentation } from '../previewer';
 import { isPartOfImportStatement } from './utils';
+import { ConfigManager } from '../../../core/config';
 
-export const completionOptions: ts.GetCompletionsAtPositionOptions = {
-	importModuleSpecifierPreference: 'relative',
-	importModuleSpecifierEnding: 'auto',
-	quotePreference: 'single',
-	includeCompletionsForModuleExports: true,
-	includeCompletionsForImportStatements: true,
-	includeCompletionsWithInsertText: true,
-	allowIncompleteCompletions: true,
-	includeCompletionsWithSnippetText: true,
-};
+// export const completionOptions: ts.GetCompletionsAtPositionOptions = {
+// 	importModuleSpecifierPreference: 'relative',
+// 	importModuleSpecifierEnding: 'auto',
+// 	quotePreference: 'single',
+// 	includeCompletionsForModuleExports: true,
+// 	includeCompletionsForImportStatements: true,
+// 	includeCompletionsWithInsertText: true,
+// 	allowIncompleteCompletions: true,
+// 	includeCompletionsWithSnippetText: true,
+// };
 
 /**
  * The language service throws an error if the character is not a valid trigger character.
@@ -66,7 +67,7 @@ export interface CompletionItemData extends TextDocumentIdentifier {
 }
 
 export class CompletionsProviderImpl implements CompletionsProvider<CompletionItemData> {
-	constructor(private languageServiceManager: LanguageServiceManager) {}
+	constructor(private languageServiceManager: LanguageServiceManager, private configManager: ConfigManager) {}
 
 	private readonly validTriggerCharacters = ['.', '"', "'", '`', '/', '@', '<', '#'] as const;
 
@@ -132,13 +133,21 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			return null;
 		}
 
+		const tsPreferences = await this.configManager.getTSPreferences(document);
+		const formatOptions = await this.configManager.getTSFormatConfig(document);
+
 		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
 		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
 
-		const completions = lang.getCompletionsAtPosition(filePath, offset, {
-			...completionOptions,
-			triggerCharacter: validTriggerCharacter,
-		});
+		const completions = lang.getCompletionsAtPosition(
+			filePath,
+			offset,
+			{
+				...tsPreferences,
+				triggerCharacter: validTriggerCharacter,
+			},
+			formatOptions
+		);
 
 		if (completions === undefined || completions.entries.length === 0) {
 			return null;
@@ -175,6 +184,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 	): Promise<AppCompletionItem<CompletionItemData>> {
 		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
 
+		const tsPreferences = await this.configManager.getTSPreferences(document);
+
 		const data: CompletionItemData | undefined = item.data as any;
 
 		if (!data || !data.filePath || cancellationToken?.isCancellationRequested) {
@@ -188,7 +199,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			data.originalItem.name, // entryName
 			{}, // formatOptions
 			data.originalItem.source, // source
-			completionOptions, // preferences
+			tsPreferences, // preferences
 			data.originalItem.data // data
 		);
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -32,17 +32,6 @@ import { getMarkdownDocumentation } from '../previewer';
 import { isPartOfImportStatement } from './utils';
 import { ConfigManager } from '../../../core/config';
 
-// export const completionOptions: ts.GetCompletionsAtPositionOptions = {
-// 	importModuleSpecifierPreference: 'relative',
-// 	importModuleSpecifierEnding: 'auto',
-// 	quotePreference: 'single',
-// 	includeCompletionsForModuleExports: true,
-// 	includeCompletionsForImportStatements: true,
-// 	includeCompletionsWithInsertText: true,
-// 	allowIncompleteCompletions: true,
-// 	includeCompletionsWithSnippetText: true,
-// };
-
 /**
  * The language service throws an error if the character is not a valid trigger character.
  * Also, the completions are worse.

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -16,10 +16,10 @@ describe('CSS Plugin', () => {
 	}
 
 	describe('provide completions', () => {
-		it('in style tags', () => {
+		it('in style tags', async () => {
 			const { plugin, document } = setup('<style></style>');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 7), {
+			const completions = await plugin.getCompletions(document, Position.create(0, 7), {
 				triggerCharacter: '.',
 			} as CompletionContext);
 
@@ -27,13 +27,13 @@ describe('CSS Plugin', () => {
 			expect(completions, 'Expected completions to not be empty').to.not.be.null;
 		});
 
-		it('in multiple style tags', () => {
+		it('in multiple style tags', async () => {
 			const { plugin, document } = setup('<style></style><style></style>');
 
-			const completions1 = plugin.getCompletions(document, Position.create(0, 7), {
+			const completions1 = await plugin.getCompletions(document, Position.create(0, 7), {
 				triggerCharacter: '.',
 			} as CompletionContext);
-			const completions2 = plugin.getCompletions(document, Position.create(0, 22), {
+			const completions2 = await plugin.getCompletions(document, Position.create(0, 22), {
 				triggerCharacter: '.',
 			} as CompletionContext);
 
@@ -43,19 +43,19 @@ describe('CSS Plugin', () => {
 			expect(completions2, 'Expected completions2 to not be empty').to.not.be.null;
 		});
 
-		it('in style attributes', () => {
+		it('in style attributes', async () => {
 			const { plugin, document } = setup('<div style=""></div>');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 12));
+			const completions = await plugin.getCompletions(document, Position.create(0, 12));
 
 			expect(completions.items, 'Expected completions to be an array').to.be.an('array');
 			expect(completions, 'Expected completions to not be empty').to.not.be.null;
 		});
 
-		it('for :global modifier', () => {
+		it('for :global modifier', async () => {
 			const { plugin, document } = setup('<style>:g</style>');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 9), {
+			const completions = await plugin.getCompletions(document, Position.create(0, 9), {
 				triggerCharacter: ':',
 			} as CompletionContext);
 			const globalCompletion = completions?.items.find((item) => item.label === ':global()');
@@ -63,10 +63,10 @@ describe('CSS Plugin', () => {
 			expect(globalCompletion, 'Expected completions to contain :global modifier').to.not.be.null;
 		});
 
-		it('Emmet completions', () => {
+		it('Emmet completions', async () => {
 			const { plugin, document } = setup('<style>h1 {p2}</style>');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 13));
+			const completions = await plugin.getCompletions(document, Position.create(0, 13));
 			const emmetCompletion = completions?.items.find((item) => item.detail === 'Emmet Abbreviation');
 
 			expect(emmetCompletion).to.deep.equal({
@@ -82,21 +82,21 @@ describe('CSS Plugin', () => {
 			});
 		});
 
-		it('should not provide completions for unclosed style tags', () => {
+		it('should not provide completions for unclosed style tags', async () => {
 			const { plugin, document } = setup('<style>');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 7), {
+			const completions = await plugin.getCompletions(document, Position.create(0, 7), {
 				triggerCharacter: '.',
 			} as CompletionContext);
 
 			expect(completions).to.be.null;
 		});
 
-		it('should not provide completions if feature is disabled', () => {
+		it('should not provide completions if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<style></style>');
 
 			// Disable completions
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				css: {
 					completions: {
 						enabled: false,
@@ -104,21 +104,22 @@ describe('CSS Plugin', () => {
 				},
 			});
 
-			const completions = plugin.getCompletions(document, Position.create(0, 7), {
+			const completions = await plugin.getCompletions(document, Position.create(0, 7), {
 				triggerCharacter: '.',
 			} as CompletionContext);
 
-			expect(configManager.enabled(`css.completions.enabled`), 'Expected completions to be disabled in configManager')
-				.to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'css', 'completions');
+
+			expect(isEnabled).to.be.false;
 			expect(completions, 'Expected completions to be null').to.be.null;
 		});
 	});
 
 	describe('provide hover info', () => {
-		it('in style tags', () => {
+		it('in style tags', async () => {
 			const { plugin, document } = setup('<style>h1 {color:blue;}</style>');
 
-			expect(plugin.doHover(document, Position.create(0, 8))).to.deep.equal(<Hover>{
+			expect(await plugin.doHover(document, Position.create(0, 8))).to.deep.equal(<Hover>{
 				contents: [
 					{ language: 'html', value: '<h1>' },
 					'[Selector Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity): (0, 0, 1)',
@@ -126,7 +127,7 @@ describe('CSS Plugin', () => {
 				range: Range.create(0, 7, 0, 9),
 			});
 
-			expect(plugin.doHover(document, Position.create(0, 12))).to.deep.equal(<Hover>{
+			expect(await plugin.doHover(document, Position.create(0, 12))).to.deep.equal(<Hover>{
 				contents: {
 					kind: 'markdown',
 					value:
@@ -136,10 +137,10 @@ describe('CSS Plugin', () => {
 			});
 		});
 
-		it('in style attributes', () => {
+		it('in style attributes', async () => {
 			const { plugin, document } = setup('<div style="color: red"></div>');
 
-			expect(plugin.doHover(document, Position.create(0, 13))).to.deep.equal(<Hover>{
+			expect(await plugin.doHover(document, Position.create(0, 13))).to.deep.equal(<Hover>{
 				contents: {
 					kind: 'markdown',
 					value:
@@ -149,19 +150,19 @@ describe('CSS Plugin', () => {
 			});
 		});
 
-		it('should not provide hover info for unclosed style tags', () => {
+		it('should not provide hover info for unclosed style tags', async () => {
 			const { plugin, document } = setup('<style>h1 {color:blue;}');
 
-			const hoverInfo = plugin.doHover(document, Position.create(0, 8));
+			const hoverInfo = await plugin.doHover(document, Position.create(0, 8));
 
 			expect(hoverInfo).to.be.null;
 		});
 
-		it('should not provide hover info if feature is disabled', () => {
+		it('should not provide hover info if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<style>h1 {}</style>');
 
 			// Disable hover info
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				css: {
 					hover: {
 						enabled: false,
@@ -169,9 +170,11 @@ describe('CSS Plugin', () => {
 				},
 			});
 
-			const hoverInfo = plugin.doHover(document, Position.create(0, 8));
+			const hoverInfo = await plugin.doHover(document, Position.create(0, 8));
 
-			expect(configManager.enabled(`css.hover.enabled`), 'Expected hover to be disabled in configManager').to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'css', 'hover');
+
+			expect(isEnabled).to.be.false;
 			expect(hoverInfo, 'Expected hoverInfo to be null').to.be.null;
 		});
 	});
@@ -235,10 +238,10 @@ describe('CSS Plugin', () => {
 	});
 
 	describe('provides document symbols', () => {
-		it('for normal CSS', () => {
+		it('for normal CSS', async () => {
 			const { plugin, document } = setup('<style>h1 {color: red;}</style>');
 
-			const symbols = plugin.getDocumentSymbols(document);
+			const symbols = await plugin.getDocumentSymbols(document);
 
 			expect(symbols).to.deep.equal([
 				{
@@ -252,10 +255,10 @@ describe('CSS Plugin', () => {
 			]);
 		});
 
-		it('for multiple style tags', () => {
+		it('for multiple style tags', async () => {
 			const { plugin, document } = setup('<style>h1 {color: red;}</style><style>h2 {color: blue;}</style>');
 
-			const symbols = plugin.getDocumentSymbols(document);
+			const symbols = await plugin.getDocumentSymbols(document);
 
 			expect(symbols).to.deep.equal([
 				{
@@ -271,11 +274,11 @@ describe('CSS Plugin', () => {
 			]);
 		});
 
-		it('should not provide document symbols if feature is disabled', () => {
+		it('should not provide document symbols if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<style>h1 {color: red;}</style>');
 
 			// Disable documentSymbols
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				css: {
 					documentSymbols: {
 						enabled: false,
@@ -283,21 +286,20 @@ describe('CSS Plugin', () => {
 				},
 			});
 
-			const symbols = plugin.getDocumentSymbols(document);
+			const symbols = await plugin.getDocumentSymbols(document);
 
-			expect(
-				configManager.enabled(`css.documentSymbols.enabled`),
-				'Expected documentSymbols to be disabled in configManager'
-			).to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'css', 'documentSymbols');
+
+			expect(isEnabled).to.be.false;
 			expect(symbols, 'Expected symbols to be empty').to.be.empty;
 		});
 	});
 
 	describe('provide document colors', () => {
-		it('for normal css', () => {
+		it('for normal css', async () => {
 			const { plugin, document } = setup('<style>h1 {color:blue;}</>');
 
-			const colors = plugin.getColorPresentations(document, Range.create(0, 17, 0, 21), {
+			const colors = await plugin.getColorPresentations(document, Range.create(0, 17, 0, 21), {
 				alpha: 1,
 				blue: 255,
 				green: 0,
@@ -336,11 +338,11 @@ describe('CSS Plugin', () => {
 			]);
 		});
 
-		it('should not provide document colors if feature is disabled', () => {
+		it('should not provide document colors if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<style>h1 {color: blue;}</style>');
 
 			// Disable document colors
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				css: {
 					documentColors: {
 						enabled: false,
@@ -348,12 +350,11 @@ describe('CSS Plugin', () => {
 				},
 			});
 
-			const documentColors = plugin.getDocumentColors(document);
+			const documentColors = await plugin.getDocumentColors(document);
 
-			expect(
-				configManager.enabled(`css.documentColors.enabled`),
-				'Expected documentColors to be disabled in configManager'
-			).to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'css', 'documentColors');
+
+			expect(isEnabled).to.be.false;
 			expect(documentColors, 'Expected documentColors to be null').to.be.empty;
 		});
 	});

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -15,37 +15,37 @@ describe('HTML Plugin', () => {
 	}
 
 	describe('provide completions', () => {
-		it('for normal html', () => {
+		it('for normal html', async () => {
 			const { plugin, document } = setup('<');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 1));
+			const completions = await plugin.getCompletions(document, Position.create(0, 1));
 			expect(completions.items, 'Expected completions to be an array').to.be.an('array');
 			expect(completions, 'Expected completions to not be empty').to.not.be.undefined;
 		});
 
-		it('for style lang in style tags', () => {
+		it('for style lang in style tags', async () => {
 			const { plugin, document } = setup('<sty');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 4));
+			const completions = await plugin.getCompletions(document, Position.create(0, 4));
 			expect(completions.items, 'Expected completions to be an array').to.be.an('array');
 			expect(completions!.items.find((item) => item.label === 'style (lang="less")')).to.not.be.undefined;
 		});
 
-		it('should not provide completions inside of an expression', () => {
+		it('should not provide completions inside of an expression', async () => {
 			const { plugin, document } = setup('<div class={');
 
-			const completions = plugin.getCompletions(document, Position.create(0, 12));
+			const completions = await plugin.getCompletions(document, Position.create(0, 12));
 			expect(completions).to.be.null;
 
-			const tagCompletion = plugin.doTagComplete(document, Position.create(0, 12));
+			const tagCompletion = await plugin.doTagComplete(document, Position.create(0, 12));
 			expect(tagCompletion).to.be.null;
 		});
 
-		it('should not provide completions if feature is disabled', () => {
+		it('should not provide completions if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<');
 
 			// Disable completions
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				html: {
 					completions: {
 						enabled: false,
@@ -53,19 +53,19 @@ describe('HTML Plugin', () => {
 				},
 			});
 
-			const completions = plugin.getCompletions(document, Position.create(0, 7));
+			const completions = await plugin.getCompletions(document, Position.create(0, 7));
+			const isEnabled = await configManager.isEnabled(document, 'html', 'completions');
 
-			expect(configManager.enabled(`html.completions.enabled`), 'Expected completions to be disabled in configManager')
-				.to.be.false;
+			expect(isEnabled).to.be.false;
 			expect(completions, 'Expected completions to be null').to.be.null;
 		});
 	});
 
 	describe('provide hover info', () => {
-		it('for HTML elements', () => {
+		it('for HTML elements', async () => {
 			const { plugin, document } = setup('<p>Build fast websites, faster.</p>');
 
-			expect(plugin.doHover(document, Position.create(0, 1))).to.deep.equal(<Hover>{
+			expect(await plugin.doHover(document, Position.create(0, 1))).to.deep.equal(<Hover>{
 				contents: {
 					kind: 'markdown',
 					value:
@@ -76,10 +76,10 @@ describe('HTML Plugin', () => {
 			});
 		});
 
-		it('for HTML attributes', () => {
+		it('for HTML attributes', async () => {
 			const { plugin, document } = setup('<p class="motto">Build fast websites, faster.</p>');
 
-			expect(plugin.doHover(document, Position.create(0, 4))).to.deep.equal(<Hover>{
+			expect(await plugin.doHover(document, Position.create(0, 4))).to.deep.equal(<Hover>{
 				contents: {
 					kind: 'markdown',
 					value:
@@ -90,11 +90,11 @@ describe('HTML Plugin', () => {
 			});
 		});
 
-		it('should not provide hover info if feature is disabled', () => {
+		it('should not provide hover info if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<p>Build fast websites, faster.</p>');
 
 			// Disable hover info
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				html: {
 					hover: {
 						enabled: false,
@@ -102,9 +102,10 @@ describe('HTML Plugin', () => {
 				},
 			});
 
-			const hoverInfo = plugin.doHover(document, Position.create(0, 1));
+			const hoverInfo = await plugin.doHover(document, Position.create(0, 1));
+			const isEnabled = await configManager.isEnabled(document, 'html', 'hover');
 
-			expect(configManager.enabled(`html.hover.enabled`), 'Expected hover to be disabled in configManager').to.be.false;
+			expect(isEnabled).to.be.false;
 			expect(hoverInfo, 'Expected hoverInfo to be null').to.be.null;
 		});
 	});
@@ -129,10 +130,10 @@ describe('HTML Plugin', () => {
 	});
 
 	describe('provides document symbols', () => {
-		it('for html', () => {
+		it('for html', async () => {
 			const { plugin, document } = setup('<div><p>Astro</p></div>');
 
-			const symbols = plugin.getDocumentSymbols(document);
+			const symbols = await plugin.getDocumentSymbols(document);
 
 			expect(symbols).to.deep.equal([
 				{
@@ -150,11 +151,11 @@ describe('HTML Plugin', () => {
 			]);
 		});
 
-		it('should not provide document symbols if feature is disabled', () => {
+		it('should not provide document symbols if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<div><p>Astro</p></div>');
 
 			// Disable documentSymbols
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				html: {
 					documentSymbols: {
 						enabled: false,
@@ -162,12 +163,10 @@ describe('HTML Plugin', () => {
 				},
 			});
 
-			const symbols = plugin.getDocumentSymbols(document);
+			const symbols = await plugin.getDocumentSymbols(document);
+			const isEnabled = await configManager.isEnabled(document, 'html', 'documentSymbols');
 
-			expect(
-				configManager.enabled(`html.documentSymbols.enabled`),
-				'Expected documentSymbols to be disabled in configManager'
-			).to.be.false;
+			expect(isEnabled).to.be.false;
 			expect(symbols, 'Expected symbols to be empty').to.be.empty;
 		});
 	});

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -28,7 +28,7 @@ describe('TypeScript Plugin', () => {
 		it('should not provide documentSymbols if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('documentSymbols/documentSymbols.astro');
 
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				typescript: {
 					documentSymbols: {
 						enabled: false,
@@ -37,8 +37,9 @@ describe('TypeScript Plugin', () => {
 			});
 
 			const symbols = await plugin.getDocumentSymbols(document);
+			const isEnabled = await configManager.isEnabled(document, 'typescript', 'documentSymbols');
 
-			expect(configManager.enabled(`typescript.documentSymbols.enabled`)).to.be.false;
+			expect(isEnabled).to.be.false;
 			expect(symbols).to.be.empty;
 		});
 	});
@@ -54,7 +55,7 @@ describe('TypeScript Plugin', () => {
 		it('should not provide hover info if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('hoverInfo.astro');
 
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				typescript: {
 					hover: {
 						enabled: false,
@@ -64,7 +65,9 @@ describe('TypeScript Plugin', () => {
 
 			const hoverInfo = await plugin.doHover(document, Position.create(1, 10));
 
-			expect(configManager.enabled(`typescript.hover.enabled`)).to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'typescript', 'hover');
+
+			expect(isEnabled).to.be.false;
 			expect(hoverInfo).to.be.null;
 		});
 	});
@@ -80,7 +83,7 @@ describe('TypeScript Plugin', () => {
 		it('should not provide diagnostics if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('diagnostics/basic.astro');
 
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				typescript: {
 					diagnostics: {
 						enabled: false,
@@ -115,7 +118,7 @@ describe('TypeScript Plugin', () => {
 		it('should not provide code actions if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('codeActions/basic.astro');
 
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				typescript: {
 					codeActions: {
 						enabled: false,
@@ -135,7 +138,9 @@ describe('TypeScript Plugin', () => {
 				only: [CodeActionKind.QuickFix],
 			});
 
-			expect(configManager.enabled(`typescript.codeActions.enabled`)).to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'typescript', 'codeActions');
+
+			expect(isEnabled).to.be.false;
 			expect(codeActions).to.be.empty;
 		});
 	});
@@ -158,7 +163,7 @@ describe('TypeScript Plugin', () => {
 		it('should not provide semantic tokens if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('semanticTokens/frontmatter.astro');
 
-			configManager.updateConfig(<any>{
+			configManager.updateGlobalConfig(<any>{
 				typescript: {
 					semanticTokens: {
 						enabled: false,
@@ -167,7 +172,9 @@ describe('TypeScript Plugin', () => {
 			});
 
 			const semanticTokens = await plugin.getSemanticTokens(document);
-			expect(configManager.enabled(`typescript.semanticTokens.enabled`)).to.be.false;
+			const isEnabled = await configManager.isEnabled(document, 'typescript', 'semanticTokens');
+
+			expect(isEnabled).to.be.false;
 			expect(semanticTokens).to.be.null;
 		});
 	});

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -11,7 +11,7 @@ describe('TypeScript Plugin#CodeActionsProvider', () => {
 	function setup(filePath: string) {
 		const env = createEnvironment(filePath, 'typescript', 'codeActions');
 		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
-		const provider = new CodeActionsProviderImpl(languageServiceManager);
+		const provider = new CodeActionsProviderImpl(languageServiceManager, env.configManager);
 
 		return {
 			...env,

--- a/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
@@ -12,7 +12,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 	function setup(filePath: string) {
 		const env = createEnvironment(filePath, 'typescript', 'completions');
 		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
-		const provider = new CompletionsProviderImpl(languageServiceManager);
+		const provider = new CompletionsProviderImpl(languageServiceManager, env.configManager);
 
 		return {
 			...env,
@@ -56,7 +56,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 
 		expect(detail).to.equal('./imports/component.astro');
 		expect(additionalTextEdits[0].newText).to.equal(
-			`---${newLine}import Component from './imports/component.astro'${newLine}---${newLine}${newLine}`
+			`---${newLine}import Component from "./imports/component.astro"${newLine}---${newLine}${newLine}`
 		);
 	});
 
@@ -69,7 +69,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 		const { additionalTextEdits, detail } = await provider.resolveCompletion(document, item!);
 
 		expect(detail).to.equal('./imports/component.astro');
-		expect(additionalTextEdits[0].newText).to.equal(`import Component from './imports/component.astro';${newLine}`);
+		expect(additionalTextEdits[0].newText).to.equal(`import Component from "./imports/component.astro";${newLine}`);
 	});
 
 	it('resolve completion without auto import if component import already exists', async () => {
@@ -105,7 +105,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 
 		expect(item).to.deep.equal({
 			commitCharacters: ['.', ',', '('],
-			insertText: "import { MySuperFunction$1 } from './imports/definitions';",
+			insertText: 'import { MySuperFunction$1 } from "./imports/definitions";',
 			insertTextFormat: 2,
 			kind: CompletionItemKind.Function,
 			label: 'MySuperFunction',
@@ -115,7 +115,7 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 			preselect: undefined,
 			sortText: '11',
 			textEdit: {
-				newText: "import { MySuperFunction$1 } from './imports/definitions';",
+				newText: 'import { MySuperFunction$1 } from "./imports/definitions";',
 				range: Range.create(1, 1, 1, 10),
 			},
 		});

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -77,77 +77,137 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "astro.plugin.typescript.enable": {
+        "astro.typescript.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript",
-          "description": "Enable the TypeScript plugin"
+          "description": "Enable TypeScript features"
         },
-        "astro.plugin.typescript.diagnostics.enable": {
+        "astro.typescript.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Diagnostics",
           "description": "Enable diagnostic messages for TypeScript"
         },
-        "astro.plugin.typescript.hover.enable": {
+        "astro.typescript.hover.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Hover Info",
           "description": "Enable hover info for TypeScript"
         },
-        "astro.plugin.typescript.documentSymbols.enable": {
+        "astro.typescript.documentSymbols.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Symbols in Outline",
           "description": "Enable document symbols for TypeScript"
         },
-        "astro.plugin.typescript.completions.enable": {
+        "astro.typescript.completions.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Completions",
           "description": "Enable completions for TypeScript"
         },
-        "astro.plugin.typescript.findReferences.enable": {
-          "type": "boolean",
-          "default": true,
-          "title": "TypeScript: Find References",
-          "description": "Enable find-references for TypeScript"
-        },
-        "astro.plugin.typescript.definitions.enable": {
+        "astro.typescript.definitions.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Go to Definition",
           "description": "Enable go to definition for TypeScript"
         },
-        "astro.plugin.typescript.codeActions.enable": {
+        "astro.typescript.codeActions.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Code Actions",
           "description": "Enable code actions for TypeScript"
         },
-        "astro.plugin.typescript.selectionRange.enable": {
-          "type": "boolean",
-          "default": true,
-          "title": "TypeScript: Selection Range",
-          "description": "Enable selection range for TypeScript"
-        },
-        "astro.plugin.typescript.signatureHelp.enable": {
+        "astro.typescript.signatureHelp.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Signature Help",
           "description": "Enable signature help (parameter hints) for TypeScript"
         },
-        "astro.plugin.typescript.rename.enable": {
+        "astro.typescript.rename.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Rename",
           "description": "Enable rename functionality for JS/TS variables inside Astro files"
         },
-        "astro.plugin.typescript.semanticTokens.enable": {
+        "astro.typescript.semanticTokens.enabled": {
           "type": "boolean",
           "default": true,
           "title": "TypeScript: Semantic Tokens",
-          "description": "Enable semantic tokens (semantic highlight) for TypeScript."
+          "description": "Enable semantic tokens (used for semantic highlighting) for TypeScript."
+        },
+        "astro.html.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML",
+          "description": "Enable HTML features"
+        },
+        "astro.html.hover.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML: Hover Info",
+          "description": "Enable hover info for HTML"
+        },
+        "astro.html.completions.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML: Completions",
+          "description": "Enable completions for HTML"
+        },
+        "astro.html.completions.emmet": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML: Emmet Completions",
+          "description": "Enable Emmet completions for HTML"
+        },
+        "astro.html.tagComplete.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML: Tag Completion",
+          "description": "Enable tag completion for HTML"
+        },
+        "astro.html.documentSymbols.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "HTML: Symbols in Outline",
+          "description": "Enable document symbols for CSS"
+        },
+        "astro.css.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS",
+          "description": "Enable CSS features"
+        },
+        "astro.css.hover.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS: Hover Info",
+          "description": "Enable hover info for CSS"
+        },
+        "astro.css.completions.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS: Completions",
+          "description": "Enable completions for CSS"
+        },
+        "astro.css.completions.emmet": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS: Emmet Completions",
+          "description": "Enable Emmet completions for CSS"
+        },
+        "astro.css.documentColors.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS: Document Colors",
+          "description": "Enable color picker for CSS"
+        },
+        "astro.css.documentSymbols.enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "CSS: Symbols in Outline",
+          "description": "Enable document symbols for CSS"
         }
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,10 +5482,15 @@ type-fest@^2.5.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
   integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
 
-typescript@*, typescript@^4.5.4, typescript@~4.6.2:
+typescript@*, typescript@~4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+typescript@^4.6.0:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Changes

Configuration in language servers can work in two modes: push and pull. The former is what we're currently doing, where the client will push settings to the server at initialization, this mode is deprecated in favor of the later, pull. 

In that mode, the server will pull configurations sections from the client, [this does not make people necessarily happy](https://github.com/microsoft/language-server-protocol/issues/972) and it is in fact, not as easy as implement and use as the previous mode but it allows for per-workspace and per-document settings, which is nice

So this PR migrates to pull mode, additionally this PR includes a refactor to our settings definitions inside the VS Code's extension `package.json` to make sure every settings is there with the proper names. Some settings were removed as they're features we don't support yet anyway. 

We also now respect the user's TS settings inside their editors. Previously we'd either force the default settings or force our own settings. This allow users to control the result of completions and code actions (for instance, if you have `typescript.preferences.quoteStyle` set to `double`, the completion will now always use `"`). 

Some of the default settings are much better than what we forced on, notice how it recommends the aliases paths now, whereas previously it would recommend a relative path:

![image](https://user-images.githubusercontent.com/3019731/165994934-2635d988-8f6d-4387-8fec-fc47fad52be9.png)

## Testing

Tests updated for new config

## Docs

The new settings are documented by their title and a short description
