### PR TITLE
Add support for Linked Editing

### DIFF
--- a/.changeset/tiny-radios-train.md
+++ b/.changeset/tiny-radios-train.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Add support for giving linked editing ranges

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -25,6 +25,7 @@ import {
 	InlayHint,
 	FormattingOptions,
 	TextEdit,
+	LinkedEditingRanges,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { flatten } from 'lodash';
@@ -196,6 +197,19 @@ export class PluginHost {
 		return await this.execute<SemanticTokens>(
 			'getSemanticTokens',
 			[document, range, cancellationToken],
+			ExecuteMode.FirstNonNull
+		);
+	}
+
+	async getLinkedEditingRanges(
+		textDocument: TextDocumentIdentifier,
+		position: Position
+	): Promise<LinkedEditingRanges | null> {
+		const document = this.getDocument(textDocument.uri);
+
+		return await this.execute<LinkedEditingRanges>(
+			'getLinkedEditingRanges',
+			[document, position],
 			ExecuteMode.FirstNonNull
 		);
 	}

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -9,6 +9,7 @@ import {
 	Range,
 	SymbolInformation,
 	FormattingOptions,
+	LinkedEditingRanges,
 } from 'vscode-languageserver';
 import { doComplete as getEmmetCompletions } from '@vscode/emmet-helper';
 import { getLanguageService, HTMLFormatConfiguration } from 'vscode-html-languageservice';
@@ -149,6 +150,22 @@ export class HTMLPlugin implements Plugin {
 		}
 
 		return this.lang.getFoldingRanges(document);
+	}
+
+	getLinkedEditingRanges(document: AstroDocument, position: Position): LinkedEditingRanges | null {
+		const html = document.html;
+
+		if (!html) {
+			return null;
+		}
+
+		const ranges = this.lang.findLinkedEditingRanges(document, position, html);
+
+		if (!ranges) {
+			return null;
+		}
+
+		return { ranges };
 	}
 
 	async doTagComplete(document: AstroDocument, position: Position): Promise<string | null> {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -3,6 +3,7 @@ import {
 	CodeActionKind,
 	DidChangeConfigurationNotification,
 	InlayHintRequest,
+	LinkedEditingRangeRequest,
 	MessageType,
 	SemanticTokensRangeRequest,
 	SemanticTokensRequest,
@@ -131,6 +132,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 				colorProvider: true,
 				hoverProvider: true,
 				documentSymbolProvider: true,
+				linkedEditingRangeProvider: true,
 				semanticTokensProvider: {
 					legend: getSemanticTokenLegend(),
 					range: true,
@@ -225,6 +227,11 @@ export function startLanguageServer(connection: vscode.Connection) {
 	);
 	connection.onRequest(SemanticTokensRangeRequest.type, (evt, cancellationToken) =>
 		pluginHost.getSemanticTokens(evt.textDocument, evt.range, cancellationToken)
+	);
+
+	connection.onRequest(
+		LinkedEditingRangeRequest.type,
+		async (evt) => await pluginHost.getLinkedEditingRanges(evt.textDocument, evt.position)
 	);
 
 	connection.onDocumentFormatting((params: vscode.DocumentFormattingParams) =>

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -129,6 +129,26 @@ describe('HTML Plugin', () => {
 		});
 	});
 
+	describe('provides linked editing ranges', () => {
+		it('for html', () => {
+			const { plugin, document } = setup(`<div></div>
+			`);
+
+			const linkedEditingRanges = plugin.getLinkedEditingRanges(document, Position.create(0, 2));
+
+			expect(linkedEditingRanges.ranges).to.deep.equal([
+				{
+					start: Position.create(0, 1),
+					end: Position.create(0, 4),
+				},
+				{
+					start: Position.create(0, 7),
+					end: Position.create(0, 10),
+				},
+			]);
+		});
+	});
+
 	describe('provides formatting', () => {
 		it('return formatting', async () => {
 			const { plugin, document } = setup('<div><p>Astro</p></div>');


### PR DESCRIPTION
## Changes

Simple PR adding support for linked editing inside HTML, it's powered by our usual HTML service and as such, matches VS Code's behavior inside HTML files, down to its downfalls (ex: if you type too fast before the linked range appear, it doesn't work)

This feature is unfortunately disabled by default inside VS Code, not sure why. It's also not very pretty, but it's really useful when you have it enabled!

## Testing

Added a test

## Docs

No docs needed
