### PR TITLE
Add support for Go to References

### DIFF
--- a/.changeset/good-turtles-eat.md
+++ b/.changeset/good-turtles-eat.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': minor
+'astro-vscode': minor
+---
+
+Add support for Go to References

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -18,6 +18,7 @@ import {
 	Location,
 	Position,
 	Range,
+	ReferenceContext,
 	SemanticTokens,
 	SignatureHelp,
 	SignatureHelpContext,
@@ -234,10 +235,16 @@ export class PluginHost {
 		}
 	}
 
-	getTypeDefinition(textDocument: TextDocumentIdentifier, position: Position): Promise<Location[] | null> {
+	async getTypeDefinitions(textDocument: TextDocumentIdentifier, position: Position): Promise<Location[] | null> {
 		const document = this.getDocument(textDocument.uri);
 
-		return this.execute<Location[] | null>('getTypeDefinitions', [document, position], ExecuteMode.FirstNonNull);
+		return await this.execute<Location[] | null>('getTypeDefinitions', [document, position], ExecuteMode.FirstNonNull);
+	}
+
+	getReferences(textdocument: TextDocumentIdentifier, position: Position, context: ReferenceContext) {
+		const document = this.getDocument(textdocument.uri);
+
+		return this.execute<Location[] | null>('findReferences', [document, position, context], ExecuteMode.FirstNonNull);
 	}
 
 	async rename(

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -138,7 +138,7 @@ export interface LinkedEditingRangesProvider {
 	getLinkedEditingRanges(document: TextDocument, position: Position): Resolvable<LinkedEditingRanges | null>;
 }
 
-export interface TypeDefinitionProvider {
+export interface TypeDefinitionsProvider {
 	getTypeDefinitions(document: TextDocument, position: Position): Resolvable<Location[] | null>;
 }
 
@@ -159,7 +159,7 @@ type ProviderBase = DiagnosticsProvider &
 	HoverProvider &
 	CompletionsProvider &
 	DefinitionsProvider &
-	TypeDefinitionProvider &
+	TypeDefinitionsProvider &
 	FormattingProvider &
 	FoldingRangesProvider &
 	TagCompleteProvider &

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -12,6 +12,7 @@ import {
 	Location,
 	Position,
 	Range,
+	ReferenceContext,
 	SemanticTokens,
 	SignatureHelp,
 	SignatureHelpContext,
@@ -19,6 +20,7 @@ import {
 	TextDocumentContentChangeEvent,
 	WorkspaceEdit,
 } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { ConfigManager, LSTypescriptConfig } from '../../core/config';
 import type { AstroDocument } from '../../core/documents';
 import type { AppCompletionItem, AppCompletionList, OnWatchFileChangesParam, Plugin } from '../interfaces';
@@ -31,6 +33,7 @@ import { DocumentSymbolsProviderImpl } from './features/DocumentSymbolsProvider'
 import { FoldingRangesProviderImpl } from './features/FoldingRangesProvider';
 import { HoverProviderImpl } from './features/HoverProvider';
 import { InlayHintsProviderImpl } from './features/InlayHintsProvider';
+import { FindReferencesProviderImpl } from './features/ReferencesProvider';
 import { SemanticTokensProviderImpl } from './features/SemanticTokenProvider';
 import { SignatureHelpProviderImpl } from './features/SignatureHelpProvider';
 import { TypeDefinitionsProviderImpl } from './features/TypeDefinitionsProvider';
@@ -49,6 +52,7 @@ export class TypeScriptPlugin implements Plugin {
 	private readonly hoverProvider: HoverProviderImpl;
 	private readonly definitionsProvider: DefinitionsProviderImpl;
 	private readonly typeDefinitionsProvider: TypeDefinitionsProviderImpl;
+	private readonly referencesProvider: FindReferencesProviderImpl;
 	private readonly signatureHelpProvider: SignatureHelpProviderImpl;
 	private readonly diagnosticsProvider: DiagnosticsProviderImpl;
 	private readonly documentSymbolsProvider: DocumentSymbolsProviderImpl;
@@ -68,6 +72,7 @@ export class TypeScriptPlugin implements Plugin {
 		this.hoverProvider = new HoverProviderImpl(this.languageServiceManager);
 		this.definitionsProvider = new DefinitionsProviderImpl(this.languageServiceManager);
 		this.typeDefinitionsProvider = new TypeDefinitionsProviderImpl(this.languageServiceManager);
+		this.referencesProvider = new FindReferencesProviderImpl(this.languageServiceManager);
 		this.signatureHelpProvider = new SignatureHelpProviderImpl(this.languageServiceManager);
 		this.diagnosticsProvider = new DiagnosticsProviderImpl(this.languageServiceManager);
 		this.documentSymbolsProvider = new DocumentSymbolsProviderImpl(this.languageServiceManager);
@@ -189,8 +194,16 @@ export class TypeScriptPlugin implements Plugin {
 		return this.definitionsProvider.getDefinitions(document, position);
 	}
 
-	async getTypeDefinition(document: AstroDocument, position: Position): Promise<Location[] | null> {
+	async getTypeDefinitions(document: AstroDocument, position: Position): Promise<Location[] | null> {
 		return this.typeDefinitionsProvider.getTypeDefinitions(document, position);
+	}
+
+	async findReferences(
+		document: AstroDocument,
+		position: Position,
+		context: ReferenceContext
+	): Promise<Location[] | null> {
+		return this.referencesProvider.findReferences(document, position, context);
 	}
 
 	async getDiagnostics(document: AstroDocument, cancellationToken?: CancellationToken): Promise<Diagnostic[]> {

--- a/packages/language-server/src/plugins/typescript/features/ReferencesProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/ReferencesProvider.ts
@@ -1,0 +1,79 @@
+import type ts from 'typescript';
+import { Location, Position, ReferenceContext } from 'vscode-languageserver-types';
+import { AstroDocument, mapRangeToOriginal } from '../../../core/documents';
+import { isNotNullOrUndefined, pathToUrl } from '../../../utils';
+import type { FindReferencesProvider } from '../../interfaces';
+import type { LanguageServiceManager } from '../LanguageServiceManager';
+import { AstroSnapshot } from '../snapshots/DocumentSnapshot';
+import { convertRange, getScriptTagSnapshot } from '../utils';
+import { SnapshotFragmentMap } from './utils';
+
+export class FindReferencesProviderImpl implements FindReferencesProvider {
+	constructor(private languageServiceManager: LanguageServiceManager) {}
+
+	async findReferences(
+		document: AstroDocument,
+		position: Position,
+		context: ReferenceContext
+	): Promise<Location[] | null> {
+		const { lang, tsDoc } = await this.languageServiceManager.getLSAndTSDoc(document);
+		const mainFragment = await tsDoc.createFragment();
+
+		const offset = mainFragment.offsetAt(mainFragment.getGeneratedPosition(position));
+		const node = document.html.findNodeAt(offset);
+
+		let references: ts.ReferenceEntry[] | undefined;
+
+		if (node.tag === 'script') {
+			const {
+				snapshot: scriptTagSnapshot,
+				filePath: scriptFilePath,
+				offset: scriptOffset,
+			} = getScriptTagSnapshot(tsDoc as AstroSnapshot, document, node, position);
+
+			references = lang.getReferencesAtPosition(scriptFilePath, scriptOffset);
+
+			if (references) {
+				references = references.map((ref) => {
+					const isInSameFile = ref.fileName === scriptFilePath;
+					ref.fileName = isInSameFile ? tsDoc.filePath : ref.fileName;
+
+					if (isInSameFile) {
+						ref.textSpan.start = mainFragment.offsetAt(
+							scriptTagSnapshot.getOriginalPosition(scriptTagSnapshot.positionAt(ref.textSpan.start))
+						);
+					}
+
+					return ref;
+				});
+			}
+		} else {
+			references = lang.getReferencesAtPosition(tsDoc.filePath, offset);
+		}
+
+		if (!references) {
+			return null;
+		}
+
+		const docs = new SnapshotFragmentMap(this.languageServiceManager);
+		docs.set(tsDoc.filePath, { fragment: mainFragment, snapshot: tsDoc });
+
+		const result = await Promise.all(
+			references.map(async (reference) => {
+				if (!context.includeDeclaration) {
+					return null;
+				}
+
+				const { fragment } = await docs.retrieve(reference.fileName);
+
+				const range = mapRangeToOriginal(fragment, convertRange(fragment, reference.textSpan));
+
+				if (range.start.line >= 0 && range.end.line >= 0) {
+					return Location.create(pathToUrl(reference.fileName), range);
+				}
+			})
+		);
+
+		return result.filter(isNotNullOrUndefined);
+	}
+}

--- a/packages/language-server/src/plugins/typescript/features/TypeDefinitionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/TypeDefinitionsProvider.ts
@@ -2,13 +2,13 @@ import type ts from 'typescript';
 import { Location, Position } from 'vscode-languageserver-protocol';
 import { AstroDocument, mapRangeToOriginal } from '../../../core/documents';
 import { isNotNullOrUndefined, pathToUrl } from '../../../utils';
-import type { TypeDefinitionProvider } from '../../interfaces';
+import type { TypeDefinitionsProvider } from '../../interfaces';
 import type { LanguageServiceManager } from '../LanguageServiceManager';
 import type { AstroSnapshot } from '../snapshots/DocumentSnapshot';
 import { convertRange, ensureRealFilePath, getScriptTagSnapshot, toVirtualAstroFilePath } from '../utils';
 import { SnapshotFragmentMap } from './utils';
 
-export class TypeDefinitionsProviderImpl implements TypeDefinitionProvider {
+export class TypeDefinitionsProviderImpl implements TypeDefinitionsProvider {
 	constructor(private languageServiceManager: LanguageServiceManager) {}
 
 	async getTypeDefinitions(document: AstroDocument, position: Position): Promise<Location[]> {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -116,6 +116,7 @@ export function startLanguageServer(connection: vscode.Connection, env: RuntimeE
 				foldingRangeProvider: true,
 				definitionProvider: true,
 				typeDefinitionProvider: true,
+				referencesProvider: true,
 				renameProvider: true,
 				documentFormattingProvider: true,
 				codeActionProvider: {
@@ -228,7 +229,9 @@ export function startLanguageServer(connection: vscode.Connection, env: RuntimeE
 
 	connection.onDefinition((evt) => pluginHost.getDefinitions(evt.textDocument, evt.position));
 
-	connection.onTypeDefinition((evt) => pluginHost.getTypeDefinition(evt.textDocument, evt.position));
+	connection.onTypeDefinition((evt) => pluginHost.getTypeDefinitions(evt.textDocument, evt.position));
+
+	connection.onReferences((evt) => pluginHost.getReferences(evt.textDocument, evt.position, evt.context));
 
 	connection.onFoldingRanges((evt) => pluginHost.getFoldingRanges(evt.textDocument));
 

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -302,6 +302,32 @@ describe('PluginHost', () => {
 		});
 	});
 
+	it('executes getTypeDefinitions on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			getTypeDefinitions: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const position = Position.create(0, 0);
+
+		await pluginHost.getTypeDefinitions(textDocument, position);
+
+		sinon.assert.calledOnce(plugin.getTypeDefinitions);
+		sinon.assert.calledWithExactly(plugin.getTypeDefinitions, document, position);
+	});
+
+	it('executes getReferences on plugins', async () => {
+		const { docManager, pluginHost, plugin } = setup({
+			findReferences: sinon.stub().returns([]),
+		});
+		const document = docManager.openDocument(textDocument);
+		const position = Position.create(0, 0);
+
+		await pluginHost.getReferences(textDocument, position, { includeDeclaration: true });
+
+		sinon.assert.calledOnce(plugin.findReferences);
+		sinon.assert.calledWithExactly(plugin.findReferences, document, position, { includeDeclaration: true });
+	});
+
 	it('executes getDocumentColors on plugins', async () => {
 		const { docManager, pluginHost, plugin } = setup({
 			getDocumentColors: sinon.stub().returns([]),

--- a/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypeScriptPlugin.test.ts
@@ -50,6 +50,34 @@ describe('TypeScript Plugin', () => {
 		});
 	});
 
+	describe('provide completions', async () => {
+		it('return completions', async () => {
+			const { plugin, document } = setup('completions/basic.astro');
+
+			const completions = await plugin.getCompletions(document, Position.create(1, 8));
+			expect(completions).to.not.be.empty;
+		});
+
+		it('should not provide completions if feature is disabled', async () => {
+			const { plugin, document, configManager } = setup('completions/basic.astro');
+
+			configManager.updateGlobalConfig(<any>{
+				typescript: {
+					completions: {
+						enabled: false,
+					},
+				},
+			});
+
+			const completions = await plugin.doHover(document, Position.create(1, 8));
+
+			const isEnabled = await configManager.isEnabled(document, 'typescript', 'completions');
+
+			expect(isEnabled).to.be.false;
+			expect(completions).to.be.null;
+		});
+	});
+
 	describe('provide hover info', async () => {
 		it('return hover info', async () => {
 			const { plugin, document } = setup('hoverInfo/basic.astro');
@@ -207,6 +235,35 @@ describe('TypeScript Plugin', () => {
 
 			const inlayHints = await plugin.getInlayHints(document, Range.create(0, 0, 7, 0));
 			expect(inlayHints).to.not.be.empty;
+		});
+	});
+
+	describe('provide definitions', async () => {
+		it('return definitions', async () => {
+			const { document, plugin } = setup('definitions/sameFile.astro');
+
+			const functionDefinition = await plugin.getDefinitions(document, Position.create(1, 11));
+			expect(functionDefinition).to.not.be.empty;
+		});
+	});
+
+	describe('provide type definitions', async () => {
+		it('return type definitions', async () => {
+			const { document, plugin } = setup('typeDefinitions/sameFile.astro');
+
+			const variableDeclaration = await plugin.getTypeDefinitions(document, Position.create(2, 10));
+			expect(variableDeclaration).to.not.be.empty;
+		});
+	});
+
+	describe('provide references', async () => {
+		it('return references', async () => {
+			const { document, plugin } = setup('references/frontmatter.astro');
+
+			const references = await plugin.findReferences(document, Position.create(3, 1), {
+				includeDeclaration: true,
+			});
+			expect(references).to.not.be.empty;
 		});
 	});
 

--- a/packages/language-server/test/plugins/typescript/features/ReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/ReferencesProvider.test.ts
@@ -1,0 +1,71 @@
+import { assert, expect } from 'chai';
+import ts from 'typescript/lib/tsserverlibrary';
+import { Position, Range } from 'vscode-languageserver-types';
+import { FindReferencesProviderImpl } from '../../../../src/plugins/typescript/features/ReferencesProvider';
+import { LanguageServiceManager } from '../../../../src/plugins/typescript/LanguageServiceManager';
+import {
+	AstroSnapshot,
+	TypeScriptDocumentSnapshot,
+} from '../../../../src/plugins/typescript/snapshots/DocumentSnapshot';
+import { pathToUrl, urlToPath } from '../../../../src/utils';
+import { createEnvironment } from '../../../utils';
+
+describe('TypeScript Plugin#ReferencesProvider', () => {
+	function setup(filePath: string) {
+		const env = createEnvironment(filePath, 'typescript', 'references');
+		const languageServiceManager = new LanguageServiceManager(env.docManager, [env.fixturesDir], env.configManager, ts);
+		const provider = new FindReferencesProviderImpl(languageServiceManager);
+
+		return {
+			...env,
+			languageServiceManager,
+			provider,
+		};
+	}
+
+	it('provide references', async () => {
+		const { document, provider } = setup('frontmatter.astro');
+
+		const references = await provider.findReferences(document, Position.create(3, 1), {
+			includeDeclaration: true,
+		});
+
+		expect(references).to.deep.equal([
+			{
+				range: Range.create(1, 6, 1, 11),
+				uri: document.getURL(),
+			},
+			{
+				range: Range.create(3, 0, 3, 5),
+				uri: document.getURL(),
+			},
+			{
+				range: Range.create(5, 12, 5, 17),
+				uri: document.getURL(),
+			},
+		]);
+	});
+
+	it('provide references inside script tags', async () => {
+		const { document, provider, languageServiceManager } = setup('scriptTag.astro');
+
+		const references = await provider.findReferences(document, Position.create(3, 1), {
+			includeDeclaration: true,
+		});
+
+		expect(references).to.deep.equal([
+			{
+				range: Range.create(1, 7, 1, 12),
+				uri: document.getURL(),
+			},
+			{
+				range: Range.create(3, 1, 3, 6),
+				uri: document.getURL(),
+			},
+			{
+				range: Range.create(5, 13, 5, 18),
+				uri: document.getURL(),
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/plugins/typescript/fixtures/references/frontmatter.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/references/frontmatter.astro
@@ -1,0 +1,7 @@
+---
+const hello = 'Hey';
+
+hello;
+
+console.log(hello);
+---

--- a/packages/language-server/test/plugins/typescript/fixtures/references/scriptTag.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/references/scriptTag.astro
@@ -1,0 +1,7 @@
+<script>
+	const hello = 'Hey';
+
+	hello;
+
+	console.log(hello);
+</script>


### PR DESCRIPTION
## Changes

Add support for Go to References / Find References. This was a bit confusing because there's multiple ways to do this and I'm not sure the differences between them 🤔

Like for https://github.com/withastro/language-tools/pull/416, this is only the Astro part of it. The TS part will be tackled when we update the TS plugin.

## Testing

Added a test for this, added some tests that were missing from previous PRs

## Docs

N/A
