### PR TITLE
Fix notification fail when updating the Astro project's config

### DIFF
--- a/.changeset/violet-beds-begin.md
+++ b/.changeset/violet-beds-begin.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix changes to an Astro config file causing the extension to crash, fixed JSON modules not being updated properly


### PR DESCRIPTION
## Changes

Fixed the server restarting while trying to send a notification about an updated Astro config. Reloading when the Astro config is changed is unnecessary in our case as we don't do any special behaviour for it (`astro-preproces` when?)

Additionally, this PR adds `json` as a file format to send notifications about, which fix cache issues with JSON modules

## Testing

The client part of this notification is unfortunately currently untested, the server part is however partly tested

## Docs

N/A
