### PR TITLE
Add support for syntax highlighting events content

### DIFF
--- a/.changeset/twenty-gifts-double.md
+++ b/.changeset/twenty-gifts-double.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Add support for syntax highlighting for event handlers

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -48,6 +48,9 @@
     "astro:attribute": {
       "patterns": [
         {
+          "include": "#html:events"
+        },
+        {
           "include": "#html:attribute"
         },
         {
@@ -354,6 +357,169 @@
           "patterns": [{ "include": "source.css" }]
         },
         { "include": "#html:tag-attributes" }
+      ]
+    },
+    "html:events": {
+      "name": "meta.attribute.event-handler.$1.html",
+      "begin": "on(s(croll|t(orage|alled)|u(spend|bmit)|e(curitypolicyviolation|ek(ing|ed)|lect))|hashchange|c(hange|o(ntextmenu|py)|u(t|echange)|l(ick|ose)|an(cel|play(through)?))|t(imeupdate|oggle)|in(put|valid)|o(nline|ffline)|d(urationchange|r(op|ag(start|over|e(n(ter|d)|xit)|leave)?)|blclick)|un(handledrejection|load)|p(opstate|lay(ing)?|a(ste|use|ge(show|hide))|rogress)|e(nded|rror|mptied)|volumechange|key(down|up|press)|focus|w(heel|aiting)|l(oad(start|e(nd|d(data|metadata)))?|anguagechange)|a(uxclick|fterprint|bort)|r(e(s(ize|et)|jectionhandled)|atechange)|m(ouse(o(ut|ver)|down|up|enter|leave|move)|essage(error)?)|b(efore(unload|print)|lur))(?![\\w:-])",
+      "beginCaptures": {
+        "0": {
+          "name": "entity.other.attribute-name.html"
+        }
+      },
+      "end": "(?=\\s*+[^=\\s])",
+      "patterns": [
+        {
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.key-value.html"
+            }
+          },
+          "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+          "patterns": [
+            {
+              "begin": "(?=[^\\s=<>`/]|/(?!>))",
+              "end": "(?!\\G)",
+              "name": "meta.embedded.line.js",
+              "patterns": [
+                {
+                  "captures": {
+                    "0": {
+                      "name": "source.js"
+                    },
+                    "1": {
+                      "patterns": [
+                        {
+                          "include": "source.js"
+                        }
+                      ]
+                    }
+                  },
+                  "match": "(([^\\s\"'=<>`/]|/(?!>))+)",
+                  "name": "string.unquoted.html"
+                },
+                {
+                  "begin": "\"",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.begin.html"
+                    }
+                  },
+                  "contentName": "source.js",
+                  "end": "(\")",
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.end.html"
+                    }
+                  },
+                  "name": "string.quoted.double.html",
+                  "patterns": [
+                    {
+                      "captures": {
+                        "0": {
+                          "patterns": [
+                            {
+                              "include": "source.js"
+                            }
+                          ]
+                        }
+                      },
+                      "match": "([^\\n\"/]|/(?![/*]))+"
+                    },
+                    {
+                      "begin": "//",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.js"
+                        }
+                      },
+                      "end": "(?=\")|\\n",
+                      "name": "comment.line.double-slash.js"
+                    },
+                    {
+                      "begin": "/\\*",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.begin.js"
+                        }
+                      },
+                      "end": "(?=\")|\\*/",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.end.js"
+                        }
+                      },
+                      "name": "comment.block.js"
+                    }
+                  ]
+                },
+                {
+                  "begin": "'",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.begin.html"
+                    }
+                  },
+                  "contentName": "source.js",
+                  "end": "(')",
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.string.end.html"
+                    },
+                    "1": {
+                      "name": "source.js-ignored-vscode"
+                    }
+                  },
+                  "name": "string.quoted.single.html",
+                  "patterns": [
+                    {
+                      "captures": {
+                        "0": {
+                          "patterns": [
+                            {
+                              "include": "source.js"
+                            }
+                          ]
+                        }
+                      },
+                      "match": "([^\\n'/]|/(?![/*]))+"
+                    },
+                    {
+                      "begin": "//",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.js"
+                        }
+                      },
+                      "end": "(?=')|\\n",
+                      "name": "comment.line.double-slash.js"
+                    },
+                    {
+                      "begin": "/\\*",
+                      "beginCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.begin.js"
+                        }
+                      },
+                      "end": "(?=')|\\*/",
+                      "endCaptures": {
+                        "0": {
+                          "name": "punctuation.definition.comment.end.js"
+                        }
+                      },
+                      "name": "comment.block.js"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "match": "=",
+              "name": "invalid.illegal.unexpected-equals-sign.html"
+            }
+          ]
+        }
       ]
     },
     "html:attribute": {

--- a/packages/vscode/test/grammar/fixtures/script/events.astro
+++ b/packages/vscode/test/grammar/fixtures/script/events.astro
@@ -1,0 +1,1 @@
+<button onclick="(hello) => {console.log('hello')};">Click Me!</button>

--- a/packages/vscode/test/grammar/fixtures/script/events.astro.snap
+++ b/packages/vscode/test/grammar/fixtures/script/events.astro.snap
@@ -1,0 +1,15 @@
+><button onclick="(hello) => {console.log('hello')};">Click Me!</button>
+#^ source.astro meta.tag.any.button.start.html punctuation.definition.tag.begin.html
+# ^^^^^^ source.astro meta.tag.any.button.start.html entity.name.tag.html
+#       ^ source.astro meta.tag.any.button.start.html
+#        ^^^^^^^ source.astro meta.tag.any.button.start.html meta.attribute.event-handler.click.html entity.other.attribute-name.html
+#               ^ source.astro meta.tag.any.button.start.html meta.attribute.event-handler.click.html punctuation.separator.key-value.html
+#                ^ source.astro meta.tag.any.button.start.html meta.attribute.event-handler.click.html meta.embedded.line.js string.quoted.double.html punctuation.definition.string.begin.html
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.tag.any.button.start.html meta.attribute.event-handler.click.html meta.embedded.line.js string.quoted.double.html source.js
+#                                                   ^ source.astro meta.tag.any.button.start.html meta.attribute.event-handler.click.html meta.embedded.line.js string.quoted.double.html punctuation.definition.string.end.html
+#                                                    ^ source.astro meta.tag.any.button.start.html punctuation.definition.tag.end.html
+#                                                     ^^^^^^^^^ source.astro
+#                                                              ^^ source.astro meta.tag.any.button.end.html punctuation.definition.tag.begin.html
+#                                                                ^^^^^^ source.astro meta.tag.any.button.end.html entity.name.tag.html
+#                                                                      ^ source.astro meta.tag.any.button.end.html punctuation.definition.tag.end.html
+>


### PR DESCRIPTION
## Changes

Add support for highlighting the inside of events handlers as JavaScript, like in HTML files

<img width="632" alt="image" src="https://user-images.githubusercontent.com/3019731/190655669-53a3e088-8beb-4e15-b73c-3991fc139d07.png">

(TypeScript isn't supported inside events handlers, I was just messing around)

## Testing

Added a test

## Docs

N/A
