### PR TITLE
Properly mark optional parameters with a `?`

### DIFF
--- a/.changeset/witty-melons-count.md
+++ b/.changeset/witty-melons-count.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add `?` in the label of completions of optional parameters (including component props)

--- a/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
@@ -205,11 +205,6 @@ export class CompletionsProviderImpl implements CompletionsProvider {
 			completionItems.push(completionItem);
 		});
 
-		// Ensure that props shows up first as a completion, despite this plugin being ran after the HTML one
-		completionItems = completionItems.map((item) => {
-			return { ...item, sortText: '_' };
-		});
-
 		this.lastCompletion = {
 			tag: componentName,
 			documentVersion: componentSnapshot.version,
@@ -290,7 +285,17 @@ export class CompletionsProviderImpl implements CompletionsProvider {
 			insertText: insertText,
 			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
+			// Ensure that props shows up first as a completion, despite this plugin being ran after the HTML one
+			sortText: '\0',
 		};
+
+		if (mem.flags & ts.SymbolFlags.Optional) {
+			item.filterText = item.label;
+			item.label += '?';
+
+			// Put optional props at a lower priority
+			item.sortText = '_';
+		}
 
 		mem.getDocumentationComment(typeChecker);
 		let description = mem

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -342,6 +342,17 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 		if (comp.kindModifiers) {
 			const kindModifiers = new Set(comp.kindModifiers.split(/,|\s+/g));
 
+			if (kindModifiers.has(ScriptElementKindModifier.optionalModifier)) {
+				if (!item.insertText) {
+					item.insertText = item.label;
+				}
+
+				if (!item.filterText) {
+					item.filterText = item.label;
+				}
+				item.label += '?';
+			}
+
 			if (kindModifiers.has(ScriptElementKindModifier.deprecatedModifier)) {
 				item.tags = [CompletionItemTag.Deprecated];
 			}

--- a/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
@@ -55,7 +55,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 				insertText: 'name="$1"',
 				insertTextFormat: InsertTextFormat.Snippet,
 				commitCharacters: [],
-				sortText: '_',
+				sortText: '\u0000',
 			},
 		]);
 	});
@@ -71,7 +71,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 			insertText: 'name={$1}',
 			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
-			sortText: '_',
+			sortText: '\u0000',
 		});
 	});
 
@@ -86,7 +86,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 			insertText: 'name={$1}',
 			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
-			sortText: '_',
+			sortText: '\u0000',
 		});
 	});
 
@@ -101,7 +101,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 			insertText: 'name="$1"',
 			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
-			sortText: '_',
+			sortText: '\u0000',
 		});
 	});
 
@@ -116,7 +116,7 @@ describe('Astro Plugin#CompletionsProvider', () => {
 			insertText: 'name="$1"',
 			insertTextFormat: InsertTextFormat.Snippet,
 			commitCharacters: [],
-			sortText: '_',
+			sortText: '\u0000',
 		});
 	});
 
@@ -136,6 +136,23 @@ describe('Astro Plugin#CompletionsProvider', () => {
 			textEdit: { range: Range.create(9, 26, 9, 26), newText: 'client:load' },
 			insertTextFormat: 2,
 			command: undefined,
+		});
+	});
+
+	it('mark optional props with a ?', async () => {
+		const { provider, document } = setup('optional.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(4, 15));
+		const item = completions.items.find((completion) => completion.filterText === 'name');
+
+		expect(item).to.deep.equal({
+			label: 'name?',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
+			commitCharacters: [],
+			sortText: '_',
+			filterText: 'name',
 		});
 	});
 

--- a/packages/language-server/test/plugins/astro/fixtures/completions/optional.astro
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/optional.astro
@@ -1,0 +1,5 @@
+---
+import OptionalProps from "./optionalProps.astro";
+---
+
+<OptionalProps ></OptionalProps>

--- a/packages/language-server/test/plugins/astro/fixtures/completions/optionalProps.astro
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/optionalProps.astro
@@ -1,0 +1,5 @@
+---
+interface Props {
+	name?: string
+}
+---


### PR DESCRIPTION
## Changes

This makes it so a `?` is added to optional parameters inside completions, like it does inside `.ts` files. Also added this for props, like in JSX files. Optional props are now sorted below required ones

This makes a really nice result for components with many props, such as `astro-eleventy-img`'s `<Image>`

## Screenshots

![image](https://user-images.githubusercontent.com/3019731/168190083-ffa92125-b6ff-45e9-aa3d-4593026bfb0d.png)

![image](https://user-images.githubusercontent.com/3019731/168190135-e17ef503-45dc-4de7-9c7d-c230591786f2.png)


## Testing

Updated tests with new sorting text, added new test for components

## Docs

No docs needed