### PR TITLE
Automatically type `Astro.props` using the Props interface when available

### DIFF
--- a/.changeset/stale-geese-jam.md
+++ b/.changeset/stale-geese-jam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': minor
+---
+
+Automatically type `Astro.props` using the Props interface when available

--- a/packages/language-server/src/plugins/typescript/astro2tsx.ts
+++ b/packages/language-server/src/plugins/typescript/astro2tsx.ts
@@ -3,12 +3,28 @@ import { parseAstro } from '../../core/documents/parseAstro';
 
 function addProps(content: string, className: string): string {
 	let defaultExportType = 'Record<string, any>';
+	let shouldAddGlobal = false;
+	let astroGlobal = "type AstroGlobal = import('astro').AstroGlobal";
+	const astroGlobalConstDef = `
+	/**
+	 * Astro global available in all contexts in .astro files
+	 *
+	 * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
+	 */
+	declare const Astro: Readonly<AstroGlobal>;
+	`;
 
 	if (/(interface|type) Props/.test(content)) {
 		defaultExportType = 'Props';
+		shouldAddGlobal = true;
+		astroGlobal += ' & { props: Props }';
 	}
 
-	return EOL + `export default function ${className}__AstroComponent_(_props: ${defaultExportType}): any {}`;
+	return (
+		EOL +
+		(shouldAddGlobal ? astroGlobal + EOL + astroGlobalConstDef : '') +
+		`export default function ${className}__AstroComponent_(_props: ${defaultExportType}): any {}`
+	);
 }
 
 function escapeTemplateLiteralContent(content: string) {

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -184,5 +184,21 @@ describe('TypeScript Plugin#DiagnosticsProvider', () => {
 			const diagnostics = await provider.getDiagnostics(document);
 			expect(diagnostics).to.be.empty;
 		});
+
+		it('types Astro.props using the Props interface when available', async () => {
+			const { provider, document } = setup('propsTypes.astro');
+
+			const diagnostics = await provider.getDiagnostics(document);
+			expect(diagnostics).to.deep.equal([
+				{
+					code: 2322,
+					message: "Type 'number' is not assignable to type 'string'.",
+					range: Range.create(7, 0, 7, 8),
+					severity: DiagnosticSeverity.Error,
+					source: 'ts',
+					tags: [],
+				},
+			]);
+		});
 	});
 });

--- a/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
@@ -73,48 +73,6 @@ describe('TypeScript Plugin#SemanticTokenProvider', () => {
 				type: TokenType.method,
 				modifiers: [TokenModifier.defaultLibrary],
 			},
-			{
-				line: 6,
-				character: 11,
-				length: 'Props'.length,
-				type: TokenType.interface,
-				modifiers: [TokenModifier.declaration],
-			},
-			{
-				line: 7,
-				character: 2,
-				length: 'hello'.length,
-				type: TokenType.property,
-				modifiers: [TokenModifier.declaration],
-			},
-			{
-				line: 10,
-				character: 9,
-				length: 'hello'.length,
-				type: TokenType.variable,
-				modifiers: [TokenModifier.declaration, TokenModifier.readonly],
-			},
-			{
-				line: 10,
-				character: 19,
-				length: 'Astro'.length,
-				type: TokenType.type,
-				modifiers: [TokenModifier.readonly],
-			},
-			{
-				line: 10,
-				character: 25,
-				length: 'props'.length,
-				type: TokenType.property,
-				modifiers: [],
-			},
-			{
-				line: 10,
-				character: 34,
-				length: 'Props'.length,
-				type: TokenType.interface,
-				modifiers: [],
-			},
 		]);
 
 		expect(semanticTokens?.data).to.deep.equal(expectedTokens.data);

--- a/packages/language-server/test/plugins/typescript/fixtures/diagnostics/propsTypes.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/diagnostics/propsTypes.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+	greeting: string
+}
+
+let { greeting } = Astro.props
+
+greeting = 0
+greeting;
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/semanticTokens/frontmatter.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/semanticTokens/frontmatter.astro
@@ -3,10 +3,4 @@
 	var variable = "Astro"
 
 	console.log()
-
-	interface Props {
-		hello: string
-	}
-
-	const { hello } = Astro.props as Props
 ---


### PR DESCRIPTION
## Changes

When a `Props` interface/type is available, we'll now type `Astro.props` on the Astro global with it automatically. The type is not strict, it's `Record<string, any> & Props`. We could make it strict, but it would require to copy the JSDoc definition of `Astro.props` in the language-server (and in the future, the compiler), which is fine but a bit annoying

## Testing

Added a test

## Docs

N/A
