### PR TITLE
Fix regression related to completions for HTML attributes

### DIFF
--- a/.changeset/spotty-bulldogs-tell.md
+++ b/.changeset/spotty-bulldogs-tell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix completions for HTML attributes not working anymore since 0.20.3

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -115,8 +115,7 @@ export class HTMLPlugin implements Plugin {
 		const results =
 			inComponentTag && !inTagName
 				? removeDataAttrCompletion(this.attributeOnlyLang.doComplete(document, position, html).items)
-				: // We filter items with no documentation to prevent duplicates with our own defined script and style tags
-				  this.lang.doComplete(document, position, html).items.filter((item) => item.documentation !== undefined);
+				: this.lang.doComplete(document, position, html).items.filter(isNoAddedTagWithNoDocumentation);
 
 		const langCompletions = inComponentTag ? [] : this.getLangCompletions(results);
 
@@ -125,6 +124,12 @@ export class HTMLPlugin implements Plugin {
 			// Emmet completions change on every keystroke, so they are never complete
 			emmetResults.items.length > 0
 		);
+
+		// Filter script and style completions with no documentation to prevent duplicates
+		// due to our added definitions for those tags
+		function isNoAddedTagWithNoDocumentation(item: CompletionItem) {
+			return !(['script', 'style'].includes(item.label) && item.documentation === undefined);
+		}
 	}
 
 	getFoldingRanges(document: AstroDocument): FoldingRange[] | null {

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -23,6 +23,13 @@ describe('HTML Plugin', () => {
 			expect(completions, 'Expected completions to not be empty').to.not.be.undefined;
 		});
 
+		it('for html attributes', async () => {
+			const { plugin, document } = setup('<a aria-autocomplete=""');
+
+			const completions = await plugin.getCompletions(document, Position.create(0, 21));
+			expect(completions?.items).to.not.be.empty;
+		});
+
 		it('for style lang in style tags', async () => {
 			const { plugin, document } = setup('<sty');
 


### PR DESCRIPTION
## Changes

Fixed completions for HTML attributes not working anymore since 0.20.3. Attributes have no description, so we were filtering them out accidentally We didn't have a test for this, so we didn't catch that regression, unfortunately.

## Testing

Added a test

## Docs

N/A
