### PR TITLE
Remove Lodash from codebase

### DIFF
--- a/.changeset/twelve-roses-hammer.md
+++ b/.changeset/twelve-roses-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Remove Lodash from the code base, significally reducing the file count of the package

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -22,7 +22,6 @@
     "@astrojs/vue-language-integration": "^0.1.1",
     "@astrojs/svelte-language-integration": "^0.1.6",
     "@vscode/emmet-helper": "^2.8.4",
-    "lodash": "^4.17.21",
     "source-map": "^0.7.3",
     "typescript": "~4.6.4",
     "vscode-css-languageservice": "^6.0.1",
@@ -35,7 +34,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
-    "@types/lodash": "^4.14.179",
     "@types/mocha": "^9.1.0",
     "@types/sinon": "^10.0.11",
     "astro": "^1.0.0-beta.1",

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -1,9 +1,9 @@
-import { merge, get } from 'lodash';
 import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { LSConfig, LSCSSConfig, LSFormatConfig, LSHTMLConfig, LSTypescriptConfig } from './interfaces';
 import { Connection, FormattingOptions } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { FormatCodeSettings, InlayHintsOptions, SemicolonPreference, UserPreferences } from 'typescript';
+import { get, mergeDeep } from '../../utils';
 
 export const defaultLSConfig: LSConfig = {
 	typescript: {
@@ -75,9 +75,9 @@ export class ConfigManager {
 		delete this.documentSettings[scopeUri];
 	}
 
-	async getConfig<T>(section: string, scopeUri: string): Promise<T> {
+	async getConfig<T>(section: string, scopeUri: string): Promise<T | Record<string, any>> {
 		if (!this.connection) {
-			return get(this.globalConfig, section);
+			return get<T>(this.globalConfig, section) ?? {};
 		}
 
 		if (!this.documentSettings[scopeUri]) {
@@ -214,9 +214,9 @@ export class ConfigManager {
 	 */
 	updateGlobalConfig(config: DeepPartial<LSConfig> | any, outsideAstro?: boolean) {
 		if (outsideAstro) {
-			this.globalConfig = merge({}, this.globalConfig, config);
+			this.globalConfig = mergeDeep({}, this.globalConfig, config);
 		} else {
-			this.globalConfig.astro = merge({}, defaultLSConfig, this.globalConfig.astro, config);
+			this.globalConfig.astro = mergeDeep({}, defaultLSConfig, this.globalConfig.astro, config);
 		}
 
 		this.shouldRefreshTSServices = true;

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -28,7 +28,6 @@ import {
 	LinkedEditingRanges,
 } from 'vscode-languageserver';
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
-import { flatten } from 'lodash';
 import { DocumentManager } from '../core/documents/DocumentManager';
 import { isNotNullOrUndefined } from '../utils';
 import { getNodeIfIsInHTMLStartTag, isInComponentStartTag } from '../core/documents';
@@ -39,7 +38,7 @@ enum ExecuteMode {
 	Collect,
 }
 
-interface PluginHostConfig {
+export interface PluginHostConfig {
 	filterIncompleteCompletions: boolean;
 	definitionLinkSupport: boolean;
 }
@@ -105,7 +104,7 @@ export class PluginHost {
 			});
 		}
 
-		let flattenedCompletions = flatten(completions.map((completion) => completion.result.items));
+		let flattenedCompletions = completions.flatMap((completion) => completion.result.items);
 		const isIncomplete = completions.reduce(
 			(incomplete, completion) => incomplete || completion.result.isIncomplete,
 			false as boolean
@@ -132,7 +131,8 @@ export class PluginHost {
 	async getDiagnostics(textDocument: TextDocumentIdentifier): Promise<Diagnostic[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(await this.execute<Diagnostic[]>('getDiagnostics', [document], ExecuteMode.Collect));
+		const diagnostics = await this.execute<Diagnostic>('getDiagnostics', [document], ExecuteMode.Collect);
+		return diagnostics;
 	}
 
 	async doHover(textDocument: TextDocumentIdentifier, position: Position): Promise<Hover | null> {
@@ -144,23 +144,21 @@ export class PluginHost {
 	async formatDocument(textDocument: TextDocumentIdentifier, options: FormattingOptions): Promise<TextEdit[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(await this.execute<TextEdit[]>('formatDocument', [document, options], ExecuteMode.Collect));
+		return await this.execute<TextEdit>('formatDocument', [document, options], ExecuteMode.Collect);
 	}
 
 	async getCodeActions(
 		textDocument: TextDocumentIdentifier,
 		range: Range,
 		context: CodeActionContext,
-		cancellationToken: CancellationToken
+		cancellationToken?: CancellationToken
 	): Promise<CodeAction[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(
-			await this.execute<CodeAction[]>(
-				'getCodeActions',
-				[document, range, context, cancellationToken],
-				ExecuteMode.Collect
-			)
+		return await this.execute<CodeAction>(
+			'getCodeActions',
+			[document, range, context, cancellationToken],
+			ExecuteMode.Collect
 		);
 	}
 
@@ -173,21 +171,19 @@ export class PluginHost {
 	async getFoldingRanges(textDocument: TextDocumentIdentifier): Promise<FoldingRange[] | null> {
 		const document = this.getDocument(textDocument.uri);
 
-		const foldingRanges = flatten(
-			await this.execute<FoldingRange[]>('getFoldingRanges', [document], ExecuteMode.Collect)
-		);
-
-		return foldingRanges;
+		return await this.execute<FoldingRange>('getFoldingRanges', [document], ExecuteMode.Collect);
 	}
 
 	async getDocumentSymbols(
 		textDocument: TextDocumentIdentifier,
-		cancellationToken: CancellationToken
+		cancellationToken?: CancellationToken
 	): Promise<SymbolInformation[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(
-			await this.execute<SymbolInformation[]>('getDocumentSymbols', [document, cancellationToken], ExecuteMode.Collect)
+		return await this.execute<SymbolInformation>(
+			'getDocumentSymbols',
+			[document, cancellationToken],
+			ExecuteMode.Collect
 		);
 	}
 
@@ -220,9 +216,7 @@ export class PluginHost {
 	): Promise<DefinitionLink[] | Location[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		const definitions = flatten(
-			await this.execute<DefinitionLink[]>('getDefinitions', [document, position], ExecuteMode.Collect)
-		);
+		const definitions = await this.execute<DefinitionLink>('getDefinitions', [document, position], ExecuteMode.Collect);
 
 		if (this.pluginHostConfig.definitionLinkSupport) {
 			return definitions;
@@ -244,17 +238,7 @@ export class PluginHost {
 	async getDocumentColors(textDocument: TextDocumentIdentifier): Promise<ColorInformation[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(await this.execute<ColorInformation[]>('getDocumentColors', [document], ExecuteMode.Collect));
-	}
-
-	async getInlayHints(
-		textDocument: TextDocumentIdentifier,
-		range: Range,
-		cancellationToken: CancellationToken
-	): Promise<InlayHint[]> {
-		const document = this.getDocument(textDocument.uri);
-
-		return flatten(await this.execute<InlayHint[]>('getInlayHints', [document, range], ExecuteMode.FirstNonNull));
+		return await this.execute<ColorInformation>('getDocumentColors', [document], ExecuteMode.Collect);
 	}
 
 	async getColorPresentations(
@@ -264,23 +248,32 @@ export class PluginHost {
 	): Promise<ColorPresentation[]> {
 		const document = this.getDocument(textDocument.uri);
 
-		return flatten(
-			await this.execute<ColorPresentation[]>('getColorPresentations', [document, range, color], ExecuteMode.Collect)
+		return await this.execute<ColorPresentation>(
+			'getColorPresentations',
+			[document, range, color],
+			ExecuteMode.Collect
 		);
+	}
+
+	async getInlayHints(
+		textDocument: TextDocumentIdentifier,
+		range: Range,
+		cancellationToken?: CancellationToken
+	): Promise<InlayHint[]> {
+		const document = this.getDocument(textDocument.uri);
+
+		return (await this.execute<InlayHint[]>('getInlayHints', [document, range], ExecuteMode.FirstNonNull)) ?? [];
 	}
 
 	async getSignatureHelp(
 		textDocument: TextDocumentIdentifier,
 		position: Position,
 		context: SignatureHelpContext | undefined,
-		cancellationToken: CancellationToken
+		cancellationToken?: CancellationToken
 	): Promise<SignatureHelp | null> {
 		const document = this.getDocument(textDocument.uri);
-		if (!document) {
-			throw new Error('Cannot call methods on an unopened document');
-		}
 
-		return await this.execute<any>(
+		return await this.execute<SignatureHelp>(
 			'getSignatureHelp',
 			[document, position, context, cancellationToken],
 			ExecuteMode.FirstNonNull
@@ -323,12 +316,14 @@ export class PluginHost {
 				}
 				return null;
 			case ExecuteMode.Collect:
-				return Promise.all(
-					plugins.map((plugin) => {
-						let ret = this.tryExecutePlugin(plugin, name, args, []);
-						return ret;
-					})
-				);
+				return (
+					await Promise.all(
+						plugins.map((plugin) => {
+							let ret = this.tryExecutePlugin(plugin, name, args, []);
+							return ret;
+						})
+					)
+				).flat();
 			case ExecuteMode.None:
 				await Promise.all(plugins.map((plugin) => this.tryExecutePlugin(plugin, name, args, null)));
 				return;

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -33,7 +33,6 @@ import { getLanguage, getLanguageService } from './language-service';
 import { AttributeContext, getAttributeContextAtPosition } from '../../core/documents/parseHtml';
 import { StyleAttributeDocument } from './StyleAttributeDocument';
 import { getIdClassCompletion } from './features/getIdClassCompletions';
-import { flatten } from 'lodash';
 
 export class CSSPlugin implements Plugin {
 	__name = 'css';
@@ -215,7 +214,7 @@ export class CSSPlugin implements Plugin {
 			return [];
 		}
 
-		const allColorInfo = this.getCSSDocumentsForDocument(document).map((cssDoc) => {
+		const allColorInfo = this.getCSSDocumentsForDocument(document).flatMap((cssDoc) => {
 			const cssLang = extractLanguage(cssDoc);
 			const langService = getLanguageService(cssLang);
 
@@ -228,7 +227,7 @@ export class CSSPlugin implements Plugin {
 				.map((colorInfo) => mapObjWithRangeToOriginal(cssDoc, colorInfo));
 		});
 
-		return flatten(allColorInfo);
+		return allColorInfo;
 	}
 
 	async getColorPresentations(document: AstroDocument, range: Range, color: Color): Promise<ColorPresentation[]> {
@@ -236,7 +235,7 @@ export class CSSPlugin implements Plugin {
 			return [];
 		}
 
-		const allColorPres = this.getCSSDocumentsForDocument(document).map((cssDoc) => {
+		const allColorPres = this.getCSSDocumentsForDocument(document).flatMap((cssDoc) => {
 			const cssLang = extractLanguage(cssDoc);
 			const langService = getLanguageService(cssLang);
 
@@ -252,18 +251,18 @@ export class CSSPlugin implements Plugin {
 				.map((colorPres) => mapColorPresentationToOriginal(cssDoc, colorPres));
 		});
 
-		return flatten(allColorPres);
+		return allColorPres;
 	}
 
 	getFoldingRanges(document: AstroDocument): FoldingRange[] | null {
-		const allFoldingRanges = this.getCSSDocumentsForDocument(document).map((cssDoc) => {
+		const allFoldingRanges = this.getCSSDocumentsForDocument(document).flatMap((cssDoc) => {
 			const cssLang = extractLanguage(cssDoc);
 			const langService = getLanguageService(cssLang);
 
 			return langService.getFoldingRanges(cssDoc).map((foldingRange) => mapFoldingRangeToParent(cssDoc, foldingRange));
 		});
 
-		return flatten(allFoldingRanges);
+		return allFoldingRanges;
 	}
 
 	async getDocumentSymbols(document: AstroDocument): Promise<SymbolInformation[]> {
@@ -271,13 +270,13 @@ export class CSSPlugin implements Plugin {
 			return [];
 		}
 
-		const allDocumentSymbols = this.getCSSDocumentsForDocument(document).map((cssDoc) => {
+		const allDocumentSymbols = this.getCSSDocumentsForDocument(document).flatMap((cssDoc) => {
 			return getLanguageService(extractLanguage(cssDoc))
 				.findDocumentSymbols(cssDoc, cssDoc.stylesheet)
 				.map((symbol) => mapSymbolInformationToOriginal(cssDoc, symbol));
 		});
 
-		return flatten(allDocumentSymbols);
+		return allDocumentSymbols;
 	}
 
 	private inStyleAttributeWithoutInterpolation(

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -1,4 +1,3 @@
-import { flatten } from 'lodash';
 import ts, { CodeFixAction, FileTextChanges } from 'typescript';
 import { CancellationToken } from 'vscode-languageserver';
 import {
@@ -239,7 +238,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 				fixName: 'import',
 			})) ?? [];
 
-		return flatten(completion.entries.filter((c) => c.name === name || c.name === suffixedName).map(toFix));
+		return completion.entries.filter((c) => c.name === name || c.name === suffixedName).flatMap(toFix);
 	}
 
 	private async organizeSortImports(

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -38,7 +38,6 @@ import {
 	SnapshotFragment,
 } from '../snapshots/DocumentSnapshot';
 import { getRegExpMatches, isNotNullOrUndefined } from '../../../utils';
-import { flatten } from 'lodash';
 import { getMarkdownDocumentation } from '../previewer';
 import { isPartOfImportStatement } from './utils';
 import { ConfigManager } from '../../../core/config';
@@ -483,7 +482,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 		const rawImports = getRegExpMatches(scriptImportRegex, document.getText()).map((match) =>
 			(match[1] ?? match[2]).split(',')
 		);
-		const tidiedImports = flatten(rawImports).map((match) => match.trim());
+		const tidiedImports = rawImports.flat().map((match) => match.trim());
 		return new Set(tidiedImports);
 	}
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -38,6 +38,46 @@ export function getLastPartOfPath(path: string): string {
 }
 
 /**
+ * Return an element in an object using a path as a string (ex: `astro.typescript.format` will return astro['typescript']['format']).
+ * From: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
+ */
+export function get<T>(obj: Record<string, any>, path: string) {
+	const travel = (regexp: RegExp) =>
+		String.prototype.split
+			.call(path, regexp)
+			.filter(Boolean)
+			.reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+	const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+	return result === undefined ? undefined : (result as T);
+}
+
+/**
+ * Performs a deep merge of objects and returns new object. Does not modify
+ * objects (immutable) and merges arrays via concatenation.
+ * From: https://stackoverflow.com/a/48218209
+ */
+export function mergeDeep(...objects: Record<string, any>[]): Record<string, any> {
+	const isObject = (obj: Record<string, any>) => obj && typeof obj === 'object';
+
+	return objects.reduce((prev, obj) => {
+		Object.keys(obj).forEach((key) => {
+			const pVal = prev[key];
+			const oVal = obj[key];
+
+			if (Array.isArray(pVal) && Array.isArray(oVal)) {
+				prev[key] = pVal.concat(...oVal);
+			} else if (isObject(pVal) && isObject(oVal)) {
+				prev[key] = mergeDeep(pVal, oVal);
+			} else {
+				prev[key] = oVal;
+			}
+		});
+
+		return prev;
+	}, {});
+}
+
+/**
  * Transform a string into PascalCase
  */
 export function toPascalCase(string: string) {
@@ -72,11 +112,6 @@ export function isPossibleComponent(node: Node): boolean {
 	return !!node.tag?.[0].match(/[A-Z]/) || !!node.tag?.match(/.+[.][A-Z]/);
 }
 
-/** Flattens an array */
-export function flatten<T>(arr: T[][]): T[] {
-	return arr.reduce((all, item) => [...all, ...item], []);
-}
-
 /** Clamps a number between min and max */
 export function clamp(num: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, num));
@@ -95,6 +130,25 @@ export function isBeforeOrEqualToPosition(position: Position, positionToTest: Po
 		positionToTest.line < position.line ||
 		(positionToTest.line === position.line && positionToTest.character <= position.character)
 	);
+}
+
+/**
+ * Like str.lastIndexOf, but for regular expressions. Note that you need to provide the g-flag to your RegExp!
+ */
+export function regexLastIndexOf(text: string, regex: RegExp, endPos?: number) {
+	if (endPos === undefined) {
+		endPos = text.length;
+	} else if (endPos < 0) {
+		endPos = 0;
+	}
+
+	const stringToWorkWith = text.substring(0, endPos + 1);
+	let lastIndexOf = -1;
+	let result: RegExpExecArray | null = null;
+	while ((result = regex.exec(stringToWorkWith)) !== null) {
+		lastIndexOf = result.index;
+	}
+	return lastIndexOf;
 }
 
 /**

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -1,0 +1,320 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Color, CompletionTriggerKind } from 'vscode-languageserver';
+import { CompletionItem, Location, LocationLink, Position, Range, TextDocumentItem } from 'vscode-languageserver-types';
+import { AstroDocument, DocumentManager } from '../../src/core/documents';
+import { PluginHost, PluginHostConfig } from '../../src/plugins';
+
+describe('PluginHost', () => {
+	const textDocument: TextDocumentItem = {
+		uri: 'file:///astro.astro',
+		version: 0,
+		languageId: 'astro',
+		text: 'Hello, world!',
+	};
+
+	function setup<T>(
+		pluginProviderStubs: T,
+		config: PluginHostConfig = {
+			definitionLinkSupport: true,
+			filterIncompleteCompletions: false,
+		}
+	) {
+		const docManager = new DocumentManager((document) => new AstroDocument(document.uri, document.text));
+
+		const pluginHost = new PluginHost(docManager);
+		const plugin = {
+			...pluginProviderStubs,
+			__name: 'test',
+		};
+
+		pluginHost.initialize(config);
+		pluginHost.registerPlugin(plugin);
+
+		return { docManager, pluginHost, plugin };
+	}
+
+	it('executes getCompletions on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getCompletions: sinon.stub().returns({ items: [] }),
+		});
+		const document = docManager.openDocument(textDocument);
+		const pos = Position.create(0, 0);
+
+		await pluginHost.getCompletions(textDocument, pos, {
+			triggerKind: CompletionTriggerKind.TriggerCharacter,
+			triggerCharacter: '.',
+		});
+
+		sinon.assert.calledOnce(plugin.getCompletions);
+		sinon.assert.calledWithExactly(
+			plugin.getCompletions,
+			document,
+			pos,
+			{
+				triggerKind: CompletionTriggerKind.TriggerCharacter,
+				triggerCharacter: '.',
+			},
+			undefined
+		);
+	});
+
+	describe('getCompletions (incomplete)', () => {
+		function setupGetIncompleteCompletions(filterServerSide: boolean) {
+			const { docManager, pluginHost } = setup(
+				{
+					getCompletions: sinon.stub().returns({
+						isIncomplete: true,
+						items: <CompletionItem[]>[{ label: 'Hello' }, { label: 'foo' }],
+					}),
+				},
+				{ definitionLinkSupport: true, filterIncompleteCompletions: filterServerSide }
+			);
+			docManager.openDocument(textDocument);
+			return pluginHost;
+		}
+
+		it('filters client side', async () => {
+			const pluginHost = setupGetIncompleteCompletions(false);
+			const completions = await pluginHost.getCompletions(textDocument, Position.create(0, 2));
+
+			expect(completions.items).to.deep.equal(<CompletionItem[]>[{ label: 'Hello' }, { label: 'foo' }]);
+		});
+
+		it('filters server side', async () => {
+			const pluginHost = setupGetIncompleteCompletions(true);
+			const completions = await pluginHost.getCompletions(textDocument, Position.create(0, 2));
+
+			expect(completions.items).to.deep.equal(<CompletionItem[]>[{ label: 'Hello' }]);
+		});
+	});
+
+	it('executes resolveCompletion on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			resolveCompletion: sinon.stub().returns({}),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.resolveCompletion(textDocument, { label: 'Hello' });
+
+		sinon.assert.calledOnce(plugin.resolveCompletion);
+		sinon.assert.calledWithExactly(plugin.resolveCompletion, document, { label: 'Hello' });
+	});
+
+	it('executes getDiagnostics on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getDiagnostics: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.getDiagnostics(textDocument);
+
+		sinon.assert.calledOnce(plugin.getDiagnostics);
+		sinon.assert.calledWithExactly(plugin.getDiagnostics, document);
+	});
+
+	it('executes doHover on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			doHover: sinon.stub().returns(null),
+		});
+		const document = docManager.openDocument(textDocument);
+		const pos = Position.create(0, 0);
+
+		await pluginHost.doHover(textDocument, pos);
+
+		sinon.assert.calledOnce(plugin.doHover);
+		sinon.assert.calledWithExactly(plugin.doHover, document, pos);
+	});
+
+	it('executes formatDocument on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			formatDocument: sinon.stub().returns(''),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.formatDocument(textDocument, { tabSize: 2, insertSpaces: true });
+
+		sinon.assert.calledOnce(plugin.formatDocument);
+		sinon.assert.calledWithExactly(plugin.formatDocument, document, { tabSize: 2, insertSpaces: true });
+	});
+
+	it('executes getCodeActions on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getCodeActions: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const range = Range.create(Position.create(0, 0), Position.create(0, 0));
+
+		await pluginHost.getCodeActions(textDocument, range, { diagnostics: [] });
+
+		sinon.assert.calledOnce(plugin.getCodeActions);
+		sinon.assert.calledWithExactly(plugin.getCodeActions, document, range, { diagnostics: [] }, undefined);
+	});
+
+	it('executes getFoldingRanges on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getFoldingRanges: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.getFoldingRanges(textDocument);
+
+		sinon.assert.calledOnce(plugin.getFoldingRanges);
+		sinon.assert.calledWithExactly(plugin.getFoldingRanges, document);
+	});
+
+	it('executes getDocumentSymbols on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getDocumentSymbols: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.getDocumentSymbols(textDocument);
+
+		sinon.assert.calledOnce(plugin.getDocumentSymbols);
+		sinon.assert.calledWithExactly(plugin.getDocumentSymbols, document, undefined);
+	});
+
+	it('executes getSemanticTokens on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getSemanticTokens: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.getSemanticTokens(textDocument);
+
+		sinon.assert.calledOnce(plugin.getSemanticTokens);
+		sinon.assert.calledWithExactly(plugin.getSemanticTokens, document, undefined, undefined);
+	});
+
+	it('executes getLinkedEditingRanges on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getLinkedEditingRanges: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const position = Position.create(0, 0);
+
+		await pluginHost.getLinkedEditingRanges(textDocument, position);
+
+		sinon.assert.calledOnce(plugin.getLinkedEditingRanges);
+		sinon.assert.calledWithExactly(plugin.getLinkedEditingRanges, document, position);
+	});
+
+	describe('getDefinitions', () => {
+		function setupGetDefinitions(linkSupport: boolean) {
+			const { pluginHost, docManager } = setup(
+				{
+					getDefinitions: sinon.stub().returns([
+						<LocationLink>{
+							targetRange: Range.create(Position.create(0, 0), Position.create(0, 2)),
+							targetSelectionRange: Range.create(Position.create(0, 0), Position.create(0, 1)),
+							targetUri: 'uri',
+						},
+					]),
+				},
+				{ definitionLinkSupport: linkSupport, filterIncompleteCompletions: false }
+			);
+			docManager.openDocument(textDocument);
+			return pluginHost;
+		}
+
+		it('uses LocationLink', async () => {
+			const pluginHost = setupGetDefinitions(true);
+			const definitions = await pluginHost.getDefinitions(textDocument, Position.create(0, 0));
+
+			expect(definitions).to.deep.equal([
+				<LocationLink>{
+					targetRange: Range.create(Position.create(0, 0), Position.create(0, 2)),
+					targetSelectionRange: Range.create(Position.create(0, 0), Position.create(0, 1)),
+					targetUri: 'uri',
+				},
+			]);
+		});
+
+		it('uses Location', async () => {
+			const pluginHost = setupGetDefinitions(false);
+			const definitions = await pluginHost.getDefinitions(textDocument, Position.create(0, 0));
+
+			expect(definitions).to.deep.equal([
+				<Location>{
+					range: Range.create(Position.create(0, 0), Position.create(0, 1)),
+					uri: 'uri',
+				},
+			]);
+		});
+	});
+
+	it('executes getDocumentColors on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getDocumentColors: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+
+		await pluginHost.getDocumentColors(textDocument);
+
+		sinon.assert.calledOnce(plugin.getDocumentColors);
+		sinon.assert.calledWithExactly(plugin.getDocumentColors, document);
+	});
+
+	it('executes getColorPresentations on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getColorPresentations: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const range = Range.create(Position.create(0, 0), Position.create(0, 1));
+		const color = Color.create(0, 0, 0, 0);
+
+		await pluginHost.getColorPresentations(textDocument, range, color);
+
+		sinon.assert.calledOnce(plugin.getColorPresentations);
+		sinon.assert.calledWithExactly(plugin.getColorPresentations, document, range, color);
+	});
+
+	it('executes getInlayHints on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getInlayHints: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const range = Range.create(Position.create(0, 0), Position.create(0, 1));
+
+		await pluginHost.getInlayHints(textDocument, range);
+
+		sinon.assert.calledOnce(plugin.getInlayHints);
+		sinon.assert.calledWithExactly(plugin.getInlayHints, document, range);
+	});
+
+	it('executes getSignatureHelp on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getSignatureHelp: sinon.stub().returns({}),
+		});
+		const document = docManager.openDocument(textDocument);
+		const position = Position.create(0, 0);
+
+		await pluginHost.getSignatureHelp(textDocument, position, undefined);
+
+		sinon.assert.calledOnce(plugin.getSignatureHelp);
+		sinon.assert.calledWithExactly(plugin.getSignatureHelp, document, position, undefined, undefined);
+	});
+
+	it('executes onWatchFileChanges on plugins', async () => {
+		const { pluginHost, plugin } = setup({
+			onWatchFileChanges: sinon.stub(),
+		});
+
+		pluginHost.onWatchFileChanges([]);
+
+		sinon.assert.calledOnce(plugin.onWatchFileChanges);
+		sinon.assert.calledWithExactly(plugin.onWatchFileChanges, []);
+	});
+
+	it('executes updateNonAstroFile on plugins', async () => {
+		const { pluginHost, plugin } = setup({
+			updateNonAstroFile: sinon.stub(),
+		});
+
+		pluginHost.updateNonAstroFile('astro.astro', []);
+
+		sinon.assert.calledOnce(plugin.updateNonAstroFile);
+		sinon.assert.calledWithExactly(plugin.updateNonAstroFile, 'astro.astro', []);
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,11 +749,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz"
   integrity sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==
 
-"@types/lodash@^4.14.179":
-  version "4.14.179"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz"
-  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
-
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz"


### PR DESCRIPTION
## Changes

This completely removes Lodash from the language-server codebase, lighten up the files count significantly (Lodash is 1000+ files)

## Testing

Tests still pass, added a test suite for the entire PluginHost

## Docs

No docs needed
