### PR TITLE
[feature] yarn berry support (#370)

### DIFF
--- a/.changeset/healthy-parents-fly.md
+++ b/.changeset/healthy-parents-fly.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Added settings to configure the path to the language server and the runtime to use to run it

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-this-alias': 'off',
-    'no-console': ['error', { allow: ['warn', 'error'] }],
+    'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error'],
     'prefer-const': 'off',

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -87,6 +87,16 @@
       "type": "object",
       "title": "Astro configuration",
       "properties": {
+        "astro.language-server.ls-path": {
+          "scope": "resource",
+          "type": "string",
+          "title": "Language Server: Path"
+        },
+        "astro.language-server.runtime": {
+          "scope": "resource",
+          "type": "string",
+          "title": "Language Server: Runtime"
+        },
         "astro.trace.server": {
           "scope": "window",
           "type": "string",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -88,14 +88,16 @@
       "title": "Astro configuration",
       "properties": {
         "astro.language-server.ls-path": {
-          "scope": "resource",
+          "scope": "application",
           "type": "string",
-          "title": "Language Server: Path"
+          "title": "Language Server: Path",
+          "description": "Path to the language server executable. You won't need this in most cases, set this only when needing a specific version of the language server"
         },
         "astro.language-server.runtime": {
-          "scope": "resource",
+          "scope": "application",
           "type": "string",
-          "title": "Language Server: Runtime"
+          "title": "Language Server: Runtime",
+          "description": "Path to the node executable used to execute the language server. You won't need this in most cases"
         },
         "astro.trace.server": {
           "scope": "window",

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
 	window,
 	commands,
@@ -23,7 +24,19 @@ const TagCloseRequest: RequestType<TextDocumentPositionParams, string, any> = ne
 let client: LanguageClient;
 
 export async function activate(context: ExtensionContext) {
-	const serverModule = require.resolve('@astrojs/language-server/bin/nodeServer.js');
+	const runtimeConfig = workspace.getConfiguration("astro.language-server");
+
+	const { workspaceFolders } = workspace;
+	const rootPath = workspaceFolders?.[0].uri.fsPath;
+
+	let lsPath = runtimeConfig.get<string>("ls-path");
+	if (typeof lsPath === 'string' && lsPath.trim() !== '' && typeof rootPath === 'string') {
+		lsPath = path.isAbsolute(lsPath) ? lsPath : path.join(rootPath, lsPath);
+	} else {
+		lsPath = undefined;
+	}
+
+	const serverModule = require.resolve(lsPath ?? '@astrojs/language-server/bin/nodeServer.js');
 
 	const port = 6040;
 	const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
@@ -36,6 +49,12 @@ export async function activate(context: ExtensionContext) {
 			options: debugOptions,
 		},
 	};
+
+	const serverRuntime = runtimeConfig.get<string>('runtime');
+	if (serverRuntime) {
+		serverOptions.run.runtime = serverRuntime;
+		serverOptions.debug.runtime = serverRuntime;
+	}
 
 	const clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'astro' }],

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -24,14 +24,15 @@ const TagCloseRequest: RequestType<TextDocumentPositionParams, string, any> = ne
 let client: LanguageClient;
 
 export async function activate(context: ExtensionContext) {
-	const runtimeConfig = workspace.getConfiguration("astro.language-server");
+	const runtimeConfig = workspace.getConfiguration('astro.language-server');
 
 	const { workspaceFolders } = workspace;
 	const rootPath = workspaceFolders?.[0].uri.fsPath;
 
-	let lsPath = runtimeConfig.get<string>("ls-path");
+	let lsPath = runtimeConfig.get<string>('ls-path');
 	if (typeof lsPath === 'string' && lsPath.trim() !== '' && typeof rootPath === 'string') {
 		lsPath = path.isAbsolute(lsPath) ? lsPath : path.join(rootPath, lsPath);
+		console.info(`Using language server at ${lsPath}`);
 	} else {
 		lsPath = undefined;
 	}
@@ -54,6 +55,7 @@ export async function activate(context: ExtensionContext) {
 	if (serverRuntime) {
 		serverOptions.run.runtime = serverRuntime;
 		serverOptions.debug.runtime = serverRuntime;
+		console.info(`Using ${serverRuntime} as runtime`);
 	}
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
closes #370 

## Changes

- adds and implements `astro.langauge-server.ls-path` setting
- adds and implements `astro.language-server.runtime` setting

## Testing

Ran locally with the instructions from `./CONTRIBUTING.md` inside a project with PnP enabled

## Docs

No docs were updated, doesn't look like the settings are necessary documented anywhere inside the codebase
