### PR TITLE
Improve completions on the Fragment element, add completions for slot on components

### DIFF
--- a/.changeset/twenty-bats-visit.md
+++ b/.changeset/twenty-bats-visit.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Improve completions on the Fragment element, add completions for slot on components

--- a/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
@@ -71,7 +71,7 @@ export class CompletionsProviderImpl implements CompletionsProvider {
 			}
 
 			const isAstro = componentFilePath?.endsWith('.astro');
-			if (!isAstro) {
+			if (!isAstro && node.tag !== 'Fragment') {
 				const directives = removeDataAttrCompletion(this.directivesHTMLLang.doComplete(document, position, html).items);
 				items.push(...directives);
 			}

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -62,7 +62,7 @@ export class HTMLPlugin implements Plugin {
 		}
 
 		// If the node we're hovering on is a component, instead only provide astro-specific hover info
-		if (isPossibleComponent(node)) {
+		if (isPossibleComponent(node) && node.tag !== 'Fragment') {
 			return this.componentLang.doHover(document, position, html);
 		}
 

--- a/packages/language-server/src/plugins/html/features/astro-attributes.ts
+++ b/packages/language-server/src/plugins/html/features/astro-attributes.ts
@@ -1,4 +1,7 @@
-import { newHTMLDataProvider } from 'vscode-html-languageservice';
+import { newHTMLDataProvider, getDefaultHTMLDataProvider } from 'vscode-html-languageservice';
+
+const defaultProvider = getDefaultHTMLDataProvider();
+const slotAttr = defaultProvider.provideAttributes('div').find((attr) => attr.name === 'slot')!;
 
 export const classListAttribute = newHTMLDataProvider('class-list', {
 	version: 1,
@@ -174,6 +177,7 @@ export const astroAttributes = newHTMLDataProvider('astro-attributes', {
 				},
 			],
 		},
+		slotAttr,
 	],
 });
 

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -93,7 +93,7 @@ describe('PluginHost', () => {
 			const completions = await pluginHost.getCompletions(document, pos);
 			const labels = completions.items.map((item) => item.label);
 
-			expect(labels).to.deep.equal(['set:html', 'set:text', 'is:raw']);
+			expect(labels).to.deep.equal(['set:html', 'set:text', 'is:raw', 'slot']);
 		});
 
 		it('filters out TS completions inside framework component starting tag', async () => {
@@ -107,6 +107,7 @@ describe('PluginHost', () => {
 				'set:html',
 				'set:text',
 				'is:raw',
+				'slot',
 				'client:load',
 				'client:idle',
 				'client:visible',


### PR DESCRIPTION
## Changes

Update completions on the Fragment element to not have client directives and the slot attribute. Also added the slot attributes to all components

Before:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/3019731/190682355-97477cde-b7e5-4fbf-9d81-2b005eaeeee2.png">

After: 
<img width="523" alt="image" src="https://user-images.githubusercontent.com/3019731/190682110-114b9ee7-a425-4727-a79d-d6460a80e351.png">

## Testing

Updated tests

## Docs

N/A
