### PR TITLE
Add config setting to support arbitrary attributes

### DIFF
--- a/.changeset/gold-rocks-hear.md
+++ b/.changeset/gold-rocks-hear.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Added a new setting (`astro.typescript.allowArbitraryAttributes`) to enable support for arbitrary attributes

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -51,7 +51,7 @@ type DeepPartial<T> = T extends Record<string, unknown>
  * For more info on this, see the [internal docs](../../../../../docs/internal/language-server/config.md)
  */
 export class ConfigManager {
-	public globalConfig: Record<string, any> = { astro: defaultLSConfig };
+	private globalConfig: Record<string, any> = { astro: defaultLSConfig };
 	private documentSettings: Record<string, Record<string, Promise<any>>> = {};
 
 	// If set to true, the next time we need a TypeScript language service, we'll rebuild it so it gets the new config

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { merge, get } from 'lodash';
 import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { LSConfig, LSCSSConfig, LSFormatConfig, LSHTMLConfig, LSTypescriptConfig } from './interfaces';
 import { Connection, FormattingOptions } from 'vscode-languageserver';
@@ -8,6 +8,7 @@ import { FormatCodeSettings, InlayHintsOptions, SemicolonPreference, UserPrefere
 export const defaultLSConfig: LSConfig = {
 	typescript: {
 		enabled: true,
+		allowArbitraryAttributes: false,
 		diagnostics: { enabled: true },
 		hover: { enabled: true },
 		completions: { enabled: true },
@@ -50,8 +51,11 @@ type DeepPartial<T> = T extends Record<string, unknown>
  * For more info on this, see the [internal docs](../../../../../docs/internal/language-server/config.md)
  */
 export class ConfigManager {
-	private globalConfig: Record<string, any> = { astro: defaultLSConfig };
+	public globalConfig: Record<string, any> = { astro: defaultLSConfig };
 	private documentSettings: Record<string, Record<string, Promise<any>>> = {};
+
+	// If set to true, the next time we need a TypeScript language service, we'll rebuild it so it gets the new config
+	public shouldRefreshTSServices = false;
 
 	private isTrusted = true;
 
@@ -64,6 +68,7 @@ export class ConfigManager {
 	updateConfig() {
 		// Reset all cached document settings
 		this.documentSettings = {};
+		this.shouldRefreshTSServices = true;
 	}
 
 	removeDocument(scopeUri: string) {
@@ -72,7 +77,7 @@ export class ConfigManager {
 
 	async getConfig<T>(section: string, scopeUri: string): Promise<T> {
 		if (!this.connection) {
-			return this.globalConfig[section];
+			return get(this.globalConfig, section);
 		}
 
 		if (!this.documentSettings[scopeUri]) {
@@ -213,6 +218,8 @@ export class ConfigManager {
 		} else {
 			this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
 		}
+
+		this.shouldRefreshTSServices = true;
 	}
 }
 

--- a/packages/language-server/src/core/config/interfaces.ts
+++ b/packages/language-server/src/core/config/interfaces.ts
@@ -16,6 +16,7 @@ export interface LSFormatConfig {
 
 export interface LSTypescriptConfig {
 	enabled: boolean;
+	allowArbitraryAttributes: boolean;
 	diagnostics: {
 		enabled: boolean;
 	};

--- a/packages/language-server/src/plugins/typescript/LanguageServiceManager.ts
+++ b/packages/language-server/src/plugins/typescript/LanguageServiceManager.ts
@@ -24,6 +24,7 @@ export class LanguageServiceManager {
 		this.docContext = {
 			createDocument: this.createDocument,
 			globalSnapshotManager: this.globalSnapshotManager,
+			configManager: this.configManager,
 		};
 
 		const handleDocumentChange = (document: AstroDocument) => {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -159,6 +159,8 @@ export function startLanguageServer(connection: vscode.Connection) {
 		} else {
 			configManager.updateGlobalConfig(<LSConfig>change.settings.astro || defaultLSConfig);
 		}
+
+		updateAllDiagnostics();
 	});
 
 	// Documents

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1,4 +1,4 @@
-import { config, expect } from 'chai';
+import { expect } from 'chai';
 import { DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import { createEnvironment } from '../../../utils';
 import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { config, expect } from 'chai';
 import { DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import { createEnvironment } from '../../../utils';
 import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
@@ -41,6 +41,19 @@ describe('TypeScript Plugin#DiagnosticsProvider', () => {
 				tags: [],
 			},
 		]);
+	});
+
+	it('support arbitrary attributes when enabled', async () => {
+		const { provider, document, configManager } = setup('arbitraryAttrs.astro');
+
+		configManager.updateGlobalConfig(<any>{
+			typescript: {
+				allowArbitraryAttributes: true,
+			},
+		});
+
+		const diagnostics = await provider.getDiagnostics(document);
+		expect(diagnostics).to.be.empty;
 	});
 
 	it('provide deprecated and unused hints', async () => {

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/arbitraryAttrs.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/arbitraryAttrs.astro
@@ -1,0 +1,1 @@
+<div astroIsCool></div>

--- a/packages/language-server/types/arbitrary-attrs.d.ts
+++ b/packages/language-server/types/arbitrary-attrs.d.ts
@@ -1,0 +1,5 @@
+declare namespace astroHTML.JSX {
+	interface HTMLAttributes {
+		[name: string]: any;
+	}
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -100,6 +100,12 @@
           "title": "TypeScript",
           "description": "Enable TypeScript features"
         },
+        "astro.typescript.allowArbitraryAttributes": {
+          "type": "boolean",
+          "default": false,
+          "title": "TypeScript: Allow arbitrary attributes on HTML elements",
+          "description": "Enable the usage of non-standard HTML attributes, such as the ones added by AlpineJS or petite-vue"
+        },
         "astro.typescript.diagnostics.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Changes

This adds a setting `astro.typescript.allowArbitraryAttributes` to enable support for non-standard attributes. This is part of the puzzle to support frameworks that want users to add attributes to HTML elements such as Alpine and petite-vue

Additionally, while testing this I realized that there was an issue where for clients that don't support `workspace/configuration`, every single `getConfig` call that used a path instead of a simple string (ex: `astro.format` instead of `astro`) would return `undefined` so I fixed that

## Testing

Added a test

## Docs

The added setting has a description and a title to indicate what it does and when it can be useful