### PR TITLE
Fix language server when not init options were passed

### DIFF
--- a/.changeset/seven-cows-sit.md
+++ b/.changeset/seven-cows-sit.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix language server not working when no initlizationOptions were passed

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -41,6 +41,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 	let hasConfigurationCapability = false;
 
 	connection.onInitialize((params: vscode.InitializeParams) => {
+		const environment: 'node' | 'browser' = params.initializationOptions?.environment ?? 'node';
 		const workspaceUris = params.workspaceFolders?.map((folder) => folder.uri.toString()) ?? [params.rootUri ?? ''];
 
 		workspaceUris.forEach((uri) => {
@@ -73,7 +74,7 @@ export function startLanguageServer(connection: vscode.Connection) {
 		pluginHost.registerPlugin(new CSSPlugin(configManager));
 
 		// We don't currently support running the TypeScript and Astro plugin in the browser
-		if (params.initializationOptions.environment !== 'browser') {
+		if (environment === 'node') {
 			const languageServiceManager = new LanguageServiceManager(
 				documentManager,
 				workspaceUris.map(normalizeUri),


### PR DESCRIPTION
## Changes

Due to a missing `?`, the language server failed to open whenever no init params were passed at all. This fix this

Fix https://github.com/withastro/language-tools/issues/369

## Testing

Tested manually

## Docs

N/A. Plan to write docs about init options in the future
