### PR TITLE
Add a debug command to show the current document's TSX output

### DIFF
--- a/.changeset/little-ties-matter.md
+++ b/.changeset/little-ties-matter.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Added a debug command to show the currently opened document's TSX output

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -44,6 +44,8 @@ import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import { DefinitionsProviderImpl } from './features/DefinitionsProvider';
 import { InlayHintsProviderImpl } from './features/InlayHintsProvider';
 import { FormattingProviderImpl } from './features/FormattingProvider';
+import astro2tsx, { Astro2TSXResult } from './astro2tsx';
+import { classNameFromFilename } from './snapshots/utils';
 
 export class TypeScriptPlugin implements Plugin {
 	__name = 'typescript';
@@ -237,6 +239,10 @@ export class TypeScriptPlugin implements Plugin {
 		cancellationToken?: CancellationToken
 	): Promise<SignatureHelp | null> {
 		return this.signatureHelpProvider.getSignatureHelp(document, position, context, cancellationToken);
+	}
+
+	getTSXForDocument(document: AstroDocument): Astro2TSXResult {
+		return astro2tsx(document.getText(), classNameFromFilename(document.getURL()));
 	}
 
 	private async featureEnabled(document: AstroDocument, feature: keyof LSTypescriptConfig) {

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -15,7 +15,7 @@ function escapeTemplateLiteralContent(content: string) {
 	return content.replace(/`/g, '\\`');
 }
 
-interface Astro2TSXResult {
+export interface Astro2TSXResult {
 	code: string;
 }
 

--- a/packages/language-server/src/plugins/typescript/snapshots/utils.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/utils.ts
@@ -89,7 +89,7 @@ export function createFromFrameworkFilePath(filePath: string, framework: Framewo
 	return new TypeScriptDocumentSnapshot(0, filePath, code, ts.ScriptKind.TSX);
 }
 
-function classNameFromFilename(filename: string): string {
+export function classNameFromFilename(filename: string): string {
 	const url = URI.parse(filename);
 	const withoutExtensions = Utils.basename(url).slice(0, -Utils.extname(url).length);
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -25,8 +25,6 @@ import { AstroDocument } from './core/documents';
 import { getSemanticTokenLegend } from './plugins/typescript/utils';
 import { sortImportKind } from './plugins/typescript/features/CodeActionsProvider';
 import { LSConfig } from './core/config';
-import astro2tsx from './plugins/typescript/astro2tsx';
-import { classNameFromFilename } from './plugins/typescript/snapshots/utils';
 
 const TagCloseRequest: vscode.RequestType<vscode.TextDocumentPositionParams, string | null, any> =
 	new vscode.RequestType('html/tag');

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -77,6 +77,10 @@
       {
         "command": "astro.restartLanguageServer",
         "title": "Astro: Restart Language Server"
+      },
+      {
+        "command": "astro.showTSXOutput",
+        "title": "Astro: Debug: Show TSX Output"
       }
     ],
     "configuration": {

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,4 +1,13 @@
-import { window, commands, workspace, ExtensionContext, TextDocument, Position, TextDocumentChangeEvent } from 'vscode';
+import {
+	window,
+	commands,
+	workspace,
+	ExtensionContext,
+	TextDocument,
+	Position,
+	TextDocumentChangeEvent,
+	ViewColumn,
+} from 'vscode';
 import {
 	LanguageClient,
 	RequestType,
@@ -101,6 +110,23 @@ export async function activate(context: ExtensionContext) {
 	context.subscriptions.push(
 		commands.registerCommand('astro.restartLanguageServer', async () => {
 			await restartClient(true);
+		}),
+		commands.registerCommand('astro.showTSXOutput', async () => {
+			const content = await getLSClient().sendRequest<string | undefined>(
+				'$/getTSXOutput',
+				window.activeTextEditor?.document.uri.toString()
+			);
+
+			if (content) {
+				const document = await workspace.openTextDocument({ content, language: 'typescriptreact' });
+
+				await window.showTextDocument(document, {
+					preview: true,
+					viewColumn: ViewColumn.Beside,
+				});
+			} else {
+				window.showErrorMessage("Could not open the current document's TSX output");
+			}
 		})
 	);
 


### PR DESCRIPTION
## Changes

Gone are the days of adding a `console.log` to `astro2tsx`. We now have a convenient command to show the output. Will be very convenient for helping people out

<img width="1423" alt="image" src="https://user-images.githubusercontent.com/3019731/181774522-932be0ea-3008-4e3b-a2f0-2cc6360d6414.png">

## Testing

N/A, debug command

## Docs

Commands are self-documented
