### PR TITLE
[WIP] Update LSP to 3.17, readd inlay hints

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -25,13 +25,13 @@
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
     "typescript": "~4.6.4",
-    "vscode-css-languageservice": "^5.1.13",
-    "vscode-html-languageservice": "^4.2.5",
-    "vscode-languageserver": "^8.0.0",
-    "vscode-languageserver-protocol": "^3.17.0",
-    "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.17.0",
-    "vscode-uri": "^3.0.2"
+    "vscode-css-languageservice": "^6.0.1",
+    "vscode-html-languageservice": "^5.0.0",
+    "vscode-languageserver": "^8.0.1",
+    "vscode-languageserver-protocol": "^3.17.1",
+    "vscode-languageserver-textdocument": "^1.0.4",
+    "vscode-languageserver-types": "^3.17.1",
+    "vscode-uri": "^3.0.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -24,13 +24,13 @@
     "@vscode/emmet-helper": "^2.8.4",
     "lodash": "^4.17.21",
     "source-map": "^0.7.3",
-    "typescript": "~4.6.2",
+    "typescript": "~4.6.4",
     "vscode-css-languageservice": "^5.1.13",
     "vscode-html-languageservice": "^4.2.5",
-    "vscode-languageserver": "7.0.0",
-    "vscode-languageserver-protocol": "^3.16.0",
+    "vscode-languageserver": "^8.0.0",
+    "vscode-languageserver-protocol": "^3.17.0",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.16.0",
+    "vscode-languageserver-types": "^3.17.0",
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -3,7 +3,7 @@ import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { LSConfig, LSCSSConfig, LSFormatConfig, LSHTMLConfig, LSTypescriptConfig } from './interfaces';
 import { Connection, FormattingOptions } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { FormatCodeSettings, SemicolonPreference, UserPreferences } from 'typescript';
+import { FormatCodeSettings, InlayHintsOptions, SemicolonPreference, UserPreferences } from 'typescript';
 
 export const defaultLSConfig: LSConfig = {
 	typescript: {
@@ -161,6 +161,25 @@ export class ConfigManager {
 		};
 	}
 
+	async getTSInlayHintsPreferences(document: TextDocument): Promise<InlayHintsOptions> {
+		const config = (await this.getConfig<any>('typescript', document.uri)) ?? {};
+
+		const tsPreferences = this.getTSPreferences(document);
+
+		return {
+			...tsPreferences,
+			includeInlayParameterNameHints: getInlayParameterNameHintsPreference(config),
+			includeInlayParameterNameHintsWhenArgumentMatchesName: !(
+				config.inlayHints?.parameterNames?.suppressWhenArgumentMatchesName ?? true
+			),
+			includeInlayFunctionParameterTypeHints: config.inlayHints?.parameterTypes?.enabled ?? false,
+			includeInlayVariableTypeHints: config.inlayHints?.variableTypes?.enabled ?? false,
+			includeInlayPropertyDeclarationTypeHints: config.inlayHints?.propertyDeclarationTypes?.enabled ?? false,
+			includeInlayFunctionLikeReturnTypeHints: config.inlayHints?.functionLikeReturnTypes?.enabled ?? false,
+			includeInlayEnumMemberValueHints: config.inlayHints?.enumMemberValues?.enabled ?? false,
+		};
+	}
+
 	/**
 	 * Return true if a plugin and an optional feature is enabled
 	 */
@@ -176,10 +195,17 @@ export class ConfigManager {
 
 	/**
 	 * Updating the global config should only be done in cases where the client doesn't support `workspace/configuration`
-	 * or inside of tests
+	 * or inside of tests.
+	 *
+	 * The `outsideAstro` parameter can be set to true to change configurations in the global scope.
+	 * For example, to change TypeScript settings
 	 */
-	updateGlobalConfig(config: DeepPartial<LSConfig>) {
-		this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
+	updateGlobalConfig(config: DeepPartial<LSConfig> | any, outsideAstro?: boolean) {
+		if (outsideAstro) {
+			this.globalConfig = merge({}, this.globalConfig, config);
+		} else {
+			this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
+		}
 	}
 }
 
@@ -217,5 +243,18 @@ function getImportModuleSpecifierEndingPreference(config: any) {
 			return 'js';
 		default:
 			return 'auto';
+	}
+}
+
+function getInlayParameterNameHintsPreference(config: any) {
+	switch (config.inlayHints?.parameterNames?.enabled) {
+		case 'none':
+			return 'none';
+		case 'literals':
+			return 'literals';
+		case 'all':
+			return 'all';
+		default:
+			return undefined;
 	}
 }

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -22,6 +22,7 @@ import {
 	SemanticTokens,
 	CodeActionContext,
 	CodeAction,
+	InlayHint,
 	FormattingOptions,
 	TextEdit,
 } from 'vscode-languageserver';
@@ -230,6 +231,16 @@ export class PluginHost {
 		const document = this.getDocument(textDocument.uri);
 
 		return flatten(await this.execute<ColorInformation[]>('getDocumentColors', [document], ExecuteMode.Collect));
+	}
+
+	async getInlayHints(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		cancellationToken: CancellationToken
+	): Promise<InlayHint[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return flatten(await this.execute<InlayHint[]>('getInlayHints', [document, range], ExecuteMode.FirstNonNull));
 	}
 
 	async getColorPresentations(

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -13,6 +13,7 @@ import {
 	FoldingRange,
 	FormattingOptions,
 	Hover,
+	InlayHint,
 	LinkedEditingRanges,
 	Position,
 	Range,
@@ -103,6 +104,10 @@ export interface UpdateImportsProvider {
 	updateImports(fileRename: FileRename): Resolvable<WorkspaceEdit | null>;
 }
 
+export interface InlayHintsProvider {
+	getInlayHints(document: TextDocument, range: Range): Resolvable<InlayHint[]>;
+}
+
 export interface RenameProvider {
 	rename(document: TextDocument, position: Position, newName: string): Resolvable<WorkspaceEdit | null>;
 	prepareRename(document: TextDocument, position: Position): Resolvable<Range | null>;
@@ -164,6 +169,7 @@ type ProviderBase = DiagnosticsProvider &
 	SelectionRangeProvider &
 	OnWatchFileChangesProvider &
 	LinkedEditingRangesProvider &
+	InlayHintsProvider &
 	UpdateNonAstroFile;
 
 export type LSProvider = ProviderBase;

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -10,6 +10,7 @@ import {
 	FoldingRange,
 	FormattingOptions,
 	Hover,
+	InlayHint,
 	Position,
 	Range,
 	SemanticTokens,
@@ -41,6 +42,7 @@ import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
 import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import { DefinitionsProviderImpl } from './features/DefinitionsProvider';
+import { InlayHintsProviderImpl } from './features/InlayHintsProvider';
 import { FormattingProviderImpl } from './features/FormattingProvider';
 
 export class TypeScriptPlugin implements Plugin {
@@ -56,6 +58,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly signatureHelpProvider: SignatureHelpProviderImpl;
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
+	private readonly inlayHintsProvider: InlayHintsProviderImpl;
 	private readonly semanticTokensProvider: SemanticTokensProviderImpl;
 	private readonly foldingRangesProvider: FoldingRangesProviderImpl;
 	private readonly formattingProvider: FormattingProviderImpl;
@@ -72,6 +75,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
 		this.semanticTokensProvider = new SemanticTokensProviderImpl(this.languageServiceManager);
+		this.inlayHintsProvider = new InlayHintsProviderImpl(this.languageServiceManager, this.configManager);
 		this.foldingRangesProvider = new FoldingRangesProviderImpl(this.languageServiceManager);
 		this.formattingProvider = new FormattingProviderImpl(this.languageServiceManager, this.configManager);
 	}
@@ -183,6 +187,10 @@ export class TypeScriptPlugin implements Plugin {
 		cancellationToken?: CancellationToken
 	): Promise<AppCompletionItem<CompletionItemData>> {
 		return this.completionProvider.resolveCompletion(document, completionItem, cancellationToken);
+	}
+
+	async getInlayHints(document: AstroDocument, range: Range): Promise<InlayHint[]> {
+		return this.inlayHintsProvider.getInlayHints(document, range);
 	}
 
 	async getDefinitions(document: AstroDocument, position: Position): Promise<DefinitionLink[]> {

--- a/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/InlayHintsProvider.ts
@@ -1,0 +1,43 @@
+import { InlayHint } from 'vscode-languageserver';
+import { AstroDocument } from '../../../core/documents';
+import { InlayHintsProvider } from '../../interfaces';
+import { LanguageServiceManager } from '../LanguageServiceManager';
+import { toVirtualAstroFilePath } from '../utils';
+import { InlayHintKind, Range } from 'vscode-languageserver-types';
+import ts from 'typescript';
+import { ConfigManager } from '../../../core/config';
+
+export class InlayHintsProviderImpl implements InlayHintsProvider {
+	constructor(private languageServiceManager: LanguageServiceManager, private configManager: ConfigManager) {}
+
+	async getInlayHints(document: AstroDocument, range: Range): Promise<InlayHint[]> {
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+
+		const filePath = toVirtualAstroFilePath(tsDoc.filePath);
+		const fragment = await tsDoc.createFragment();
+
+		const start = fragment.offsetAt(fragment.getGeneratedPosition(range.start));
+		const end = fragment.offsetAt(fragment.getGeneratedPosition(range.end));
+
+		const tsPreferences = await this.configManager.getTSInlayHintsPreferences(document);
+
+		const inlayHints = lang.provideInlayHints(filePath, { start, length: end - start }, tsPreferences);
+
+		return inlayHints.map((hint) => {
+			const result = InlayHint.create(
+				fragment.getOriginalPosition(fragment.positionAt(hint.position)),
+				hint.text,
+				hint.kind === ts.InlayHintKind.Type
+					? InlayHintKind.Type
+					: hint.kind === ts.InlayHintKind.Parameter
+					? InlayHintKind.Parameter
+					: undefined
+			);
+
+			result.paddingLeft = hint.whitespaceBefore;
+			result.paddingRight = hint.whitespaceAfter;
+
+			return result;
+		});
+	}
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode-languageserver';
 import {
 	CodeActionKind,
 	DidChangeConfigurationNotification,
+	InlayHintRequest,
 	MessageType,
 	SemanticTokensRangeRequest,
 	SemanticTokensRequest,
@@ -135,6 +136,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 					range: true,
 					full: true,
 				},
+				inlayHintProvider: true,
 				signatureHelpProvider: {
 					triggerCharacters: ['(', ',', '<'],
 					retriggerCharacters: [')'],
@@ -232,6 +234,10 @@ export function startLanguageServer(connection: vscode.Connection) {
 	connection.onDocumentColor((params: vscode.DocumentColorParams) => pluginHost.getDocumentColors(params.textDocument));
 	connection.onColorPresentation((params: vscode.ColorPresentationParams) =>
 		pluginHost.getColorPresentations(params.textDocument, params.range, params.color)
+	);
+
+	connection.onRequest(InlayHintRequest.type, (params: vscode.InlayHintParams, cancellationToken) =>
+		pluginHost.getInlayHints(params.textDocument, params.range, cancellationToken)
 	);
 
 	connection.onRequest(TagCloseRequest, (evt: any) => pluginHost.doTagComplete(evt.textDocument, evt.position));

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -83,7 +83,7 @@ describe('HTML Plugin', () => {
 				contents: {
 					kind: 'markdown',
 					value:
-						'A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the method [`Document.getElementsByClassName()`](/en-US/docs/Web/API/Document/getElementsByClassName "returns an array-like object of all child elements which have all of the given class names.").\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class)',
+						'A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](https://developer.mozilla.org/docs/Web/CSS/Class_selectors) or functions like the method [`Document.getElementsByClassName()`](https://developer.mozilla.org/docs/Web/API/Document/getElementsByClassName "returns an array-like object of all child elements which have all of the given class names.").\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/class)',
 				},
 
 				range: Range.create(0, 3, 0, 8),

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -179,6 +179,31 @@ describe('TypeScript Plugin', () => {
 		});
 	});
 
+	describe('provide inlay hints', async () => {
+		it('return inlay hints', async () => {
+			const { plugin, document, configManager } = setup('inlayHints/basic.astro');
+
+			configManager.updateGlobalConfig(
+				{
+					typescript: {
+						inlayHints: {
+							parameterNames: {
+								enabled: 'all',
+							},
+							parameterTypes: {
+								enabled: 'all',
+							},
+						},
+					},
+				},
+				true
+			);
+
+			const inlayHints = await plugin.getInlayHints(document, Range.create(0, 0, 7, 0));
+			expect(inlayHints).to.not.be.empty;
+		});
+	});
+
 	describe('provide folding ranges', async () => {
 		it('return folding ranges', async () => {
 			const { plugin, document } = setup('foldingRanges/frontmatter.astro');

--- a/packages/language-server/test/plugins/typescript/features/InlayHintsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/InlayHintsProvider.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import { Hover, InlayHintKind, Position, Range } from 'vscode-languageserver-types';
+import { InlayHintsProviderImpl } from '../../../../src/plugins/typescript/features/InlayHintsProvider';
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import { createEnvironment } from '../../../utils';
+
+describe('TypeScript Plugin#InlayHintsProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'inlayHints');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new InlayHintsProviderImpl(languageServiceManager, env.configManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('provide inlay hints when enabled', async () => {
+		const { provider, document, configManager } = setup('basic.astro');
+
+		configManager.updateGlobalConfig(
+			{
+				typescript: {
+					inlayHints: {
+						parameterNames: {
+							enabled: 'all',
+						},
+						parameterTypes: {
+							enabled: 'all',
+						},
+					},
+				},
+			},
+			true
+		);
+
+		const inlayHints = await provider.getInlayHints(document, Range.create(0, 0, 7, 0));
+
+		expect(inlayHints).to.deep.equal([
+			{
+				kind: InlayHintKind.Type,
+				label: ': any',
+				paddingLeft: true,
+				paddingRight: undefined,
+				position: Position.create(1, 22),
+			},
+			{
+				kind: InlayHintKind.Parameter,
+				label: 'params:',
+				paddingLeft: undefined,
+				paddingRight: true,
+				position: Position.create(5, 7),
+			},
+		]);
+	});
+
+	it('provide inlay hints inside script tags', async () => {
+		const { provider, document, configManager } = setup('scriptTag.astro');
+
+		configManager.updateGlobalConfig(
+			{
+				typescript: {
+					inlayHints: {
+						parameterNames: {
+							enabled: 'all',
+						},
+						parameterTypes: {
+							enabled: 'all',
+						},
+					},
+				},
+			},
+			true
+		);
+
+		const inlayHints = await provider.getInlayHints(document, Range.create(0, 0, 7, 0));
+
+		expect(inlayHints).to.deep.equal([
+			{
+				kind: InlayHintKind.Type,
+				label: ': any',
+				paddingLeft: true,
+				paddingRight: undefined,
+				position: Position.create(1, 22),
+			},
+			{
+				kind: InlayHintKind.Parameter,
+				label: 'params:',
+				paddingLeft: undefined,
+				paddingRight: true,
+				position: Position.create(5, 7),
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/inlayHints/basic.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/inlayHints/basic.astro
@@ -1,0 +1,7 @@
+---
+	function hello(params) {
+
+	}
+
+	hello({})
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/inlayHints/scriptTag.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/inlayHints/scriptTag.astro
@@ -1,0 +1,7 @@
+<script>
+	function hello(params) {
+
+	}
+
+	hello({})
+</script>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@astrojs/language-server": "0.18.1",
     "@astrojs/ts-plugin": "0.2.1",
-    "vscode-languageclient": "~7.0.0"
+    "vscode-languageclient": "^8.0.0"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -19,7 +19,7 @@
     "test": "node ./test/runTest.js"
   },
   "engines": {
-    "vscode": "^1.56.0"
+    "vscode": "^1.67.0"
   },
   "activationEvents": [
     "onLanguage:astro",
@@ -28,11 +28,11 @@
   "dependencies": {
     "@astrojs/language-server": "0.18.1",
     "@astrojs/ts-plugin": "0.2.1",
-    "vscode-languageclient": "^8.0.0"
+    "vscode-languageclient": "^8.0.1"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
-    "@types/vscode": "^1.56.0",
+    "@types/vscode": "^1.67.0",
     "@vscode/test-electron": "^2.1.3",
     "astro-scripts": "file:../../scripts",
     "glob": "^7.2.0"

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -41,10 +41,9 @@ export async function activate(context: ExtensionContext) {
 	};
 
 	client = createLanguageServer(serverOptions, clientOptions);
-	context.subscriptions.push(client.start());
 
 	client
-		.onReady()
+		.start()
 		.then(() => {
 			const tagRequestor = (document: TextDocument, position: Position) => {
 				const param = client.code2ProtocolConverter.asTextDocumentPositionParams(document, position);
@@ -105,8 +104,7 @@ export async function activate(context: ExtensionContext) {
 		await client.stop();
 
 		client = createLanguageServer(serverOptions, clientOptions);
-		context.subscriptions.push(client.start());
-		await client.onReady();
+		await client.start();
 
 		if (showNotification) {
 			window.showInformationMessage('Astro language server restarted.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4936,7 +4936,7 @@ semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.5:
+semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -5584,7 +5584,7 @@ typescript@*, typescript@~4.6.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
-typescript@^4.6.0:
+typescript@^4.6.0, typescript@~4.6.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
@@ -5860,14 +5860,19 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-languageclient@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-jsonrpc@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0.tgz#43cca5b81d46ddffb8608de9d43faaa8c0eb616b"
+  integrity sha512-gc16lr5REIvxqCLQ9Bwf0fQMCnX5eSFoXeXymSXh80HXUtk7E3TWqT/QduFmWK6PSjruWpwc9X2mmpD1WBcS2g==
+
+vscode-languageclient@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.0.tgz#f2e342b5f0a6bc9d0e8ffadff1e99f7695de08f2"
+  integrity sha512-4/jsbWE2G609rkJ36uZTrXEsoCmZjhTOpIw1La3ILEnHclhtHe4X/nZp8WGrTKvT/jh/sGhJqWzLPnTcoiQO3g==
   dependencies:
     minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.0"
 
 vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   version "3.16.0"
@@ -5876,6 +5881,14 @@ vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   dependencies:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
+
+vscode-languageserver-protocol@3.17.0, vscode-languageserver-protocol@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0.tgz#9fa8d366a57b7f5bca4f0bbe5ff9deeba9a1a03a"
+  integrity sha512-SizljNNWWcgKCoXFL8xvzQptzH599YUVmde7wS/ESxgRRzAiIf6jR7i+CoiLU6G/6ySG351MNSvc8z33ncmLNQ==
+  dependencies:
+    vscode-jsonrpc "8.0.0"
+    vscode-languageserver-types "3.17.0"
 
 vscode-languageserver-textdocument@^1.0.1, vscode-languageserver-textdocument@^1.0.3, vscode-languageserver-textdocument@^1.0.4:
   version "1.0.4"
@@ -5887,12 +5900,24 @@ vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.15.1, vscode-
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
+vscode-languageserver-types@3.17.0, vscode-languageserver-types@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0.tgz#98f27a8855152897c9dde6127cb778ce70c7c239"
+  integrity sha512-ECJg27DKWEfkIUuNyjMydPsl5Lu7XX1xmwEpZ61I4oeK1qFNbfp3tSZUVmeMPPgnNjasd1rrb3on9jbSe5g3nQ==
+
 vscode-languageserver@7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz"
   integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
   dependencies:
     vscode-languageserver-protocol "3.16.0"
+
+vscode-languageserver@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.0.tgz#e8dee1548e2f5a777ded56e3ec890d452e5c1b2b"
+  integrity sha512-qa2ue4cFHJN2nyLCe4P9WG6R7c+KfVox/6q90aJFc5oZb9sE2VjijDwxq0u9oWNScn/7QpESUvGE8OEHTuktXw==
+  dependencies:
+    vscode-languageserver-protocol "3.17.0"
 
 vscode-nls@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,10 +848,10 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/vscode@^1.56.0":
-  version "1.66.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.66.0.tgz#e90e1308ad103f2bd31b72c17b8031b4cec0713d"
-  integrity sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==
+"@types/vscode@^1.67.0":
+  version "1.67.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.67.0.tgz#8eaba41d1591aa02f5d960b7dfae3b16e066f08c"
+  integrity sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==
 
 "@typescript-eslint/eslint-plugin@^4.22.0":
   version "4.33.0"
@@ -5835,6 +5835,16 @@ vscode-css-languageservice@^5.1.13:
     vscode-nls "^5.0.0"
     vscode-uri "^3.0.2"
 
+vscode-css-languageservice@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-6.0.1.tgz#ccf94944e094dcc5833d1b4ac276994b698e9283"
+  integrity sha512-81n/eeYuJwQdvpoy6IK1258PtPbO720fl13FcJ5YQECPyHMFkmld1qKHwPJkyLbLPfboqJPM53ys4xW8v+iBVw==
+  dependencies:
+    vscode-languageserver-textdocument "^1.0.4"
+    vscode-languageserver-types "^3.17.1"
+    vscode-nls "^5.0.1"
+    vscode-uri "^3.0.3"
+
 vscode-html-languageservice@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.2.2.tgz"
@@ -5845,14 +5855,14 @@ vscode-html-languageservice@^4.2.2:
     vscode-nls "^5.0.0"
     vscode-uri "^3.0.3"
 
-vscode-html-languageservice@^4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-4.2.5.tgz#c0cc8ff3d824d16388bbac187e1828749eccf006"
-  integrity sha512-dbr10KHabB9EaK8lI0XZW7SqOsTfrNyT3Nuj0GoPi4LjGKUmMiLtsqzfedIzRTzqY+w0FiLdh0/kQrnQ0tLxrw==
+vscode-html-languageservice@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-5.0.0.tgz#c68613f836d7fcff125183d78e6f1f0ff326fa55"
+  integrity sha512-KJG13z54aLszskp3ETf8b1EKDypr2Sf5RUsfR6OXmKqEl2ZUfyIxsWz4gbJWjPzoJZx/bGH0ZXVwxJ1rg8OKRQ==
   dependencies:
     vscode-languageserver-textdocument "^1.0.4"
-    vscode-languageserver-types "^3.16.0"
-    vscode-nls "^5.0.0"
+    vscode-languageserver-types "^3.17.1"
+    vscode-nls "^5.0.1"
     vscode-uri "^3.0.3"
 
 vscode-jsonrpc@6.0.0:
@@ -5860,19 +5870,19 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-jsonrpc@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0.tgz#43cca5b81d46ddffb8608de9d43faaa8c0eb616b"
-  integrity sha512-gc16lr5REIvxqCLQ9Bwf0fQMCnX5eSFoXeXymSXh80HXUtk7E3TWqT/QduFmWK6PSjruWpwc9X2mmpD1WBcS2g==
+vscode-jsonrpc@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
+  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-languageclient@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.0.tgz#f2e342b5f0a6bc9d0e8ffadff1e99f7695de08f2"
-  integrity sha512-4/jsbWE2G609rkJ36uZTrXEsoCmZjhTOpIw1La3ILEnHclhtHe4X/nZp8WGrTKvT/jh/sGhJqWzLPnTcoiQO3g==
+vscode-languageclient@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz#bf5535c4463a78daeaca0bcb4f5868aec86bb301"
+  integrity sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==
   dependencies:
     minimatch "^3.0.4"
     semver "^7.3.5"
-    vscode-languageserver-protocol "3.17.0"
+    vscode-languageserver-protocol "3.17.1"
 
 vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   version "3.16.0"
@@ -5882,13 +5892,13 @@ vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
 
-vscode-languageserver-protocol@3.17.0, vscode-languageserver-protocol@^3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0.tgz#9fa8d366a57b7f5bca4f0bbe5ff9deeba9a1a03a"
-  integrity sha512-SizljNNWWcgKCoXFL8xvzQptzH599YUVmde7wS/ESxgRRzAiIf6jR7i+CoiLU6G/6ySG351MNSvc8z33ncmLNQ==
+vscode-languageserver-protocol@3.17.1, vscode-languageserver-protocol@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
+  integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
   dependencies:
-    vscode-jsonrpc "8.0.0"
-    vscode-languageserver-types "3.17.0"
+    vscode-jsonrpc "8.0.1"
+    vscode-languageserver-types "3.17.1"
 
 vscode-languageserver-textdocument@^1.0.1, vscode-languageserver-textdocument@^1.0.3, vscode-languageserver-textdocument@^1.0.4:
   version "1.0.4"
@@ -5900,10 +5910,10 @@ vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.15.1, vscode-
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver-types@3.17.0, vscode-languageserver-types@^3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0.tgz#98f27a8855152897c9dde6127cb778ce70c7c239"
-  integrity sha512-ECJg27DKWEfkIUuNyjMydPsl5Lu7XX1xmwEpZ61I4oeK1qFNbfp3tSZUVmeMPPgnNjasd1rrb3on9jbSe5g3nQ==
+vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
 vscode-languageserver@7.0.0:
   version "7.0.0"
@@ -5912,17 +5922,22 @@ vscode-languageserver@7.0.0:
   dependencies:
     vscode-languageserver-protocol "3.16.0"
 
-vscode-languageserver@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.0.tgz#e8dee1548e2f5a777ded56e3ec890d452e5c1b2b"
-  integrity sha512-qa2ue4cFHJN2nyLCe4P9WG6R7c+KfVox/6q90aJFc5oZb9sE2VjijDwxq0u9oWNScn/7QpESUvGE8OEHTuktXw==
+vscode-languageserver@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz#56bd7a01f5c88af075a77f1d220edcb30fc4bdc7"
+  integrity sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==
   dependencies:
-    vscode-languageserver-protocol "3.17.0"
+    vscode-languageserver-protocol "3.17.1"
 
 vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+
+vscode-nls@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.1.tgz#ba23fc4d4420d25e7f886c8e83cbdcec47aa48b2"
+  integrity sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A==
 
 vscode-oniguruma@^1.6.1:
   version "1.6.2"


### PR DESCRIPTION
## Changes

This migrates us to LSP 3.17 with all the related packages also updated to their latest 3.17-compatible versions

## Testing

No tests needed

## Docs

No docs needed
