### PR TITLE
Load web module from ?target=web

### DIFF
--- a/.changeset/pink-coats-applaud.md
+++ b/.changeset/pink-coats-applaud.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix extension not working properly inside the browser

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "Launch Web Extension",
-      "type": "pwa-extensionHost",
+      "type": "extensionHost",
       "debugWebWorkerHost": true,
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode", "--extensionDevelopmentKind=web"],

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -260,12 +260,14 @@
           "description": "Enable document symbols for CSS"
         },
         "astro.format.indentFrontmatter": {
+          "deprecationMessage": "The `astro.format` settings are deprecated. Formatting is now powered by Prettier and can be configured through a Prettier configuration file.",
           "type": "boolean",
           "default": false,
           "title": "Formatting: Indent frontmatter",
           "description": "Indent the formatter by one level of indentation"
         },
         "astro.format.newLineAfterFrontmatter": {
+          "deprecationMessage": "The `astro.format` settings are deprecated. Formatting is now powered by Prettier and can be configured through a Prettier configuration file.",
           "type": "boolean",
           "default": true,
           "title": "Formatting: Add line return after the frontmatter",

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -12,8 +12,8 @@ import { commonActivate, getInitOptions } from './shared';
 const TagCloseRequest: RequestType<TextDocumentPositionParams, string, any> = new RequestType('html/tag');
 
 export async function activate(context: ExtensionContext) {
-	const serverMain = Uri.joinPath(context.extensionUri, 'dist/browser/server.js').with({ query: '?target=web' });
-	const worker = new Worker(serverMain.toString());
+	const serverMain = Uri.joinPath(context.extensionUri, 'dist/browser/server.js').with({ query: 'target=web' });
+	const worker = new Worker(serverMain.toString(true));
 
 	const clientOptions = getInitOptions('browser', {
 		serverPath: undefined,

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -4,7 +4,6 @@ import {
 	LanguageClientOptions,
 	RequestType,
 	TextDocumentPositionParams,
-	URI,
 } from 'vscode-languageclient/browser';
 import * as tsVersion from './features/typescriptVersionBrowser';
 import { activateTagClosing } from './html/autoClose';

--- a/packages/vscode/src/browser.ts
+++ b/packages/vscode/src/browser.ts
@@ -4,6 +4,7 @@ import {
 	LanguageClientOptions,
 	RequestType,
 	TextDocumentPositionParams,
+	URI,
 } from 'vscode-languageclient/browser';
 import * as tsVersion from './features/typescriptVersionBrowser';
 import { activateTagClosing } from './html/autoClose';
@@ -12,7 +13,7 @@ import { commonActivate, getInitOptions } from './shared';
 const TagCloseRequest: RequestType<TextDocumentPositionParams, string, any> = new RequestType('html/tag');
 
 export async function activate(context: ExtensionContext) {
-	const serverMain = Uri.joinPath(context.extensionUri, 'dist/browser/server.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'dist/browser/server.js').with({ query: '?target=web' });
 	const worker = new Worker(serverMain.toString());
 
 	const clientOptions = getInitOptions('browser', {


### PR DESCRIPTION
## Changes

Load the server web module using the `?target=web` query param to make sure it loads the proper version when distributed on the web (otherwise it loads the browser module of the node version, which is empty). In local with the web extension host the query param is just ignored, so there's no need to apply this conditionally 

## Testing

Tested manually

## Docs

Added some deprecation messages to the old formatting settings
