### PR TITLE
fix: handle the case when server settings are not provided, again

### DIFF
--- a/.changeset/blue-dodos-approve.md
+++ b/.changeset/blue-dodos-approve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixed more bugs where nonexistent server settings would result in a crash

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -188,9 +188,16 @@ export class ConfigManager {
 		plugin: keyof LSConfig,
 		feature?: keyof LSTypescriptConfig | keyof LSCSSConfig | keyof LSHTMLConfig
 	): Promise<boolean> {
-		const config = await this.getConfig<any>('astro', document.uri);
+		const config = (await this.getConfig<any>('astro', document.uri)) ?? {};
 
-		return feature ? config[plugin].enabled && config[plugin][feature].enabled : config[plugin].enabled;
+		if (config[plugin]) {
+			let res = config[plugin].enabled;
+			if (feature && config[plugin][feature]) {
+				res = res && config[plugin][feature].enabled;
+			}
+			return res;
+		}
+		return false;
 	}
 
 	/**

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -92,8 +92,8 @@ export class HTMLPlugin implements Plugin {
 		};
 
 		const emmetConfig = await this.configManager.getEmmetConfig(document);
-		const extensionConfig = await this.configManager.getConfig<LSConfig>('astro', document.uri);
-		if (extensionConfig.html.completions.emmet) {
+		const extensionConfig = (await this.configManager.getConfig<LSConfig>('astro', document.uri)) ?? {};
+		if (extensionConfig?.html?.completions?.emmet) {
 			this.lang.setCompletionParticipants([
 				{
 					onHtmlContent: () =>


### PR DESCRIPTION
## Changes

If no configuration was provided to the server, it would fail to start with errors such as the following:
```
TypeError: Cannot read properties of undefined (reading 'enabled')
    at ConfigManager.isEnabled (/home/hexular/prog/repos/language-tools/packages/language-server/dist/core/config/ConfigManager.js:181:97)
    at runNextTicks (node:internal/process/task_queues:61:5)
    at listOnTimeout (node:internal/timers:528:9)
    at processTimers (node:internal/timers:502:7)
    at async TypeScriptPlugin.featureEnabled (/home/hexular/prog/repos/language-tools/packages/language-server/dist/plugins/typescript/TypeScriptPlugin.js:159:12)
    at async TypeScriptPlugin.getDiagnostics (/home/hexular/prog/repos/language-tools/packages/language-server/dist/plugins/typescript/TypeScriptPlugin.js:130:10)
    at async PluginHost.tryExecutePlugin (/home/hexular/prog/repos/language-tools/packages/language-server/dist/plugins/PluginHost.js:193:14)
    at async Promise.all (index 0)
```

This change fixes the few remaining `getConfig` calls that don't check for the case where no configuration is provided.

This is a very similar fix to #262.

## Testing

Is there a way to test this?

## Docs

Bug fix only.
