### PR TITLE
Add support for props completions from `.d.ts` files, improve performance

### DIFF
--- a/.changeset/itchy-eyes-hear.md
+++ b/.changeset/itchy-eyes-hear.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for loading props completions from .d.ts files, improve performance of props completions

--- a/packages/language-server/src/plugins/astro/AstroPlugin.ts
+++ b/packages/language-server/src/plugins/astro/AstroPlugin.ts
@@ -17,7 +17,7 @@ export class AstroPlugin implements Plugin {
 		this.configManager = configManager;
 		this.languageServiceManager = new LanguageServiceManager(docManager, workspaceUris, configManager);
 
-		this.completionProvider = new CompletionsProviderImpl(docManager, this.languageServiceManager);
+		this.completionProvider = new CompletionsProviderImpl(this.languageServiceManager);
 	}
 
 	async getCompletions(

--- a/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
@@ -9,7 +9,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	function setup(filePath: string) {
 		const env = createEnvironment(filePath, 'astro', 'completions');
 		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
-		const provider = new CompletionsProviderImpl(env.docManager, languageServiceManager);
+		const provider = new CompletionsProviderImpl(languageServiceManager);
 
 		return {
 			...env,
@@ -27,7 +27,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 
 		expect(completions.items).to.deep.equal([
 			{
-				commitCharacters: ['-'],
+				commitCharacters: [],
 				detail: 'Component script',
 				insertText: '---\n$0\n---',
 				insertTextFormat: 2,
@@ -46,7 +46,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of Astro components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(7, 20));
+		const completions = await provider.getCompletions(document, Position.create(8, 20));
 
 		expect(completions.items).to.deep.equal([
 			{
@@ -63,7 +63,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of Svelte components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(8, 26));
+		const completions = await provider.getCompletions(document, Position.create(9, 26));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -78,7 +78,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of JSX components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(9, 14));
+		const completions = await provider.getCompletions(document, Position.create(10, 14));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -90,10 +90,25 @@ describe('Astro Plugin#CompletionsProvider', () => {
 		});
 	});
 
+	it('provide prop completions in starting tag of JSX components with .d.ts definitions', async () => {
+		const { provider, document } = setup('component.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(11, 17));
+
+		expect(completions.items).to.deep.contain({
+			label: 'name',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
+			commitCharacters: [],
+			sortText: '_',
+		});
+	});
+
 	it('provide prop completions in starting tag of TSX components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(10, 14));
+		const completions = await provider.getCompletions(document, Position.create(12, 14));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -108,7 +123,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide client directives completions for non-astro components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(8, 26));
+		const completions = await provider.getCompletions(document, Position.create(9, 26));
 
 		expect(completions.items).to.deep.contain({
 			label: 'client:load',
@@ -118,7 +133,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 				value:
 					'Start importing the component JS at page load. Hydrate the component when import completes.\n\n[Astro reference](https://docs.astro.build/en/reference/directives-reference/#clientload)',
 			},
-			textEdit: { range: Range.create(8, 26, 8, 26), newText: 'client:load' },
+			textEdit: { range: Range.create(9, 26, 9, 26), newText: 'client:load' },
 			insertTextFormat: 2,
 			command: undefined,
 		});

--- a/packages/language-server/test/plugins/astro/fixtures/completions/JSXComponentDTS.d.ts
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/JSXComponentDTS.d.ts
@@ -1,0 +1,7 @@
+interface Props {
+	name: string
+}
+
+declare const HelloWorld: (props: Props) => any
+
+export default HelloWorld

--- a/packages/language-server/test/plugins/astro/fixtures/completions/JSXComponentDTS.jsx
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/JSXComponentDTS.jsx
@@ -1,0 +1,3 @@
+export default function HelloWorld({name}) {
+	return <div>{name}</div>
+}

--- a/packages/language-server/test/plugins/astro/fixtures/completions/component.astro
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/component.astro
@@ -2,10 +2,12 @@
 	import ComponentWithProps from "./props.astro"
 	import SvelteComponentWithProps from "./SvelteComponent.svelte"
 	import JSXComponent from "./JSXComponent"
+	import JSXComponentDTS from "./JSXComponentDTS"
 	import TSXComponent from "./TSXComponent"
 ---
 
 <ComponentWithProps ></ComponentWithProps>
 <SvelteComponentWithProps ></SvelteComponentWithProps>
 <JSXComponent ></JSXComponent>
+<JSXComponentDTS ></JSXComponentDTS>
 <TSXComponent ></TSXComponent>

--- a/packages/language-server/test/plugins/astro/fixtures/tsconfig.json
+++ b/packages/language-server/test/plugins/astro/fixtures/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
     "baseUrl": "."
-  }
+  },
 }


### PR DESCRIPTION
## Changes

This PR does a few things to the Astro plugin's completions :sweat_smile:

- Add support for getting props from `.d.ts` files, for transpiled `jsx` components (this was discovered through Ben's stream on FrontendHorse where Prismic didn't get completions)
- Improve performance for getting props completions, I added a cache (like the TS's completions) and additionally removed additional unnecessary TS calls as they're super expensive. In local, this made the completion about 150-200ms(!) faster
- Removed `-` as a commit character for the frontend completions. It's not possible for a commit character to not be included in the completion, which meant that users would end up with one too many dash after using the frontmatter completion
- Misc refactors

![image](https://user-images.githubusercontent.com/3019731/167170961-09d22f47-11fd-456a-8c99-930490231c26.png)

**Note:**
Getting types from complex files is very slow, this is also the case inside `.ts` and `.tsx` files. Prismic especially runs into this a lot, getting props require parsing multiple massive `.d.ts` files. Not much we can do here

## Testing

Tests added and updated

## Docs

No docs needed
