### PR TITLE
Fix completions not working inside script tags, fix abusive completions

### DIFF
--- a/.changeset/brown-taxis-look.md
+++ b/.changeset/brown-taxis-look.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix completions not working inside script tags, fix duplicate completions in some cases, added completions for the slot element

--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -134,6 +134,14 @@ export function isInComponentStartTag(html: HTMLDocument, offset: number): boole
 }
 
 /**
+ * Return if a given offset is inside the name of a tag
+ */
+export function isInTagName(html: HTMLDocument, offset: number): boolean {
+	const node = html.findNodeAt(offset);
+	return offset > node.start && offset < node.start + (node.tag?.length ?? 0);
+}
+
+/**
  * Return true if a specific node could be a component.
  * This is not a 100% sure test as it'll return false for any component that does not match the standard format for a component
  */

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -88,21 +88,16 @@ export class PluginHost {
 
 		if (html && ts) {
 			const inComponentStartTag = isInComponentStartTag(document.html, document.offsetAt(position));
-			if (!inComponentStartTag) {
+
+			// If the HTML plugin returned completions, it's highly likely that TS ones are duplicate
+			if (html.result.items.length > 0) {
 				ts.result.items = [];
 			}
 
-			// If the Astro plugin has completions for us, don't show TypeScript's as they're most likely duplicates
+			// Inside components, if the Astro plugin has completions we don't want the TS ones are they're duplicates
 			if (astro && astro.result.items.length > 0 && inComponentStartTag) {
 				ts.result.items = [];
 			}
-
-			ts.result.items = ts.result.items.map((item) => {
-				if (item.sortText != '-1') {
-					item.sortText = 'Z' + (item.sortText || '');
-				}
-				return item;
-			});
 		}
 
 		let flattenedCompletions = completions.flatMap((completion) => completion.result.items);

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -16,41 +16,8 @@ export const classListAttribute = newHTMLDataProvider('class-list', {
 	],
 });
 
-export const astroAttributes = newHTMLDataProvider('astro-attributes', {
+export const astroElements = newHTMLDataProvider('astro-elements', {
 	version: 1,
-	globalAttributes: [
-		{
-			name: 'set:html',
-			description: 'Inject unescaped HTML into this tag',
-			references: [
-				{
-					name: 'Astro reference',
-					url: 'https://docs.astro.build/en/reference/directives-reference/#sethtml',
-				},
-			],
-		},
-		{
-			name: 'set:text',
-			description: 'Inject escaped text into this tag',
-			references: [
-				{
-					name: 'Astro reference',
-					url: 'https://docs.astro.build/en/reference/directives-reference/#settext',
-				},
-			],
-		},
-		{
-			name: 'is:raw',
-			description: 'Instructs the Astro compiler to treat any children of this element as text',
-			valueSet: 'v',
-			references: [
-				{
-					name: 'Astro reference',
-					url: 'https://docs.astro.build/en/reference/directives-reference/#israw',
-				},
-			],
-		},
-	],
 	tags: [
 		{
 			name: 'script',
@@ -143,6 +110,43 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 							url: 'https://docs.astro.build/en/reference/directives-reference/#isinline',
 						},
 					],
+				},
+			],
+		},
+	],
+});
+
+export const astroAttributes = newHTMLDataProvider('astro-attributes', {
+	version: 1,
+	globalAttributes: [
+		{
+			name: 'set:html',
+			description: 'Inject unescaped HTML into this tag',
+			references: [
+				{
+					name: 'Astro reference',
+					url: 'https://docs.astro.build/en/reference/directives-reference/#sethtml',
+				},
+			],
+		},
+		{
+			name: 'set:text',
+			description: 'Inject escaped text into this tag',
+			references: [
+				{
+					name: 'Astro reference',
+					url: 'https://docs.astro.build/en/reference/directives-reference/#settext',
+				},
+			],
+		},
+		{
+			name: 'is:raw',
+			description: 'Instructs the Astro compiler to treat any children of this element as text',
+			valueSet: 'v',
+			references: [
+				{
+					name: 'Astro reference',
+					url: 'https://docs.astro.build/en/reference/directives-reference/#israw',
 				},
 			],
 		},

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -20,6 +20,30 @@ export const astroElements = newHTMLDataProvider('astro-elements', {
 	version: 1,
 	tags: [
 		{
+			name: 'slot',
+			description:
+				'The slot element is a placeholder for external HTML content, allowing you to inject (or “slot”) child elements from other files into your component template.',
+			references: [
+				{
+					name: 'Astro reference',
+					url: 'https://docs.astro.build/en/core-concepts/astro-components/#slots',
+				},
+			],
+			attributes: [
+				{
+					name: 'name',
+					description:
+						'The name attribute allows you to pass only HTML elements with the corresponding slot name into a slot’s location.',
+					references: [
+						{
+							name: 'Astro reference',
+							url: 'https://docs.astro.build/en/core-concepts/astro-components/#named-slots',
+						},
+					],
+				},
+			],
+		},
+		{
 			name: 'script',
 			attributes: [
 				{

--- a/packages/language-server/test/plugins/fixtures/pluginHostCompletions/AstroComponent.astro
+++ b/packages/language-server/test/plugins/fixtures/pluginHostCompletions/AstroComponent.astro
@@ -1,0 +1,1 @@
+<div>Hello from Astro</div>

--- a/packages/language-server/test/plugins/fixtures/pluginHostCompletions/VueComponent.vue
+++ b/packages/language-server/test/plugins/fixtures/pluginHostCompletions/VueComponent.vue
@@ -1,0 +1,3 @@
+<template>
+	<div>Hello from Vue</div>
+</template>

--- a/packages/language-server/test/plugins/fixtures/pluginHostCompletions/astroAndTS.astro
+++ b/packages/language-server/test/plugins/fixtures/pluginHostCompletions/astroAndTS.astro
@@ -1,0 +1,7 @@
+---
+import AstroComponent from "./AstroComponent.astro"
+import VueComponent from "./VueComponent.vue"
+---
+
+<AstroComponent ></AstroComponent>
+<VueComponent ></VueComponent>

--- a/packages/language-server/test/plugins/fixtures/tsconfig.json
+++ b/packages/language-server/test/plugins/fixtures/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+}

--- a/packages/language-server/test/utils.ts
+++ b/packages/language-server/test/utils.ts
@@ -22,7 +22,7 @@ export function createEnvironment(filePath: string, baseDir: string, pathPrefix?
 	return { document, docManager, configManager, fixturesDir: pathToUrl(fixtureDir) };
 }
 
-function openDocument(filePath: string, baseDir: string, docManager: DocumentManager) {
+export function openDocument(filePath: string, baseDir: string, docManager: DocumentManager) {
 	const path = join(baseDir, filePath);
 
 	if (!ts.sys.fileExists(path) || !path) {


### PR DESCRIPTION
## Changes

This PR does two things:
- Fix the completion filtering logic so that we don't accidentally filter completions inside script tags
- Update the completion filtering logic so that some duplicated completions are now fixed and some uninteresting completions are now filtered

Additionally, this PR remove some now unnecessary logic that manually added extensions to auto imports inside script tags.

## Testing

Added tests for filtering completions in the start of components

## Docs

N/A
