### PR TITLE
Add support for props completions and type checking for Vue components

### DIFF
--- a/.changeset/rare-cameras-wash.md
+++ b/.changeset/rare-cameras-wash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for completions and type checking for Vue props

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -19,6 +19,7 @@
     "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --timeout 20000 --require ts-node/register \"test/**/*.ts\" --exclude \"test/**/*.d.ts\""
   },
   "dependencies": {
+    "@astrojs/vue-language-integration": "^0.1.0",
     "@astrojs/svelte-language-integration": "^0.1.4",
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",

--- a/packages/language-server/src/plugins/typescript/snapshots/utils.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/utils.ts
@@ -5,6 +5,7 @@ import { URI, Utils } from 'vscode-uri';
 import { FrameworkExt, getFrameworkFromFilePath, isAstroFilePath, isFrameworkFilePath } from '../utils';
 import { AstroSnapshot, TypeScriptDocumentSnapshot } from './DocumentSnapshot';
 import { toTSX as svelte2tsx } from '@astrojs/svelte-language-integration';
+import { toTSX as vue2tsx } from '@astrojs/vue-language-integration';
 import { toPascalCase } from '../../../utils';
 
 // Utilities to create Snapshots from different contexts
@@ -76,8 +77,8 @@ export function createFromFrameworkFilePath(filePath: string, framework: Framewo
 
 	if (framework === 'svelte') {
 		code = svelte2tsx(originalText, className);
-	} else {
-		code = `export default function ${className}__AstroComponent_(props: Record<string, any>): any {}`;
+	} else if (framework === 'vue') {
+		code = vue2tsx(originalText, className);
 	}
 
 	return new TypeScriptDocumentSnapshot(0, filePath, code, ts.ScriptKind.TSX);

--- a/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
@@ -46,7 +46,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of Astro components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(8, 20));
+		const completions = await provider.getCompletions(document, Position.create(10, 20));
 
 		expect(completions.items).to.deep.equal([
 			{
@@ -60,10 +60,40 @@ describe('Astro Plugin#CompletionsProvider', () => {
 		]);
 	});
 
+	it('provide prop completions in starting tag of Vue components', async () => {
+		const { provider, document } = setup('component.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(11, 14));
+
+		expect(completions.items).to.deep.contain({
+			label: 'name',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
+			commitCharacters: [],
+			sortText: '_',
+		});
+	});
+
+	it('provide prop completions in starting tag of Vue components with props defined using TypeScript', async () => {
+		const { provider, document } = setup('component.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(12, 16));
+
+		expect(completions.items).to.deep.contain({
+			label: 'name',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
+			commitCharacters: [],
+			sortText: '_',
+		});
+	});
+
 	it('provide prop completions in starting tag of Svelte components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(9, 26));
+		const completions = await provider.getCompletions(document, Position.create(13, 26));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -78,7 +108,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of JSX components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(10, 14));
+		const completions = await provider.getCompletions(document, Position.create(14, 14));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -93,7 +123,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of JSX components with .d.ts definitions', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(11, 17));
+		const completions = await provider.getCompletions(document, Position.create(15, 17));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -108,7 +138,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide prop completions in starting tag of TSX components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(12, 14));
+		const completions = await provider.getCompletions(document, Position.create(16, 14));
 
 		expect(completions.items).to.deep.contain({
 			label: 'name',
@@ -123,7 +153,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 	it('provide client directives completions for non-astro components', async () => {
 		const { provider, document } = setup('component.astro');
 
-		const completions = await provider.getCompletions(document, Position.create(9, 26));
+		const completions = await provider.getCompletions(document, Position.create(13, 26));
 
 		expect(completions.items).to.deep.contain({
 			label: 'client:load',
@@ -133,7 +163,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 				value:
 					'Start importing the component JS at page load. Hydrate the component when import completes.\n\n[Astro reference](https://docs.astro.build/en/reference/directives-reference/#clientload)',
 			},
-			textEdit: { range: Range.create(9, 26, 9, 26), newText: 'client:load' },
+			textEdit: { range: Range.create(13, 26, 13, 26), newText: 'client:load' },
 			insertTextFormat: 2,
 			command: undefined,
 		});

--- a/packages/language-server/test/plugins/astro/fixtures/completions/VueComponent.vue
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/VueComponent.vue
@@ -1,0 +1,5 @@
+<script setup>
+	defineProps({
+		name: { type: String },
+	})
+</script>

--- a/packages/language-server/test/plugins/astro/fixtures/completions/VueComponentTS.vue
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/VueComponentTS.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts">
+	defineProps<{name: string}>()
+</script>

--- a/packages/language-server/test/plugins/astro/fixtures/completions/component.astro
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/component.astro
@@ -1,5 +1,7 @@
 ---
 	import ComponentWithProps from "./props.astro"
+	import VueComponent from "./VueComponent.vue"
+	import VueComponentTS from "./VueComponentTS.vue"
 	import SvelteComponentWithProps from "./SvelteComponent.svelte"
 	import JSXComponent from "./JSXComponent"
 	import JSXComponentDTS from "./JSXComponentDTS"
@@ -7,6 +9,8 @@
 ---
 
 <ComponentWithProps ></ComponentWithProps>
+<VueComponent ></VueComponent>
+<VueComponentTS ></VueComponent>
 <SvelteComponentWithProps ></SvelteComponentWithProps>
 <JSXComponent ></JSXComponent>
 <JSXComponentDTS ></JSXComponentDTS>

--- a/packages/vue-language-integration/package.json
+++ b/packages/vue-language-integration/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@astrojs/vue-language-integration",
+  "version": "0.1.0",
+  "description": "",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "astro-scripts dev \"src/**/*.ts\""
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@vue/compiler-sfc": "^3.2.33",
+    "@vue/runtime-core": "^3.2.33"
+  }
+}

--- a/packages/vue-language-integration/src/index.ts
+++ b/packages/vue-language-integration/src/index.ts
@@ -1,0 +1,49 @@
+import { parse } from '@vue/compiler-sfc';
+
+export const languageId = 'vue';
+export const extension = '.vue';
+
+export function toTSX(code: string, className: string): string {
+	let result = `export default function ${className}__AstroComponent_(): any {}`;
+
+	// NOTE: As you can expect, using regexes for this is not exactly the most reliable way of doing things
+	// However, I couldn't figure out a way to do it using Vue's compiler, I tried looking at how Volar does it, but I
+	// didn't really understand everything happening there and it seemed to be pretty Volar-specific. I do believe
+	// someone more knowledgable on Vue's internals could figure it out, but since this solution is good enough for most
+	// Vue components (and it's an improvement over, well, nothing), it's alright, I think
+	try {
+		const parsedResult = parse(code);
+
+		if (parsedResult.descriptor.scriptSetup) {
+			const definePropsType = parsedResult.descriptor.scriptSetup.content.match(/defineProps<([\s\S]+)>/m);
+
+			if (definePropsType) {
+				result = `
+						${parsedResult.descriptor.scriptSetup.content}
+
+						export default function ${className}__AstroComponent_(_props: ${definePropsType[1]}): any {
+							<div></div>
+						}
+				`;
+			} else {
+				const defineProps = parsedResult.descriptor.scriptSetup.content.match(/defineProps\([\s\S]+\)/m);
+
+				if (defineProps) {
+					result = `
+					import { defineProps } from '@vue/runtime-core';
+
+					const Props = ${defineProps[0]}
+
+					export default function ${className}__AstroComponent_(_props: typeof Props): any {
+						<div></div>
+					}
+				`;
+				}
+			}
+		}
+	} catch (e: any) {
+		return result;
+	}
+
+	return result;
+}

--- a/packages/vue-language-integration/tsconfig.json
+++ b/packages/vue-language-integration/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2020",
+    "module": "CommonJS"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,6 +233,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.16.4":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
+  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
+
 "@babel/parser@^7.16.7", "@babel/parser@^7.17.3":
   version "7.17.3"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz"
@@ -944,6 +949,79 @@
     https-proxy-agent "^5.0.0"
     rimraf "^3.0.2"
     unzipper "^0.10.11"
+
+"@vue/compiler-core@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.33.tgz#e915d59cce85898f5c5cfebe4c09e539278c3d59"
+  integrity sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/shared" "3.2.33"
+    estree-walker "^2.0.2"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz#6db84296f949f18e5d3e7fd5e80f943dbed7d5ec"
+  integrity sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==
+  dependencies:
+    "@vue/compiler-core" "3.2.33"
+    "@vue/shared" "3.2.33"
+
+"@vue/compiler-sfc@^3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz#7ce01dc947a8b76c099811dc6ca58494d4dc773d"
+  integrity sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.33"
+    "@vue/compiler-dom" "3.2.33"
+    "@vue/compiler-ssr" "3.2.33"
+    "@vue/reactivity-transform" "3.2.33"
+    "@vue/shared" "3.2.33"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+    postcss "^8.1.10"
+    source-map "^0.6.1"
+
+"@vue/compiler-ssr@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz#3e820267e4eea48fde9519f006dedca3f5e42e71"
+  integrity sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==
+  dependencies:
+    "@vue/compiler-dom" "3.2.33"
+    "@vue/shared" "3.2.33"
+
+"@vue/reactivity-transform@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz#286063f44ca56150ae9b52f8346a26e5913fa699"
+  integrity sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.33"
+    "@vue/shared" "3.2.33"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+
+"@vue/reactivity@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.33.tgz#c84eedb5225138dbfc2472864c151d3efbb4b673"
+  integrity sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==
+  dependencies:
+    "@vue/shared" "3.2.33"
+
+"@vue/runtime-core@^3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.33.tgz#2df8907c85c37c3419fbd1bdf1a2df097fa40df2"
+  integrity sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==
+  dependencies:
+    "@vue/reactivity" "3.2.33"
+    "@vue/shared" "3.2.33"
+
+"@vue/shared@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.33.tgz#69a8c99ceb37c1b031d5cc4aec2ff1dc77e1161e"
+  integrity sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==
 
 "@web/parse5-utils@^1.3.0":
   version "1.3.0"
@@ -2307,6 +2385,11 @@ estree-util-visit@^1.0.0:
     "@types/estree-jsx" "^0.0.1"
     "@types/unist" "^2.0.0"
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 estree-walker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.1.tgz#c2a9fb4a30232f5039b7c030b37ead691932debd"
@@ -3407,7 +3490,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@^0.25.9:
+magic-string@^0.25.7, magic-string@^0.25.9:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
   integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
@@ -4091,6 +4174,11 @@ nanoid@3.3.1, nanoid@^3.3.1:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
+nanoid@^3.3.3:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
@@ -4426,6 +4514,15 @@ postcss-load-config@^3.1.4:
   dependencies:
     lilconfig "^2.0.5"
     yaml "^1.10.2"
+
+postcss@^8.1.10:
+  version "8.4.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.13.tgz#7c87bc268e79f7f86524235821dfdf9f73e5d575"
+  integrity sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==
+  dependencies:
+    nanoid "^3.3.3"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 postcss@^8.4.12:
   version "8.4.12"
@@ -4981,15 +5078,15 @@ source-map@^0.5.0:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
+source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"


### PR DESCRIPTION
## Changes

This adds support for getting props from Vue files, similar to what we do for Svelte. Unfortunately, there's about 6 ways you can define props inside a Vue 3 component and it's not very possible for us to support all them. So I decided to focus on supporting the ones that are the most used. 

As such, we only support the following inside `script setup` (so Composition API):

Non-TS way:

```vue
<script setup>
  defineProps({
    name: { type: String, required: true },
  })
</script>
```

TS-way:

```vue
<script setup lang="ts">
  defineProps<{name: string}>()
</script>
```

&

```vue
<script setup lang="ts">
  interface Props {
    name: string
  }

  defineProps<Props>()
</script>
```

This fixes https://github.com/withastro/language-tools/issues/169

## Screenshots

![image](https://user-images.githubusercontent.com/3019731/168182587-7a6df1e8-65dd-4142-b342-338e1a8428eb.png)

![image](https://user-images.githubusercontent.com/3019731/168182655-ee57430a-2624-4126-9d35-73f1afe28772.png)

(JSX props errors are already insanely verbose and for Vue components defined without TypeScript, they're even more verbose, we need to figure out a solution for making props errors clearer at some point, but that's outside the scope of this PR)

For components where props are defined with TS, the error is just like JSX's:

![image](https://user-images.githubusercontent.com/3019731/168183965-9c4f3d99-d10c-4b1f-ab3b-133da56c7c71.png)


## Caveats

Regexes. (@FredKSchott suggested this solution to me, so, all credits to him)

I tried to get it to work using the Vue compiler, but unfortunately the documentation isn't amazing and I have no knowledge of Vue's internals. I then tried using Volar's code-gen package public API but it's also undocumented, there's literally 0 usage of it on GitHub as far as I could find and it always returned empty values so.. I don't know. I also didn't want to involve TypeScript in this as we have to make those snapshots very often and parsing with TypeScript would make it things very slow

To be clear however, even though I do not trust regexes, this works, it's just that it's technically possible to encounter edge cases (ex: you have a defineProps inside a comment) and I do not like that. 

However, this is clearly an improvement over the previous solution which was, well, nothing.

## Testing

Added tests for both supported ways of defining props

## Docs

No docs needed
