### PR TITLE
Update exports for astro check

### DIFF
--- a/.changeset/nasty-ants-search.md
+++ b/.changeset/nasty-ants-search.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Updated exports for `astro check`

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -5,7 +5,7 @@ import { PluginHost, TypeScriptPlugin } from './plugins';
 export { DiagnosticSeverity } from 'vscode-languageserver-types';
 export { Diagnostic };
 
-interface GetDiagnosticsResult {
+export interface GetDiagnosticsResult {
 	filePath: string;
 	text: string;
 	diagnostics: Diagnostic[];

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -5,7 +5,7 @@ import { PluginHost, TypeScriptPlugin } from './plugins';
 export { DiagnosticSeverity } from 'vscode-languageserver-types';
 export { Diagnostic };
 
-export interface GetDiagnosticsResult {
+interface GetDiagnosticsResult {
 	filePath: string;
 	text: string;
 	diagnostics: Diagnostic[];

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -1,10 +1,11 @@
-import type { Diagnostic } from 'vscode-languageserver';
+import type { Diagnostic } from 'vscode-languageserver-types';
+import { ConfigManager, LSConfig } from './core/config';
 import { DocumentManager } from './core/documents';
-import { ConfigManager } from './core/config';
 import { PluginHost, TypeScriptPlugin } from './plugins';
-export { DiagnosticSeverity } from 'vscode-languageserver-protocol';
+export { DiagnosticSeverity } from 'vscode-languageserver-types';
+export { Diagnostic };
 
-interface GetDiagnosticsResult {
+export interface GetDiagnosticsResult {
 	filePath: string;
 	text: string;
 	diagnostics: Diagnostic[];
@@ -15,8 +16,12 @@ export class AstroCheck {
 	private configManager = new ConfigManager();
 	private pluginHost = new PluginHost(this.docManager);
 
-	constructor(workspacePath: string) {
+	constructor(workspacePath: string, options?: LSConfig) {
 		this.initialize(workspacePath);
+
+		if (options) {
+			this.configManager.updateGlobalConfig(options);
+		}
 	}
 
 	upsertDocument(doc: { text: string; uri: string }) {

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,1 +1,2 @@
-export { AstroCheck, DiagnosticSeverity } from './check';
+export { AstroCheck, Diagnostic, DiagnosticSeverity, GetDiagnosticsResult } from './check';
+export { offsetAt } from './core/documents';


### PR DESCRIPTION
## Changes

Some new exports are necessary from the language server for https://github.com/withastro/astro/pull/3906

Additionally, this add the ability to pass a config when initializing the AstroCheck, this will be useful to support config parameters that changes diagnostics (ex: `astro.typescript.allowArbitraryAttributes`)

## Testing

 N/A

## Docs

 N/A