### PR TITLE
Add support for Svelte components documentation

### DIFF
--- a/.changeset/wet-lizards-knock.md
+++ b/.changeset/wet-lizards-knock.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/svelte-language-integration': patch
+---
+
+Add support for showing Svelte components documentation on hover

--- a/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
@@ -59,4 +59,16 @@ describe('TypeScript Plugin#HoverProvider', () => {
 			range: Range.create(1, 7, 1, 17),
 		});
 	});
+
+	it('provides hover info with documentation for Svelte components', async () => {
+		const { provider, document } = setup('svelteComment.astro');
+
+		const hoverInfo = await provider.doHover(document, Position.create(4, 3));
+
+		expect(hoverInfo).to.deep.equal(<Hover>{
+			contents:
+				'```typescript\n(alias) function Sveltecomment(_props: typeof Props): any\nimport Sveltecomment\n```\n---\nMy super Svelte component!',
+			range: Range.create(4, 1, 4, 14),
+		});
+	});
 });

--- a/packages/language-server/test/plugins/typescript/fixtures/hoverInfo/svelteComment.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/hoverInfo/svelteComment.astro
@@ -1,0 +1,5 @@
+---
+	import Sveltecomment from "./svelteComment.svelte";
+---
+
+<Sveltecomment></Sveltecomment>

--- a/packages/language-server/test/plugins/typescript/fixtures/hoverInfo/svelteComment.svelte
+++ b/packages/language-server/test/plugins/typescript/fixtures/hoverInfo/svelteComment.svelte
@@ -1,0 +1,7 @@
+<!--
+	@component
+
+	My super Svelte component!
+-->
+
+<div>Hello from Svelte!</div>

--- a/packages/svelte-language-integration/src/index.ts
+++ b/packages/svelte-language-integration/src/index.ts
@@ -7,17 +7,14 @@ export function toTSX(code: string, className: string): string {
 	let result = 'export default function ${className}__AstroComponent_(): any {}';
 
 	try {
-		result = `${svelte2tsx(code).code}
+		let tsx = svelte2tsx(code).code;
+		tsx = 'let Props = render().props;\n' + tsx;
 
-		let Props = render().props;
-
-		export default function ${className}__AstroComponent_(_props: typeof Props): any {
-			<div></div>
-		}
-	`;
-
-		// Remove default class export from Svelte2TSX since we don't use it and instead add our own
-		result = result.replace('export default class', 'class');
+		// Replace Svelte's class export with a function export
+		result = tsx.replace(
+			/^export default[\S\s]*/gm,
+			`export default function ${className}__AstroComponent_(_props: typeof Props): any {}`
+		);
 	} catch (e: any) {
 		return result;
 	}


### PR DESCRIPTION
## Changes

Svelte components can be documented using an HTML comment inside the template with a `@component` directive. However, due to how we form our TSX output, the resulting JSDoc comment from svelte2tsx would end up in the wrong place and it wouldn't show when users hovered Svelte components. This PR fix this

![image](https://user-images.githubusercontent.com/3019731/170123679-b6fc00fc-bba5-4b32-9ca8-9a2df93b6bd6.png)

## Testing

Added a test

## Docs

No docs needed
