### PR TITLE
Don't use TypeScript's types field to add Astro types

### DIFF
--- a/.changeset/twelve-timers-build.md
+++ b/.changeset/twelve-timers-build.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': minor
+---
+
+Changed how Astro's types are consumed to avoid making type acquisition explicit inside Astro files


### PR DESCRIPTION
## Changes

This makes it so we don't use `tsconfig.json`'s `types` field to add Astro's types, instead the files are added to the project directly. This makes it so `types` is no longer explicit by default even if the users has `types` unset in their config

Fix https://github.com/withastro/language-tools/issues/345

## Testing

Tests still pass!

## Docs

N/A
