### PR TITLE
Update default settings behaviour when no settings are provided

### DIFF
--- a/.changeset/little-chefs-enjoy.md
+++ b/.changeset/little-chefs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Updated behaviour when no settings are provided. All features are now considered enabled by default

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -210,9 +210,9 @@ export class ConfigManager {
 		const config = (await this.getConfig<any>('astro', document.uri)) ?? {};
 
 		if (config[plugin]) {
-			let res = config[plugin].enabled;
+			let res = config[plugin].enabled ?? true;
 			if (feature && config[plugin][feature]) {
-				res = res && config[plugin][feature].enabled;
+				res = (res && config[plugin][feature].enabled) ?? true;
 			}
 			return res;
 		}

--- a/packages/language-server/src/core/config/interfaces.ts
+++ b/packages/language-server/src/core/config/interfaces.ts
@@ -3,79 +3,79 @@
  * Make sure that this is kept in sync with the `package.json` of the VS Code extension
  */
 export interface LSConfig {
-	typescript: LSTypescriptConfig;
-	html: LSHTMLConfig;
-	css: LSCSSConfig;
-	format: LSFormatConfig;
+	typescript?: LSTypescriptConfig;
+	html?: LSHTMLConfig;
+	css?: LSCSSConfig;
+	format?: LSFormatConfig;
 }
 
 export interface LSFormatConfig {
-	indentFrontmatter: boolean;
-	newLineAfterFrontmatter: boolean;
+	indentFrontmatter?: boolean;
+	newLineAfterFrontmatter?: boolean;
 }
 
 export interface LSTypescriptConfig {
-	enabled: boolean;
-	allowArbitraryAttributes: boolean;
-	diagnostics: {
-		enabled: boolean;
+	enabled?: boolean;
+	allowArbitraryAttributes?: boolean;
+	diagnostics?: {
+		enabled?: boolean;
 	};
-	hover: {
-		enabled: boolean;
+	hover?: {
+		enabled?: boolean;
 	};
-	documentSymbols: {
-		enabled: boolean;
+	documentSymbols?: {
+		enabled?: boolean;
 	};
-	completions: {
-		enabled: boolean;
+	completions?: {
+		enabled?: boolean;
 	};
-	definitions: {
-		enabled: boolean;
+	definitions?: {
+		enabled?: boolean;
 	};
-	codeActions: {
-		enabled: boolean;
+	codeActions?: {
+		enabled?: boolean;
 	};
-	rename: {
-		enabled: boolean;
+	rename?: {
+		enabled?: boolean;
 	};
-	signatureHelp: {
-		enabled: boolean;
+	signatureHelp?: {
+		enabled?: boolean;
 	};
-	semanticTokens: {
-		enabled: boolean;
+	semanticTokens?: {
+		enabled?: boolean;
 	};
 }
 
 export interface LSHTMLConfig {
-	enabled: boolean;
-	hover: {
-		enabled: boolean;
+	enabled?: boolean;
+	hover?: {
+		enabled?: boolean;
 	};
-	completions: {
-		enabled: boolean;
-		emmet: boolean;
+	completions?: {
+		enabled?: boolean;
+		emmet?: boolean;
 	};
-	tagComplete: {
-		enabled: boolean;
+	tagComplete?: {
+		enabled?: boolean;
 	};
-	documentSymbols: {
-		enabled: boolean;
+	documentSymbols?: {
+		enabled?: boolean;
 	};
 }
 
 export interface LSCSSConfig {
-	enabled: boolean;
-	hover: {
-		enabled: boolean;
+	enabled?: boolean;
+	hover?: {
+		enabled?: boolean;
 	};
-	completions: {
-		enabled: boolean;
-		emmet: boolean;
+	completions?: {
+		enabled?: boolean;
+		emmet?: boolean;
 	};
-	documentColors: {
-		enabled: boolean;
+	documentColors?: {
+		enabled?: boolean;
 	};
-	documentSymbols: {
-		enabled: boolean;
+	documentSymbols?: {
+		enabled?: boolean;
 	};
 }

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -165,7 +165,7 @@ export class CSSPlugin implements Plugin {
 		};
 
 		const extensionConfig = await this.configManager.getConfig<LSConfig>('astro', document.uri);
-		if (extensionConfig.css.completions.emmet) {
+		if (extensionConfig?.css?.completions?.emmet ?? true) {
 			langService.setCompletionParticipants([
 				{
 					onCssProperty: (context) => {

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -93,7 +93,7 @@ export class HTMLPlugin implements Plugin {
 
 		const emmetConfig = await this.configManager.getEmmetConfig(document);
 		const extensionConfig = (await this.configManager.getConfig<LSConfig>('astro', document.uri)) ?? {};
-		if (extensionConfig?.html?.completions?.emmet) {
+		if (extensionConfig?.html?.completions?.emmet ?? true) {
 			this.lang.setCompletionParticipants([
 				{
 					onHtmlContent: () =>


### PR DESCRIPTION
## Changes

Settings now work on an "opt-out" basis, where if a specific settings isn't provided, it'll fallback to its default value (which for features, means enabled)

The reason for this change is that in clients where you use the language server directly, for instance Neovim, the language server will in most cases be started with no settings at all and it's annoying for users to need to enable features all explicitly. For VS Code, this does not change anything because it always ship with all the settings at their default values

## Testing

This is covered already by our tests (if this broke feature checks, pretty much every test would fail). Additionally, we already have tests that test when features are disabled

## Docs

No docs needed. I'll inform people in Discord about the change for those who asked about it
