### PR TITLE
Disable labelDetails for the time being as they're buggy

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -255,9 +255,10 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 		if (detail) {
 			const { detail: itemDetail, documentation: itemDocumentation } = this.getCompletionDocument(detail);
 
-			if (data.originalItem.source) {
-				item.labelDetails = { description: data.originalItem.source };
-			}
+			// TODO: Add support for labelDetails
+			// if (data.originalItem.source) {
+			// 	item.labelDetails = { description: data.originalItem.source };
+			// }
 
 			item.detail = itemDetail;
 			item.documentation = itemDocumentation;
@@ -358,9 +359,10 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			}
 		}
 
-		if (comp.sourceDisplay) {
-			item.labelDetails = { description: ts.displayPartsToString(comp.sourceDisplay) };
-		}
+		// TODO: Add support for labelDetails
+		// if (comp.sourceDisplay) {
+		// 	item.labelDetails = { description: ts.displayPartsToString(comp.sourceDisplay) };
+		// }
 
 		item.commitCharacters = getCommitCharactersForScriptElement(comp.kind);
 		item.sortText = comp.sortText;


### PR DESCRIPTION
## Changes

labelDetails are a new feature of LSP 3.17 that I sneaked in while working on completions a while ago. Since it's just a question of setting a property to a string, I felt that it was harmless and would be a quick nice and easy win

However, it seems like there's some issues, first of all, it seems like when we resolve the completion, we overwrite the label details somehow which leads us to having to set it again, which iI don't believe is intended. Additionally, some completions are missing their label details when building the list, which makes them appear only when we resolve them which isn't desirable

I'll revisit the way we build labels and descriptions in general inside completions in the future as it's not the only part that has inconsistency with TS's and it would be nice to simplify the code

## Testing

No tests changes

## Docs

No docs needed, this wasn't documented anywhere
