### PR TITLE
Fix tsconfig.json not loading properly on Windows

### DIFF
--- a/.changeset/ninety-rice-bow.md
+++ b/.changeset/ninety-rice-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix `tsconfig.json` not loading properly in certain contexts on Windows

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from 'vscode-languageserver-types';
 import { ConfigManager, LSConfig } from './core/config';
 import { DocumentManager } from './core/documents';
 import { PluginHost, TypeScriptPlugin } from './plugins';
+import { LanguageServiceManager } from './plugins/typescript/LanguageServiceManager';
 export { DiagnosticSeverity } from 'vscode-languageserver-types';
 export { Diagnostic };
 
@@ -51,7 +52,8 @@ export class AstroCheck {
 	}
 
 	private initialize(workspacePath: string) {
-		this.pluginHost.registerPlugin(new TypeScriptPlugin(this.docManager, this.configManager, [workspacePath]));
+		const languageServiceManager = new LanguageServiceManager(this.docManager, [workspacePath], this.configManager);
+		this.pluginHost.registerPlugin(new TypeScriptPlugin(this.configManager, languageServiceManager));
 	}
 
 	private async getDiagnosticsForFile(uri: string) {

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -3,6 +3,7 @@ import { ConfigManager, LSConfig } from './core/config';
 import { DocumentManager } from './core/documents';
 import { PluginHost, TypeScriptPlugin } from './plugins';
 import { LanguageServiceManager } from './plugins/typescript/LanguageServiceManager';
+import { normalizeUri } from './utils';
 export { DiagnosticSeverity } from 'vscode-languageserver-types';
 export { Diagnostic };
 
@@ -52,7 +53,11 @@ export class AstroCheck {
 	}
 
 	private initialize(workspacePath: string) {
-		const languageServiceManager = new LanguageServiceManager(this.docManager, [workspacePath], this.configManager);
+		const languageServiceManager = new LanguageServiceManager(
+			this.docManager,
+			[normalizeUri(workspacePath)],
+			this.configManager
+		);
 		this.pluginHost.registerPlugin(new TypeScriptPlugin(this.configManager, languageServiceManager));
 	}
 

--- a/packages/language-server/src/plugins/astro/AstroPlugin.ts
+++ b/packages/language-server/src/plugins/astro/AstroPlugin.ts
@@ -13,9 +13,9 @@ export class AstroPlugin implements Plugin {
 
 	private readonly completionProvider: CompletionsProviderImpl;
 
-	constructor(docManager: DocumentManager, configManager: ConfigManager, workspaceUris: string[]) {
+	constructor(configManager: ConfigManager, languageServiceManager: LanguageServiceManager) {
 		this.configManager = configManager;
-		this.languageServiceManager = new LanguageServiceManager(docManager, workspaceUris, configManager);
+		this.languageServiceManager = languageServiceManager;
 
 		this.completionProvider = new CompletionsProviderImpl(this.languageServiceManager);
 	}

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -29,14 +29,7 @@ import { DiagnosticsProviderImpl } from './features/DiagnosticsProvider';
 import { HoverProviderImpl } from './features/HoverProvider';
 import { SignatureHelpProviderImpl } from './features/SignatureHelpProvider';
 import { LanguageServiceManager } from './LanguageServiceManager';
-import {
-	convertRange,
-	convertToLocationRange,
-	ensureRealFilePath,
-	getScriptKindFromFileName,
-	getScriptTagSnapshot,
-	toVirtualAstroFilePath,
-} from './utils';
+import { convertToLocationRange, ensureRealFilePath, getScriptKindFromFileName, toVirtualAstroFilePath } from './utils';
 import { DocumentSymbolsProviderImpl } from './features/DocumentSymbolsProvider';
 import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
@@ -65,9 +58,9 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly foldingRangesProvider: FoldingRangesProviderImpl;
 	private readonly formattingProvider: FormattingProviderImpl;
 
-	constructor(docManager: DocumentManager, configManager: ConfigManager, workspaceUris: string[]) {
+	constructor(configManager: ConfigManager, languageServiceManager: LanguageServiceManager) {
 		this.configManager = configManager;
-		this.languageServiceManager = new LanguageServiceManager(docManager, workspaceUris, configManager);
+		this.languageServiceManager = languageServiceManager;
 
 		this.codeActionsProvider = new CodeActionsProviderImpl(this.languageServiceManager, this.configManager);
 		this.completionProvider = new CompletionsProviderImpl(this.languageServiceManager, this.configManager);

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -20,11 +20,12 @@ import { HTMLPlugin } from './plugins/html/HTMLPlugin';
 import { AppCompletionItem } from './plugins/interfaces';
 import { PluginHost } from './plugins/PluginHost';
 import { TypeScriptPlugin } from './plugins';
-import { debounceThrottle, getUserAstroVersion, isAstroWorkspace, urlToPath } from './utils';
+import { debounceThrottle, getUserAstroVersion, isAstroWorkspace, normalizeUri, urlToPath } from './utils';
 import { AstroDocument } from './core/documents';
 import { getSemanticTokenLegend } from './plugins/typescript/utils';
 import { sortImportKind } from './plugins/typescript/features/CodeActionsProvider';
 import { LSConfig } from './core/config';
+import { LanguageServiceManager } from './plugins/typescript/LanguageServiceManager';
 
 const TagCloseRequest: vscode.RequestType<vscode.TextDocumentPositionParams, string | null, any> =
 	new vscode.RequestType('html/tag');
@@ -74,8 +75,14 @@ export function startLanguageServer(connection: vscode.Connection) {
 
 		// We don't currently support running the TypeScript and Astro plugin in the browser
 		if (params.initializationOptions.environment !== 'browser') {
-			typescriptPlugin = new TypeScriptPlugin(documentManager, configManager, workspaceUris);
-			pluginHost.registerPlugin(new AstroPlugin(documentManager, configManager, workspaceUris));
+			const languageServiceManager = new LanguageServiceManager(
+				documentManager,
+				workspaceUris.map(normalizeUri),
+				configManager
+			);
+
+			typescriptPlugin = new TypeScriptPlugin(configManager, languageServiceManager);
+			pluginHost.registerPlugin(new AstroPlugin(configManager, languageServiceManager));
 			pluginHost.registerPlugin(typescriptPlugin);
 		}
 

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -6,6 +6,7 @@ import { CompletionItem, Location, LocationLink, Position, Range, TextDocumentIt
 import { ConfigManager } from '../../src/core/config';
 import { AstroDocument, DocumentManager } from '../../src/core/documents';
 import { AstroPlugin, HTMLPlugin, PluginHost, PluginHostConfig, TypeScriptPlugin } from '../../src/plugins';
+import { LanguageServiceManager } from '../../src/plugins/typescript/LanguageServiceManager';
 import { openDocument } from '../utils';
 
 describe('PluginHost', () => {
@@ -69,9 +70,11 @@ describe('PluginHost', () => {
 			const docManager = new DocumentManager((document) => new AstroDocument(document.uri, document.text));
 			const pluginHost = new PluginHost(docManager);
 
+			const languageServiceManager = new LanguageServiceManager(docManager, [path], configManager);
+
 			pluginHost.registerPlugin(new HTMLPlugin(configManager));
-			pluginHost.registerPlugin(new AstroPlugin(docManager, configManager, [path]));
-			pluginHost.registerPlugin(new TypeScriptPlugin(docManager, configManager, [path]));
+			pluginHost.registerPlugin(new AstroPlugin(configManager, languageServiceManager));
+			pluginHost.registerPlugin(new TypeScriptPlugin(configManager, languageServiceManager));
 
 			const document = openDocument(filePath, path, docManager);
 

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { createEnvironment } from '../../utils';
 import { TypeScriptPlugin } from '../../../src/plugins';
 import { CodeActionKind, Position, Range } from 'vscode-languageserver-types';
+import { LanguageServiceManager } from '../../../src/plugins/typescript/LanguageServiceManager';
 
 // This file only contain basic tests to ensure that the TypeScript plugin does in fact calls the proper methods
 // and returns something. For validity tests, please check the providers themselves in the 'features' folder
@@ -9,7 +10,10 @@ import { CodeActionKind, Position, Range } from 'vscode-languageserver-types';
 describe('TypeScript Plugin', () => {
 	function setup(filePath: string) {
 		const env = createEnvironment(filePath, 'typescript');
-		const plugin = new TypeScriptPlugin(env.docManager, env.configManager, [env.fixturesDir]);
+		const plugin = new TypeScriptPlugin(
+			env.configManager,
+			new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager)
+		);
 
 		return {
 			...env,

--- a/packages/language-server/test/plugins/typescript/features/misc/alias.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/misc/alias.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { DiagnosticsProviderImpl } from '../../../../../src/plugins/typescript/features/DiagnosticsProvider';
+import { LanguageServiceManager } from '../../../../../src/plugins/typescript/LanguageServiceManager';
+import { createEnvironment } from '../../../../utils';
+
+describe('TypeScript Plugin#Support Aliases', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'misc');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager);
+		const provider = new DiagnosticsProviderImpl(languageServiceManager);
+
+		return {
+			...env,
+			provider,
+		};
+	}
+
+	it('can properly imports using tsconfig.json aliases', async () => {
+		const { provider, document } = setup('alias.astro');
+
+		const diagnostics = await provider.getDiagnostics(document);
+
+		expect(diagnostics[0].message).to.include("Property 'wow' is missing in type '{}' but required in type 'Props'.");
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/misc/alias.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/misc/alias.astro
@@ -1,0 +1,5 @@
+---
+	import BehindAnAlias from "$components/BehindAnAlias.astro";
+---
+
+<BehindAnAlias></BehindAnAlias>

--- a/packages/language-server/test/plugins/typescript/fixtures/misc/components/BehindAnAlias.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/misc/components/BehindAnAlias.astro
@@ -1,0 +1,5 @@
+---
+	export interface Props {
+		wow: string
+	}
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/fixtures/tsconfig.json
@@ -5,7 +5,9 @@
       "baseUrl": ".",
       /**For testing import json file*/
       "resolveJsonModule": true,
-      "noEmit": true
+      "paths": {
+        "$components/*": ["misc/components/*"]
+      }
     },
     "exclude": [
       /**For testing exclude */


### PR DESCRIPTION
## Changes

- Fix workspaces paths not being normalized, which lead to `tsconfig.json` not loading properly on Windows due to file URLs being wrong
- Small refactor to avoid making two LanguageServiceManager

Fix https://github.com/withastro/language-tools/issues/364

## Testing

Added a test for aliases, updated tests for refactors

## Docs

N/A
