### PR TITLE
Fix abusive warnings inside non-Astro workspaces

### DIFF
--- a/.changeset/friendly-ducks-joke.md
+++ b/.changeset/friendly-ducks-joke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixed many situations where the language server would warn abusively about not being able to find Astro

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -123,7 +123,10 @@ async function createLanguageService(
 
 	// Before Astro 1.0, JSX definitions were inside of the language-server instead of inside Astro
 	// TODO: Remove this and astro-jsx.d.ts in types when we consider having support for Astro < 1.0 unnecessary
-	if (astroVersion.major === 0 || astroVersion.full === '1.0.0-beta.0') {
+	if (
+		(astroVersion.major === 0 || astroVersion.full === '1.0.0-beta.0') &&
+		!astroVersion.full.startsWith('0.0.0-rc-') // 1.0.0's RC is considered to be 0.0.0, so we have to check for it
+	) {
 		const astroTSXFile = ts.sys.resolvePath(resolve(languageServerDirectory, '../types/astro-jsx.d.ts'));
 		scriptFileNames.push(astroTSXFile);
 
@@ -301,7 +304,7 @@ async function createLanguageService(
 			}
 
 			if (
-				astroVersion.major >= 1 &&
+				(astroVersion.major >= 1 || astroVersion.full.startsWith('0.0.0-rc-')) &&
 				astroVersion.full !== '1.0.0-beta.0' &&
 				!configJson.compilerOptions?.types.includes('astro/astro-jsx')
 			) {
@@ -366,7 +369,7 @@ async function createLanguageService(
 function getDefaultCompilerOptions(astroVersion: AstroVersion): ts.CompilerOptions {
 	const types = ['astro/env'];
 
-	if (astroVersion.major >= 1 && astroVersion.full !== '1.0.0-beta.0') {
+	if ((astroVersion.major >= 1 && astroVersion.full !== '1.0.0-beta.0') || astroVersion.full.startsWith('0.0.0-rc-')) {
 		types.push('astro/astro-jsx');
 	}
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -257,7 +257,7 @@ export function getUserAstroVersion(basePath: string): AstroVersion {
 		} catch (e) {
 			// If we still couldn't find it, it probably just doesn't exist
 			exist = false;
-			console.error(`${basePath} seems to be an Astro project, but we couldn't find Astro / Astro is not installed`);
+			console.error(`${basePath} seems to be an Astro project, but we couldn't find Astro or Astro is not installed`);
 		}
 	}
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -212,6 +212,27 @@ export function debounceThrottle<T extends (...args: any) => void>(fn: T, millis
 	return maybeCall as any;
 }
 
+/**
+ * Try to determine if a workspace could be an Astro project based on the content of `package.json`
+ */
+export function isAstroWorkspace(workspacePath: string): boolean {
+	try {
+		const astroPackageJson = require.resolve('./package.json', { paths: [workspacePath] });
+		const deps = Object.assign(
+			require(astroPackageJson).dependencies ?? {},
+			require(astroPackageJson).devDependencies ?? {}
+		);
+
+		if (Object.keys(deps).includes('astro')) {
+			return true;
+		}
+	} catch (e) {
+		return false;
+	}
+
+	return false;
+}
+
 export interface AstroVersion {
 	full: string;
 	major: number;
@@ -236,7 +257,7 @@ export function getUserAstroVersion(basePath: string): AstroVersion {
 		} catch (e) {
 			// If we still couldn't find it, it probably just doesn't exist
 			exist = false;
-			console.error(e);
+			console.error(`${basePath} seems to be an Astro project, but we couldn't find Astro / Astro is not installed`);
 		}
 	}
 

--- a/packages/language-server/test/fixtures/astro-workspace/package.json
+++ b/packages/language-server/test/fixtures/astro-workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "astro": "latest"
+  }
+}

--- a/packages/language-server/test/utils.test.ts
+++ b/packages/language-server/test/utils.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { isAstroWorkspace } from '../src/utils';
+
+describe('Utilities', () => {
+	it('isAstroWorkspace', () => {
+		const astroWorkspace = isAstroWorkspace('./test/fixtures/astro-workspace');
+		const notAstroWorkspace = isAstroWorkspace('./test/fixtures/not-astro-workspace');
+
+		expect(astroWorkspace).to.be.true;
+		expect(notAstroWorkspace).to.be.false;
+	});
+});


### PR DESCRIPTION
## Changes

Before checking if Astro is present in one of the opened workspaces, we now first check that it's actually an Astro workspace to see if our warning will be relevant or not

Fix https://github.com/withastro/language-tools/issues/296

## Testing

Tested manually + added a test for the utility

## Docs

N/A
