### PR TITLE
Fix <> inside the frontmatter messing with the HTML parsing

### DIFF
--- a/.changeset/gentle-spies-flash.md
+++ b/.changeset/gentle-spies-flash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix <> inside the frontmatter preventing certain HTML features from working inside the template

--- a/packages/language-server/src/core/documents/AstroDocument.ts
+++ b/packages/language-server/src/core/documents/AstroDocument.ts
@@ -20,7 +20,7 @@ export class AstroDocument extends WritableDocument {
 
 	private updateDocInfo() {
 		this.astroMeta = parseAstro(this.content);
-		this.html = parseHtml(this.content);
+		this.html = parseHtml(this.content, this.astroMeta);
 		this.styleTags = extractStyleTags(this.content, this.html);
 		this.scriptTags = extractScriptTags(this.content, this.html);
 	}

--- a/packages/language-server/src/core/documents/utils.ts
+++ b/packages/language-server/src/core/documents/utils.ts
@@ -1,7 +1,6 @@
 import { Position, Range } from 'vscode-languageserver';
 import type { HTMLDocument, Node } from 'vscode-html-languageservice';
 import { clamp, isInRange } from '../../utils';
-import { parseHtml } from './parseHtml';
 
 export interface TagInformation {
 	content: string;
@@ -28,8 +27,8 @@ export function* walk(node: Node): Generator<Node, void, unknown> {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
-function extractTags(text: string, tag: 'script' | 'style', html?: HTMLDocument): TagInformation[] {
-	const rootNodes = html?.roots || parseHtml(text).roots;
+function extractTags(text: string, tag: 'script' | 'style', html: HTMLDocument): TagInformation[] {
+	const rootNodes = html.roots;
 	const matchedNodes = rootNodes.filter((node) => node.tag === tag);
 
 	if (tag === 'style' && !matchedNodes.length && rootNodes.length) {
@@ -75,7 +74,7 @@ function extractTags(text: string, tag: 'script' | 'style', html?: HTMLDocument)
 	}
 }
 
-export function extractStyleTags(source: string, html?: HTMLDocument): TagInformation[] {
+export function extractStyleTags(source: string, html: HTMLDocument): TagInformation[] {
 	const styles = extractTags(source, 'style', html);
 
 	if (!styles.length) {
@@ -85,7 +84,7 @@ export function extractStyleTags(source: string, html?: HTMLDocument): TagInform
 	return styles;
 }
 
-export function extractScriptTags(source: string, html?: HTMLDocument): TagInformation[] {
+export function extractScriptTags(source: string, html: HTMLDocument): TagInformation[] {
 	const scripts = extractTags(source, 'script', html);
 
 	if (!scripts.length) {

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -178,6 +178,17 @@ describe('HTML Plugin', () => {
 			]);
 		});
 
+		it('does not provide symbols for tags inside the frontmatter', async () => {
+			const { plugin, document, configManager } = setup(`
+			---
+				const hello: MarkdownInstance<any>
+			---
+			`);
+
+			const symbols = await plugin.getDocumentSymbols(document);
+			expect(symbols).to.be.empty;
+		});
+
 		it('should not provide document symbols if feature is disabled', async () => {
 			const { plugin, document, configManager } = setup('<div><p>Astro</p></div>');
 


### PR DESCRIPTION
## Changes

Makes it so we blank <> inside the frontmatter when doing HTML parsing to avoid them messing with the HTML AST. 

Ultimately, we should probably have the compiler do the HTML parsing and AST for us to avoid those kinds of issues, as there's still remaining issues when <> are used inside the template (ex: TypeScript generics) 

## Testing

Added a test

## Docs

N/A
