### PR TITLE
Load settings from the Prettier VS Code extension when it's available

### DIFF
--- a/.changeset/neat-turtles-sleep.md
+++ b/.changeset/neat-turtles-sleep.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': minor
+---
+
+Load settings from the Prettier VS Code extension when available

--- a/.changeset/neat-turtles-sleep.md
+++ b/.changeset/neat-turtles-sleep.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/language-server': minor
+'@astrojs/language-server': patch
 ---
 
 Load settings from the Prettier VS Code extension when available

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -113,6 +113,12 @@ export class ConfigManager {
 		};
 	}
 
+	async getPrettierVSConfig(document: TextDocument): Promise<Record<string, any>> {
+		const prettierVSConfig = (await this.getConfig<Record<string, any>>('prettier', document.uri)) ?? {};
+
+		return prettierVSConfig;
+	}
+
 	async getTSFormatConfig(document: TextDocument, vscodeOptions?: FormattingOptions): Promise<FormatCodeSettings> {
 		const formatConfig = (await this.getConfig<FormatCodeSettings>('typescript.format', document.uri)) ?? {};
 


### PR DESCRIPTION
## Changes

When available, we'll now load settings from the Prettier VS Code extension, (ex: `prettier.semi`). Our settings cascade matches the one of the Prettier VS Code extension in that if a Prettier config file is available, we'll completely ignore everything else. This should lead to a consistent experience between all files no matter if they use the Astro extension to format or the Prettier VS Code extension

Fix https://github.com/withastro/language-tools/issues/390

## Testing

Tested manually in addition to current tests

## Docs

N/A
