### PR TITLE
Fix highlighting regression since VS Code 1.70

### DIFF
--- a/.changeset/olive-books-sing.md
+++ b/.changeset/olive-books-sing.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix a regression with how VS Code handle unbalanced brackets since 1.70

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -295,7 +295,14 @@
           "source.ts": "typescript",
           "source.json": "json",
           "source.tsx": "typescriptreact"
-        }
+        },
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "meta.brace.angle",
+          "punctuation.definition.tag"
+        ]
       },
       {
         "scopeName": "text.html.markdown.astro",


### PR DESCRIPTION
## Changes

Due to a bug in VS Code's TextMate engine where unbalancedBracketScopes are not respected inside embedded languages and https://github.com/microsoft/vscode/pull/151705, syntax highlighting doesn't work correctly in VS Code 1.70 inside Astro files inside expressions. This workaround this issue by manually adding TypeScript's unbalancedBracketScopes to our grammar definition

This workaround was also done by the Vue and Svelte teams to their respective grammar, so it should be safe to do for us too

## Testing

Tested manually as we can't test this in our suite since it happens inside an embedded language

## Docs

N/A
