### PR TITLE
[WIP] Add command to open dev server in a side panel

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "@astrojs/language-server": "0.19.0",
     "@astrojs/ts-plugin": "0.2.1",
+    "@proload/core": "^0.3.2",
+    "@proload/plugin-typescript": "^0.2.1",
     "vscode-languageclient": "^8.0.1",
     "vscode-tmgrammar-test": "^0.1.1"
   },
@@ -64,6 +66,11 @@
       {
         "command": "astro.restartLanguageServer",
         "title": "Astro: Restart Language Server"
+      },
+      {
+        "command": "astro.openDevServerPanel",
+        "title": "Astro: Open dev server",
+        "enablement": "workbenchState == folder || workbenchState == workspace"
       }
     ],
     "configuration": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -229,6 +229,12 @@
           "type": "boolean",
           "default": true,
           "title": "Formatting: Add a line return between the frontmatter and the template"
+        },
+        "astro.devServer.port": {
+          "type": "integer",
+          "default": 3000,
+          "title": "Dev Server: Port to check for a local server in cases where it cannot be inferred from the project",
+          "markdownDescription": "**Caution**: This should only be used in cases where you're setting the dev server port manually using a launch parameter! To change the port used by Astro when starting the dev server, please use the according setting inside your Astro's project config file (`astro.config.mjs`)\n\n[Astro reference](https://docs.astro.build/en/reference/configuration-reference/#serverport)"
         }
       }
     },

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -7,9 +7,6 @@ import {
 	Position,
 	TextDocumentChangeEvent,
 	ViewColumn,
-	RelativePattern,
-	WorkspaceFolder,
-	Uri,
 } from 'vscode';
 import {
 	LanguageClient,
@@ -136,16 +133,18 @@ export async function activate(context: ExtensionContext) {
 			 * Return a currently running dev server's URL
 			 */
 			async function getDevServerUrl() {
+				const configuredPort = workspace.getConfiguration('astro.devServer').get<number>('port') ?? 3000;
+
 				if (window.activeTextEditor) {
 					const workspaceFolder = workspace.getWorkspaceFolder(window.activeTextEditor?.document.uri);
 
 					if (workspaceFolder) {
-						return await getCurrentServer(workspaceFolder);
+						return await getCurrentServer(workspaceFolder, configuredPort);
 					}
 				} else if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
-					return await getCurrentServer(workspace.workspaceFolders[0]);
+					return await getCurrentServer(workspace.workspaceFolders[0], configuredPort);
 				} else {
-					return await getCurrentServer();
+					return await getCurrentServer(undefined, configuredPort);
 				}
 			}
 		})

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -1,0 +1,62 @@
+import * as http from 'http';
+import { WorkspaceFolder } from 'vscode';
+import load from '@proload/core';
+
+export async function getCurrentServer(workspaceDir?: WorkspaceFolder | undefined): Promise<string | undefined> {
+	if (workspaceDir) {
+		let astroConfig;
+
+		try {
+			astroConfig = await load('astro', { cwd: workspaceDir.uri.fsPath });
+		} catch (e) {
+			console.error("Couldn't load Astro config: ", e);
+		}
+
+		const initialPort = astroConfig?.value.server?.port ?? 3000;
+		const port = await getLocalhostPort(initialPort);
+
+		if (port) {
+			return `http://localhost:${port}/`;
+		}
+	} else {
+		// If we don't have a workspace, we can't know which port the user has chosen to run the dev server on
+		// As such, we'll instead try to find starting from Astro's default port. This should work just fine in most cases
+		const port = await getLocalhostPort(3000);
+
+		if (port) {
+			return `http://localhost:${port}/`;
+		}
+	}
+
+	return undefined;
+}
+
+export async function isLocalhostUsingPort(port: number) {
+	return new Promise<boolean>((resolve) => {
+		http
+			.get(
+				`http://localhost:${port}/`,
+				{
+					headers: {
+						accept: '*/*',
+					},
+				},
+				(res) => {
+					resolve(res.statusCode === 200);
+				}
+			)
+			.on('error', () => resolve(false))
+			.end();
+	});
+}
+
+async function getLocalhostPort(port: number) {
+	if (await isLocalhostUsingPort(port)) {
+		return port;
+	}
+	port++;
+}
+
+export async function sleep(ms: number) {
+	return new Promise((r) => setTimeout(r, ms));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -619,12 +619,28 @@
     deepmerge "^4.2.2"
     escalade "^3.1.1"
 
+"@proload/core@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@proload/core/-/core-0.3.2.tgz#de36f335bf87dd6aa8ba25aa92c498821db3a229"
+  integrity sha512-4ga4HpS0ieVYWVMS+F62W++6SNACBu0lkw8snw3tEdH6AeqZu8i8262n3I81jWAWXVcg3sMfhb+kBexrfGrTUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    escalade "^3.1.1"
+
 "@proload/plugin-tsm@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@proload/plugin-tsm/-/plugin-tsm-0.1.1.tgz#096cefbf9a4fab42d129db36b194c64ac0ad20ec"
   integrity sha512-qfGegg6I3YBCZDjYR9xb41MTc2EfL0sQQmw49Z/yi9OstIpUa/67MBy4AuNhoyG9FuOXia9gPoeBk5pGnBOGtA==
   dependencies:
     tsm "^2.1.4"
+
+"@proload/plugin-typescript@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@proload/plugin-typescript/-/plugin-typescript-0.2.1.tgz#83cdb85acc1a297804e99843fbe577a5e81ecfb4"
+  integrity sha512-pvlYjq1pg6XRCR8rEsSGBRe7ZfuUZWCyXeEZvoCgROBRtglw5IYOWJ29ib65jhK2LZLtVFBv4x430VJR0bdl3g==
+  dependencies:
+    "@swc-node/register" "^1.3.7"
+    typescript "^4.1.3"
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
@@ -653,6 +669,116 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
+"@swc-node/core@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@swc-node/core/-/core-1.9.0.tgz#f5208d575c1aed5a2cab7e4c04e46aca34d8c240"
+  integrity sha512-vRnvsMtL9OxybA/Wun1ZhlDvB6MNs4Zujnina0VKdGk+yI6s87KUhdTcbAY6dQMZhQTLFiC1Lnv/BuwCKcCEug==
+  dependencies:
+    "@swc/core" "^1.2.172"
+
+"@swc-node/register@^1.3.7":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@swc-node/register/-/register-1.5.1.tgz#8927783c1a53207ded076d8700270f7941aa0305"
+  integrity sha512-6IL5s4QShKGs08qAeNou3rDA3gbp2WHk6fo0XnJXQn/aC9k6FnVBbj/thGOIEDtgNhC/DKpZT8tCY1LpQnOZFg==
+  dependencies:
+    "@swc-node/core" "^1.9.0"
+    "@swc-node/sourcemap-support" "^0.2.0"
+    colorette "^2.0.16"
+    debug "^4.3.4"
+    pirates "^4.0.5"
+    tslib "^2.4.0"
+
+"@swc-node/sourcemap-support@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@swc-node/sourcemap-support/-/sourcemap-support-0.2.0.tgz#e9079f739921fbe5c49d85791703fcb1540c356b"
+  integrity sha512-FNrxdI6XMYfoNt81L8eFKEm1d8P82I1nPwS3MrnBGzZoMWB+seQhQK+iN6M5RreJxXbfZw5lF86LRjHEQeGMqg==
+  dependencies:
+    source-map-support "^0.5.21"
+
+"@swc/core-android-arm-eabi@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.192.tgz#528164a4f88f111980ad1707fbd5de70e25aba51"
+  integrity sha512-OYbmJGB9Jp2zZ/GXALTdyWSwfjfC3g/NiZLBEG/4btVA9xU4hy4kA3tiWP1pmqF29VM1a7IHtzxwMXEBwXYX9w==
+
+"@swc/core-android-arm64@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.2.192.tgz#32d96c8e24c9122652e052c55932cd0dec02ca9c"
+  integrity sha512-0/0KuxrCK+I5VB8lg/KHijR3bSeM3f+s5KlNR0uE/2Hf30gnjkBfWlokeFj2e5RhjQlCmLIAXmVDVvXU6uoh4w==
+
+"@swc/core-darwin-arm64@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.192.tgz#0965ec4e85b9c95ac7bc73da970df15e2065394e"
+  integrity sha512-dhgeWV9qgsTJKURYqMWjZRZVX41FPkOdrHXPJqm1coayphCgfYvIffmZYh0bfPHBfzHLZ/eyvhNXdgXlIJtNqQ==
+
+"@swc/core-darwin-x64@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.2.192.tgz#82f322a0916901dad094793a129d43a8f7e3790a"
+  integrity sha512-oSXeKRpwlct/PA4GmNZ1dzWUFBBv24eCt303IHOjJMyVOul+8E0Oa7sBxSwra7mvPljKEM6g06EIW+i6NzCvJQ==
+
+"@swc/core-freebsd-x64@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.192.tgz#67e535bedb9352681d2a548d0efc071e03f4d651"
+  integrity sha512-DDEUlXpyNhcslbis2viAUdZjDd9FGSKYszZCeqi/8aHZjiJYjj5EPCUJw3h0mtK0eXLFjeOaD2qfjkuZlRauig==
+
+"@swc/core-linux-arm-gnueabihf@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.192.tgz#91811a3e400a65e57bb99069eddda3c6e5af439e"
+  integrity sha512-KcwljdxT2ZBe3zy1H+1BBWk9cR6AyL9qi8/h6X78nFwiJoktk25AMLAhUSusn9VghStveWZepnaYU9kWG62x0Q==
+
+"@swc/core-linux-arm64-gnu@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.192.tgz#850bc9fbdbe08a7c1e847f20bf0d45bedc99ccf4"
+  integrity sha512-0VVFoSWNvDOIN05QsONpSbfa+NzevICc+eFsxdjqD1qRGMWLGtzTRXfdfJWvQ3qp2uSJThpU51FyIrtN59fRPQ==
+
+"@swc/core-linux-arm64-musl@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.192.tgz#91671a454c767928108277c6012f7bf851f92b8a"
+  integrity sha512-7pK5SaiB+NHHMNU/aQQzhfi1JqAxCKh0MSiSFmWtojGUAP0WYWEXGxXuw7y5zkxb4uA7EAFII0WOmmfvgM4Vvw==
+
+"@swc/core-linux-x64-gnu@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.192.tgz#48f9fb73044dd99948ae05baa5d77e71b3af3e42"
+  integrity sha512-pwt2yYy8Ox1PqXNu4egYoDLi92gF+fIo3vzfyuPZo82ie/zG+7hBb/FJeoLcchih9vq+qnTEtrC8aWNjxkQOcw==
+
+"@swc/core-linux-x64-musl@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.192.tgz#2cf24fa2c9733369d9d85731aa33f81d55f37873"
+  integrity sha512-IXCsH7xdXLASIuHJXCSavHYU2X2O5+dmtG14bKsI2i3PTqdSFaRn7WTO7C2PlLeGFxC36V967BW0tCipE+OL0A==
+
+"@swc/core-win32-arm64-msvc@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.192.tgz#9f70fe568ac7ce3b5f96e27c93fddd3a041d1b3d"
+  integrity sha512-TSPsjvlfCz5DmTc4KZvp6KkH9xi+Ir1Y8hlISzqARl3hqI9Lv7HAoXvjkO9yMfkRAEpzwPQmeH2ZUtl0oOzeYA==
+
+"@swc/core-win32-ia32-msvc@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.192.tgz#6612357fec531bdeeef7076a66a172b1cdb0442e"
+  integrity sha512-yIH68QAY/x3ekCnIwHD4f4mXiUD3KIPdDtSmrMIbwV6NgdvcadY6BT861/NfXzCiG0+o1Jkf5790BEhiWnA4GQ==
+
+"@swc/core-win32-x64-msvc@1.2.192":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.192.tgz#cc049ba896e77d3337b1772b71702e42003345a3"
+  integrity sha512-x+blRKKYgI92vHJ7twIOKcvWifAyj5AeH0G6tCbUL2qXl2TjW1gDIyYagowH/9uiIueFLPwIc/X/1BP6HxpPLg==
+
+"@swc/core@^1.2.172":
+  version "1.2.192"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.2.192.tgz#03d24cb06a4142d91e5383e53303b5dc714936c7"
+  integrity sha512-qQPt1KLeuopZ6J50MTyXkaxkMpaXbG8IHKqMhPwhGD6oarOkVjpILgMfD5esWr9v8gb9yDyOrRrfbDSWdGxDNw==
+  optionalDependencies:
+    "@swc/core-android-arm-eabi" "1.2.192"
+    "@swc/core-android-arm64" "1.2.192"
+    "@swc/core-darwin-arm64" "1.2.192"
+    "@swc/core-darwin-x64" "1.2.192"
+    "@swc/core-freebsd-x64" "1.2.192"
+    "@swc/core-linux-arm-gnueabihf" "1.2.192"
+    "@swc/core-linux-arm64-gnu" "1.2.192"
+    "@swc/core-linux-arm64-musl" "1.2.192"
+    "@swc/core-linux-x64-gnu" "1.2.192"
+    "@swc/core-linux-x64-musl" "1.2.192"
+    "@swc/core-win32-arm64-msvc" "1.2.192"
+    "@swc/core-win32-ia32-msvc" "1.2.192"
+    "@swc/core-win32-x64-msvc" "1.2.192"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1384,6 +1510,11 @@ browserslist@^4.17.5:
     node-releases "^2.0.2"
     picocolors "^1.0.0"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 buffer-indexof-polyfill@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz"
@@ -1622,6 +1753,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^2.0.16:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
+  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
 comma-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -4517,6 +4653,11 @@ pify@^4.0.1:
   resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pirates@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
+  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz"
@@ -5090,12 +5231,20 @@ source-map-js@^1.0.2:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -5455,6 +5604,11 @@ tslib@^2.0.1, tslib@^2.0.3:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tsm@^2.1.4, tsm@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/tsm/-/tsm-2.2.1.tgz"
@@ -5601,7 +5755,7 @@ typescript@*, typescript@~4.6.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
-typescript@^4.6.0, typescript@~4.6.4:
+typescript@^4.1.3, typescript@^4.6.0, typescript@~4.6.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==


### PR DESCRIPTION
## Changes

This adds a command to open the currently running dev server / a new one if there's none in a side panel in the editor. This is powered by VS Code's simple-browser (HMR is supported, clicking between the pages work etc). It loads the user's config using Proload to get the user's specified port if there's any

Some users were actually already doing this by using VS Code's Simple Browser command, however they had to start the dev server separately and type in the address manually

![image](https://user-images.githubusercontent.com/3019731/170094095-1011947f-ae4e-4d84-a1cc-8cb72bea29a9.png)

## Testing

Tested manually on Windows and Linux 

Our test setup for VS Code is currently not setup in a way that allows this to be tested as it doesn't load a project. Additionally, in a lot of way it would feel like testing things outside our world (is Proload loading the config? Does VS Code's browser work?)

## Docs

No docs needed (added commands are documented in the "Feature contributions" tab on the extension page inside VS Code automatically)