### PR TITLE
Add support for highlighting expressions inside Markdown files

### DIFF
--- a/packages/vscode/syntaxes/markdown.astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/markdown.astro.tmLanguage.json
@@ -5,9 +5,37 @@
   "patterns": [
     {
       "include": "#fenced_code_block_astro"
+    },
+    {
+      "include": "#astro:expressions"
     }
   ],
   "repository": {
+    "astro:expressions": {
+      "patterns": [
+        {
+          "begin": "\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.ts"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.ts"
+            }
+          },
+          "name": "expression.embedded.astro",
+          "contentName": "source.ts",
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        }
+      ]
+    },
     "fenced_code_block_astro": {
       "name": "markup.fenced_code.block.markdown",
       "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:astro(\\s+[^`~]*)?$)",


### PR DESCRIPTION
## Changes

Adds support for highlighting {} blocks inside Markdown files

## Caveeats

Without a custom file format, it's impossible for this to not have side-effect, as in, if you have the extension installed, even in non-Astro projects, you'll get {} highlighted. There's no way to fix this as grammars don't respect `activationEvents`

## Testing

We can't really test this since it's an injection into another grammar

## Docs

No docs needed
