### PR TITLE
Update component check so completions work inside namespaced components

### DIFF
--- a/.changeset/violet-deers-warn.md
+++ b/.changeset/violet-deers-warn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Updated Component detection so completions now work for namespaced components (for example, typing `<myMarkdown.` will now give you a completion for the Content component)

--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -126,32 +126,19 @@ export function getLineAtPosition(position: Position, text: string) {
 }
 
 /**
- * Returns the node if offset is inside a HTML start tag
- */
-export function getNodeIfIsInHTMLStartTag(html: HTMLDocument, offset: number): Node | undefined {
-	const node = html.findNodeAt(offset);
-	if (!!node.tag && node.tag[0] === node.tag[0].toLowerCase() && (!node.startTagEnd || offset < node.startTagEnd)) {
-		return node;
-	}
-}
-
-/**
- * Return if a Node is a Component
- */
-export function isComponentTag(node: Node) {
-	if (!node.tag) {
-		return false;
-	}
-	const firstChar = node.tag[0];
-	return /[A-Z]/.test(firstChar);
-}
-
-/**
  * Return if a given offset is inside the start tag of a component
  */
 export function isInComponentStartTag(html: HTMLDocument, offset: number): boolean {
 	const node = html.findNodeAt(offset);
-	return isComponentTag(node) && (!node.startTagEnd || offset < node.startTagEnd);
+	return isPossibleComponent(node) && (!node.startTagEnd || offset < node.startTagEnd);
+}
+
+/**
+ * Return true if a specific node could be a component.
+ * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
+ */
+export function isPossibleComponent(node: Node): boolean {
+	return !!node.tag?.[0].match(/[A-Z]/) || !!node.tag?.match(/.+[.][A-Z]?/);
 }
 
 /**

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -30,7 +30,7 @@ import {
 import type { AppCompletionItem, Plugin, LSProvider } from './interfaces';
 import { DocumentManager } from '../core/documents/DocumentManager';
 import { isNotNullOrUndefined, regexLastIndexOf } from '../utils';
-import { getNodeIfIsInHTMLStartTag, isInComponentStartTag } from '../core/documents';
+import { isInComponentStartTag } from '../core/documents';
 
 enum ExecuteMode {
 	None,
@@ -87,12 +87,13 @@ export class PluginHost {
 		const astro = completions.find((completion) => completion.plugin === 'astro');
 
 		if (html && ts) {
-			if (getNodeIfIsInHTMLStartTag(document.html, document.offsetAt(position))) {
+			const inComponentStartTag = isInComponentStartTag(document.html, document.offsetAt(position));
+			if (!inComponentStartTag) {
 				ts.result.items = [];
 			}
 
 			// If the Astro plugin has completions for us, don't show TypeScript's as they're most likely duplicates
-			if (astro && astro.result.items.length > 0 && isInComponentStartTag(document.html, document.offsetAt(position))) {
+			if (astro && astro.result.items.length > 0 && inComponentStartTag) {
 				ts.result.items = [];
 			}
 

--- a/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
@@ -15,8 +15,7 @@ import {
 } from 'vscode-languageserver';
 import ts from 'typescript';
 import { LanguageServiceManager as TypeScriptLanguageServiceManager } from '../../typescript/LanguageServiceManager';
-import { isInComponentStartTag, isInsideExpression } from '../../../core/documents/utils';
-import { isPossibleComponent } from '../../../utils';
+import { isInComponentStartTag, isInsideExpression, isPossibleComponent } from '../../../core/documents/utils';
 import { toVirtualAstroFilePath, toVirtualFilePath } from '../../typescript/utils';
 import { getLanguageService } from 'vscode-html-languageservice';
 import { astroDirectives } from '../../html/features/astro-attributes';

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -16,9 +16,13 @@ import { getLanguageService, HTMLFormatConfiguration } from 'vscode-html-languag
 import type { Plugin } from '../interfaces';
 import { ConfigManager } from '../../core/config/ConfigManager';
 import { AstroDocument } from '../../core/documents/AstroDocument';
-import { isInComponentStartTag, isInsideExpression, isInsideFrontmatter } from '../../core/documents/utils';
+import {
+	isInComponentStartTag,
+	isInsideExpression,
+	isInsideFrontmatter,
+	isPossibleComponent,
+} from '../../core/documents/utils';
 import { LSConfig, LSHTMLConfig } from '../../core/config/interfaces';
-import { isPossibleComponent } from '../../utils';
 import { astroAttributes, astroDirectives, classListAttribute } from './features/astro-attributes';
 import { removeDataAttrCompletion } from './utils';
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -14,9 +14,9 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver-protoc
 import type { LanguageServiceManager } from '../LanguageServiceManager';
 import {
 	getLineAtPosition,
-	isComponentTag,
 	isInsideExpression,
 	isInsideFrontmatter,
+	isPossibleComponent,
 } from '../../../core/documents/utils';
 import { AstroDocument, mapRangeToOriginal } from '../../../core/documents';
 import ts, { ScriptElementKind, ScriptElementKindModifier } from 'typescript';
@@ -172,9 +172,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 				return null;
 			}
 
-			// If the current node is not a component (aka, it doesn't start with a caps), let's disable ourselves as the user
+			// If the current node is not a component, let's disable ourselves as the user
 			// is most likely looking for HTML completions
-			if (!isCompletionInsideFrontmatter && !isComponentTag(node) && !isCompletionInsideExpression) {
+			if (!isCompletionInsideFrontmatter && !isPossibleComponent(node) && !isCompletionInsideExpression) {
 				return null;
 			}
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -1,6 +1,5 @@
 import { URI } from 'vscode-uri';
 import { Position, Range } from 'vscode-languageserver';
-import { Node } from 'vscode-html-languageservice';
 
 /** Normalizes a document URI */
 export function normalizeUri(uri: string): string {
@@ -102,14 +101,6 @@ export function modifyLines(text: string, replacementFn: (line: string, lineIdx:
 				.join('\n')
 		)
 		.join('\r\n');
-}
-
-/**
- * Return true if a specific node could be a component.
- * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
- */
-export function isPossibleComponent(node: Node): boolean {
-	return !!node.tag?.[0].match(/[A-Z]/) || !!node.tag?.match(/.+[.][A-Z]/);
 }
 
 /** Clamps a number between min and max */

--- a/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
@@ -47,6 +47,18 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 		expect(completions).to.be.null;
 	});
 
+	it('provides completion for components under a namespace', async () => {
+		const { provider, document } = setup('importNamespacedComponents.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(4, 12), {
+			triggerKind: CompletionTriggerKind.TriggerCharacter,
+			triggerCharacter: '.',
+		});
+		const labels = completions?.items.flatMap((item) => item.label);
+
+		expect(labels).to.have.members(['Hello', 'World']);
+	});
+
 	it('provide auto import completion with insert action for component - no front matter', async () => {
 		const { provider, document } = setup('autoImportNoFrontmatter.astro');
 

--- a/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionsProvider.test.ts
@@ -54,9 +54,8 @@ describe('TypeScript Plugin#CompletionsProvider', () => {
 			triggerKind: CompletionTriggerKind.TriggerCharacter,
 			triggerCharacter: '.',
 		});
-		const labels = completions?.items.flatMap((item) => item.label);
 
-		expect(labels).to.have.members(['Hello', 'World']);
+		expect(completions?.items).to.not.be.empty;
 	});
 
 	it('provide auto import completion with insert action for component - no front matter', async () => {

--- a/packages/language-server/test/plugins/typescript/fixtures/completions/importNamespacedComponents.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/completions/importNamespacedComponents.astro
@@ -1,0 +1,5 @@
+---
+	import * as components from "./imports/MultipleComponent"
+---
+
+<components.

--- a/packages/language-server/test/plugins/typescript/fixtures/completions/imports/MultipleComponent.jsx
+++ b/packages/language-server/test/plugins/typescript/fixtures/completions/imports/MultipleComponent.jsx
@@ -1,0 +1,9 @@
+function Hello() {
+	return <div>Hello</div>;
+}
+
+function World() {
+	return <div>World</div>;
+}
+
+export { Hello, World };


### PR DESCRIPTION
## Changes

Updated component check so we can get completions after the dot in `<thing.>`. This allows notably to get completion for components under a namespace and also for the `Content` component when importing Markdown (either through a dynamic imports or through `Astro.glob`)

<img width="581" alt="image" src="https://user-images.githubusercontent.com/3019731/177870308-1ce4a287-f932-4e67-8183-14429a039fe1.png">

Additionally, this made it so I could remove some unused helper functions, codebase is now smaller!

## Testing

Added a test

## Docs

No docs needed
