### PR TITLE
Add support for TypeScript inside hoisted script tags

### DIFF
--- a/.changeset/beige-glasses-complain.md
+++ b/.changeset/beige-glasses-complain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Enable support for TypeScript inside hoisted script tags

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -20,7 +20,6 @@ export enum DiagnosticCodes {
 	SPREAD_EXPECTED = 1005, // '{0}' expected.
 	DUPLICATED_JSX_ATTRIBUTES = 17001, // JSX elements cannot have multiple attributes with the same name.
 	MUST_HAVE_PARENT_ELEMENT = 2657, // JSX expressions must have one parent element.
-	CANNOT_IMPORT_TS_EXT = 2691, // An import path cannot end with a '{0}' extension. Consider importing '{1}' instead.
 	CANT_RETURN_OUTSIDE_FUNC = 1108, // A 'return' statement can only be used within a function body.
 	ISOLATED_MODULE_COMPILE_ERR = 1208, // '{0}' cannot be compiled under '--isolatedModules' because it is considered a global script file.
 	TYPE_NOT_ASSIGNABLE = 2322, // Type '{0}' is not assignable to type '{1}'.
@@ -68,7 +67,6 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
 					code: diagnostic.code,
 					tags: getDiagnosticTag(diagnostic),
 				}))
-				.filter(isNoCantEndWithTS)
 				.map(mapRange(scriptTagSnapshot, document));
 
 			scriptDiagnostics.push(...scriptDiagnostic);
@@ -232,11 +230,6 @@ function isNoSpreadExpected(diagnostic: Diagnostic, document: AstroDocument) {
 	return true;
 }
 
-/** Inside script tags, Astro currently require the `.ts` file extension for imports */
-function isNoCantEndWithTS(diagnostic: Diagnostic) {
-	return diagnostic.code !== DiagnosticCodes.CANNOT_IMPORT_TS_EXT;
-}
-
 /**
  * Ignore "Can't return outside of function body"
  * Since the frontmatter is at the top level, users trying to return a Response  for SSR mode run into this
@@ -286,15 +279,6 @@ function enhanceIfNecessary(diagnostic: Diagnostic): Diagnostic {
 				message: 'Client directives are only available on framework components',
 			};
 		}
-	}
-
-	// An import path cannot end with '.ts(x)' consider importing with no extension
-	// TODO: Remove this when https://github.com/withastro/astro/issues/3415 is fixed
-	if (diagnostic.code === DiagnosticCodes.CANNOT_IMPORT_TS_EXT) {
-		return {
-			...diagnostic,
-			message: diagnostic.message.replace(/\.jsx?/, ''),
-		};
 	}
 
 	return diagnostic;

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -249,7 +249,7 @@ describe('TypeScript Plugin#CodeActionsProvider', () => {
 								edits: [
 									{
 										newText: '// @ts-nocheck\n',
-										range: Range.create(0, 8, 0, 8),
+										range: Range.create(0, 18, 0, 18),
 									},
 								],
 								textDocument: {

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -83,6 +83,22 @@ describe('TypeScript Plugin#DiagnosticsProvider', () => {
 		expect(diagnostics).to.not.be.empty;
 	});
 
+	it('properly support TypeScript script tags', async () => {
+		const { provider, document } = setup('scriptTagTypeScript.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.deep.equal([
+			{
+				code: 8010,
+				message: 'Type annotations can only be used in TypeScript files.',
+				range: Range.create(6, 14, 6, 20),
+				severity: DiagnosticSeverity.Error,
+				source: 'ts',
+				tags: [],
+			},
+		]);
+	});
+
 	it('provide diagnostics for invalid framework components', async () => {
 		const { provider, document } = setup('frameworkComponentError.astro');
 

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/scriptTag.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/scriptTag.astro
@@ -1,4 +1,4 @@
-<script>
+<script is:inline>
 	const MyNumber = 3
 	console.log(MyNumber.toStrang())
 </script>

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/scriptTagTypeScript.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/scriptTagTypeScript.astro
@@ -1,0 +1,9 @@
+<script>
+	const astro: string = "Astro"
+	astro;
+</script>
+
+<script is:inline>
+	const astro: string = "Astro"
+	astro;
+</script>


### PR DESCRIPTION
## Changes

Editor tooling part of https://github.com/withastro/astro/pull/3665. 

This was not implemented in a retro-compatible way, which mean that users using outdated Astro versions might run into false-positive where TS doesn't properly report that TS is not supported inside script tags, I think that's okay since it shouldn't happen too often (and we're <1.0 still)

## Testing

Added a test for this, updated tests that needed changes

## Docs

No docs needed on our side, planning PR / collab for docs update however
