### PR TITLE
Fix extension failing to send a notification when `tsconfig.json` is updated

### DIFF
--- a/.changeset/hip-shirts-sneeze.md
+++ b/.changeset/hip-shirts-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix extension failing to send a notification when ts|jsconfig.json was updated

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -74,10 +74,10 @@ export async function activate(context: ExtensionContext) {
 			// language service whenever the config changes. In the future the server will handle this by itself, but for now
 			// we can't update the snapshot for those files without causing an error since the client tries to
 			// reload and send the notification at the same time
+			const fileName = params.document.fileName.split(/\/|\\/).pop() ?? params.document.fileName;
 			if (
 				['json', 'jsonc'].includes(params.document.languageId) &&
-				params.document.fileName.startsWith('tsconfig') &&
-				params.document.fileName.startsWith('jsconfig')
+				(fileName.startsWith('tsconfig') || fileName.startsWith('jsconfig'))
 			) {
 				return;
 			}


### PR DESCRIPTION
## Changes

The check in https://github.com/withastro/language-tools/pull/346 wasn't written properly and was never true, oops. This issue is annoying to test because it doesn't happen in dev

## Testing

Tested manually

## Docs

N/A
