### PR TITLE
Dont use workspace config when not supported

### DIFF
--- a/.changeset/fluffy-dolls-sell.md
+++ b/.changeset/fluffy-dolls-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Don't use `workspace/configuration` on clients that don't support it

--- a/packages/language-server/src/core/config/ConfigManager.ts
+++ b/packages/language-server/src/core/config/ConfigManager.ts
@@ -60,14 +60,9 @@ export class ConfigManager {
 
 	// If set to true, the next time we need a TypeScript language service, we'll rebuild it so it gets the new config
 	public shouldRefreshTSServices = false;
-
 	private isTrusted = true;
 
-	private connection: Connection | undefined;
-
-	constructor(connection?: Connection) {
-		this.connection = connection;
-	}
+	constructor(private connection?: Connection, private hasConfigurationCapability?: boolean) {}
 
 	updateConfig() {
 		// Reset all cached document settings
@@ -80,7 +75,7 @@ export class ConfigManager {
 	}
 
 	async getConfig<T>(section: string, scopeUri: string): Promise<T | Record<string, any>> {
-		if (!this.connection) {
+		if (!this.connection || !this.hasConfigurationCapability) {
 			return get<T>(this.globalConfig, section) ?? {};
 		}
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -40,8 +40,8 @@ export function startLanguageServer(connection: vscode.Connection, env: RuntimeE
 	// Create our managers
 	const documentManager = new DocumentManager();
 	const pluginHost = new PluginHost(documentManager);
-	const configManager = new ConfigManager(connection);
 
+	let configManager: ConfigManager;
 	let typescriptPlugin: TypeScriptPlugin = undefined as any;
 	let hasConfigurationCapability = false;
 
@@ -68,6 +68,7 @@ export function startLanguageServer(connection: vscode.Connection, env: RuntimeE
 		});
 
 		hasConfigurationCapability = !!(params.capabilities.workspace && !!params.capabilities.workspace.configuration);
+		configManager = new ConfigManager(connection, hasConfigurationCapability);
 
 		pluginHost.initialize({
 			filterIncompleteCompletions: !params.initializationOptions?.dontFilterIncompleteCompletions,


### PR DESCRIPTION
## Changes

We were wrongfully still using `workspace.getConfiguration` even on clients that didn't announce supporting `workspace/configuration`. This fix that

## Testing

Tested manually, we don't have a test setup for this right now (and all common clients support `workspace/configuration`

## Docs

N/A
