### PR TITLE
[WIP] Add basic support for CSS Module IntelliSense

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -31,12 +31,16 @@
     "vscode-languageserver-protocol": "^3.17.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-uri": "^3.0.3"
+    "vscode-uri": "^3.0.3",
+    "icss-utils": "^5.1.0",
+    "postcss": "^8.4.18",
+    "postcss-icss-selectors": "^2.0.3"
   },
   "devDependencies": {
     "@astrojs/svelte": "^1.0.0",
     "@astrojs/vue": "^1.0.0",
     "@types/chai": "^4.3.0",
+    "@types/icss-utils": "^5.1.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^16.11.58",
     "@types/prettier": "^2.7.0",

--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -2,7 +2,10 @@ import type * as svelte from '@astrojs/svelte/dist/editor.cjs';
 import type * as vue from '@astrojs/svelte/dist/editor.cjs';
 import { dirname, resolve } from 'path';
 import type * as prettier from 'prettier';
+import Processor from 'postcss/lib/processor';
+import postcssIcssSelectors from 'postcss-icss-selectors';
 
+export const processor = new Processor([postcssIcssSelectors({ mode: 'local', generateScopedName: () => '' })]);
 let isTrusted = true;
 
 export function setIsTrusted(_isTrusted: boolean) {

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -45,6 +45,7 @@ import {
 	ensureRealFilePath,
 	getScriptKindFromFileName,
 	isAstroFilePath,
+	isCSSModulePath,
 	isFrameworkFilePath,
 } from './utils';
 
@@ -239,7 +240,12 @@ export class TypeScriptPlugin implements Plugin {
 		for (const { fileName, changeType } of onWatchFileChangesParas) {
 			const scriptKind = getScriptKindFromFileName(fileName, this.ts);
 
-			if (scriptKind === this.ts.ScriptKind.Unknown && !isFrameworkFilePath(fileName) && !isAstroFilePath(fileName)) {
+			if (
+				scriptKind === this.ts.ScriptKind.Unknown &&
+				!isFrameworkFilePath(fileName) &&
+				!isAstroFilePath(fileName) &&
+				!isCSSModulePath(fileName)
+			) {
 				continue;
 			}
 

--- a/packages/language-server/src/plugins/typescript/astro-sys.ts
+++ b/packages/language-server/src/plugins/typescript/astro-sys.ts
@@ -23,10 +23,7 @@ export function createAstroSys(
 			return snapshot.getText(0, snapshot.getLength());
 		},
 		readDirectory(path, extensions, exclude, include, depth) {
-			const extensionsWithAstro = (extensions ?? []).concat(
-				...['.astro', '.svelte', '.vue', '.css'],
-				...CSSModuleExtensions
-			);
+			const extensionsWithAstro = (extensions ?? []).concat(...['.astro', '.svelte', '.vue'], ...CSSModuleExtensions);
 			const result = ts.sys.readDirectory(path, extensionsWithAstro, exclude, include, depth);
 			return result;
 		},

--- a/packages/language-server/src/plugins/typescript/astro-sys.ts
+++ b/packages/language-server/src/plugins/typescript/astro-sys.ts
@@ -24,7 +24,8 @@ export function createAstroSys(
 		},
 		readDirectory(path, extensions, exclude, include, depth) {
 			const extensionsWithAstro = (extensions ?? []).concat(
-				...['.astro', '.svelte', '.vue', '.md', '.mdx', '.html', CSSModuleExtensions]
+				...['.astro', '.svelte', '.vue', '.md', '.mdx', '.html'],
+				...CSSModuleExtensions
 			);
 			const result = ts.sys.readDirectory(path, extensionsWithAstro, exclude, include, depth);
 			return result;

--- a/packages/language-server/src/plugins/typescript/astro-sys.ts
+++ b/packages/language-server/src/plugins/typescript/astro-sys.ts
@@ -1,5 +1,5 @@
 import type { DocumentSnapshot } from './snapshots/DocumentSnapshot';
-import { ensureRealFilePath, isVirtualFilePath } from './utils';
+import { CSSModuleExtensions, ensureRealFilePath, isVirtualFilePath } from './utils';
 
 /**
  * This should only be accessed by TS Astro module resolution.
@@ -23,7 +23,10 @@ export function createAstroSys(
 			return snapshot.getText(0, snapshot.getLength());
 		},
 		readDirectory(path, extensions, exclude, include, depth) {
-			const extensionsWithAstro = (extensions ?? []).concat(...['.astro', '.svelte', '.vue']);
+			const extensionsWithAstro = (extensions ?? []).concat(
+				...['.astro', '.svelte', '.vue', '.css'],
+				...CSSModuleExtensions
+			);
 			const result = ts.sys.readDirectory(path, extensionsWithAstro, exclude, include, depth);
 			return result;
 		},

--- a/packages/language-server/src/plugins/typescript/features/DefinitionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DefinitionsProvider.ts
@@ -10,6 +10,7 @@ import {
 	ensureRealFilePath,
 	getScriptTagSnapshot,
 	isAstroFilePath,
+	isCSSModulePath,
 	isFrameworkFilePath,
 } from '../utils';
 import { SnapshotFragmentMap } from './utils';
@@ -77,7 +78,14 @@ export class DefinitionsProviderImpl implements DefinitionsProvider {
 				// For Astro, Svelte and Vue, the position is wrongly mapped to the end of the file due to the TSX output
 				// So we'll instead redirect to the beginning of the file
 				const isFramework = isFrameworkFilePath(def.fileName) || isAstroFilePath(def.fileName);
-				const textSpan = isFramework && tsDoc.filePath !== def.fileName ? { start: 0, length: 0 } : def.textSpan;
+				const isCSSModule = isCSSModulePath(fileName);
+				let textSpan = def.textSpan;
+
+				if (isFramework && tsDoc.filePath !== def.fileName) {
+					textSpan = { start: 0, length: 0 };
+				} else if (isCSSModule) {
+					snapshot
+				}
 
 				return LocationLink.create(
 					pathToUrl(fileName),

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -13,6 +13,7 @@ import {
 import { GlobalSnapshotManager, SnapshotManager } from './snapshots/SnapshotManager';
 import * as DocumentSnapshotUtils from './snapshots/utils';
 import {
+	CSSModuleExtensions,
 	ensureRealFilePath,
 	findTsConfigPath,
 	getScriptTagLanguage,
@@ -383,6 +384,11 @@ async function createLanguageService(
 				{ extension: 'vue', isMixedContent: true, scriptKind: docContext.ts.ScriptKind.Deferred },
 				{ extension: 'svelte', isMixedContent: true, scriptKind: docContext.ts.ScriptKind.Deferred },
 				{ extension: 'astro', isMixedContent: true, scriptKind: docContext.ts.ScriptKind.Deferred },
+				...CSSModuleExtensions.map((ext) => ({
+					extension: ext,
+					isMixedContent: true,
+					scriptKind: docContext.ts.ScriptKind.Deferred,
+				})),
 			]
 		);
 

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -1,3 +1,4 @@
+import { default as nodePath } from 'path';
 import type { ResolvedModule } from 'typescript';
 import { getLastPartOfPath } from '../../utils';
 import { createAstroSys } from './astro-sys';
@@ -6,6 +7,7 @@ import {
 	ensureRealFilePath,
 	getExtensionFromScriptKind,
 	isAstroFilePath,
+	isCSSModulePath,
 	isFrameworkFilePath,
 	isVirtualFilePath,
 	toVirtualFilePath,
@@ -81,7 +83,7 @@ class ImpliedNodeFormatResolver {
 		compilerOptions: ts.CompilerOptions
 	) {
 		// For Astro & Framework imports, we have to fallback to the old resolution algorithm or it doesn't work
-		if (isAstroFilePath(importPath) || isFrameworkFilePath(importPath)) {
+		if (isAstroFilePath(importPath) || isFrameworkFilePath(importPath) || isCSSModulePath(importPath)) {
 			return undefined;
 		}
 
@@ -89,7 +91,9 @@ class ImpliedNodeFormatResolver {
 		if (sourceFile) {
 			if (
 				!sourceFile.impliedNodeFormat &&
-				(isAstroFilePath(sourceFile.fileName) || isFrameworkFilePath(sourceFile.fileName))
+				(isAstroFilePath(sourceFile.fileName) ||
+					isFrameworkFilePath(sourceFile.fileName) ||
+					isCSSModulePath(sourceFile.fileName))
 			) {
 				// impliedNodeFormat is not set for non-TS files, because the TS function which calculates this works with a
 				// fixed set of extensions that does not include frameworks files

--- a/packages/language-server/src/plugins/typescript/snapshots/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/SnapshotManager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import type { TextDocumentContentChangeEvent } from 'vscode-languageserver';
 import { normalizePath } from '../../../utils';
+import { CSSModuleExtensions } from '../utils';
 import { DocumentSnapshot, TypeScriptDocumentSnapshot } from './DocumentSnapshot';
 import * as DocumentSnapshotUtils from './utils';
 
@@ -117,7 +118,7 @@ export class SnapshotManager {
 		const projectFiles = this.ts.sys
 			.readDirectory(
 				this.workspaceRoot,
-				[...Object.values(this.ts.Extension), '.astro', '.svelte', '.vue'],
+				[...Object.values(this.ts.Extension), '.astro', '.svelte', '.vue', ...CSSModuleExtensions],
 				exclude,
 				include
 			)

--- a/packages/language-server/src/plugins/typescript/snapshots/utils.ts
+++ b/packages/language-server/src/plugins/typescript/snapshots/utils.ts
@@ -134,7 +134,8 @@ export function createFromCSSFilePath(filePath: string, ts: typeof import('types
 		0,
 		filePath,
 		`declare let classes: {${processedClasses.join('\n  ')}};export default classes;`,
-		ts.ScriptKind.TS
+		ts.ScriptKind.TS,
+		false
 	);
 }
 

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -358,7 +358,22 @@ export function isVirtualSvelteFilePath(filePath: string) {
 }
 
 export function isVirtualFilePath(filePath: string) {
-	return isVirtualAstroFilePath(filePath) || isVirtualVueFilePath(filePath) || isVirtualSvelteFilePath(filePath);
+	return (
+		isVirtualAstroFilePath(filePath) ||
+		isVirtualVueFilePath(filePath) ||
+		isVirtualSvelteFilePath(filePath) ||
+		isVirtualCSSModule(filePath)
+	);
+}
+
+export const CSSModuleExtensions = ['.module.css', '.module.scss', '.module.sass', '.module.less', '.module.styl'];
+
+export function isCSSModulePath(filePath: string) {
+	return CSSModuleExtensions.some((ext) => filePath.includes(ext));
+}
+
+export function isVirtualCSSModule(filePath: string) {
+	return isCSSModulePath(filePath) && filePath.endsWith('.ts');
 }
 
 export function toVirtualAstroFilePath(filePath: string) {

--- a/packages/language-server/src/types.d.ts
+++ b/packages/language-server/src/types.d.ts
@@ -1,0 +1,8 @@
+declare module 'postcss-icss-selectors' {
+	import { PluginCreator } from 'postcss';
+	const plugin: PluginCreator<{
+		generateScopedName?(localName: string, filepath: string, css: string): string;
+		mode?: 'local' | 'global';
+	}>;
+	export = plugin;
+}

--- a/packages/vscode/scripts/build-browser.js
+++ b/packages/vscode/scripts/build-browser.js
@@ -66,6 +66,14 @@ require('esbuild').build({
 					contents: `export const TextDecoder = {}`,
 					loader: 'js',
 				}));
+				build.onResolve({ filter: /^generic-names$/ }, (args) => ({
+					path: args.path,
+					namespace: 'generic-names-ns',
+				}));
+				build.onLoad({ filter: /.*/, namespace: 'generic-names-ns' }, () => ({
+					contents: `export default function genericNames(name) { return name; }`,
+					loader: 'js',
+				}));
 			},
 		},
 	],

--- a/packages/vscode/src/shared.ts
+++ b/packages/vscode/src/shared.ts
@@ -11,12 +11,15 @@ import {
 import { BaseLanguageClient, LanguageClientOptions } from 'vscode-languageclient';
 import * as fileReferences from './features/fileReferences';
 
+export const CSSModuleExtensions = ['.module.css', '.module.scss', '.module.sass', '.module.less', '.module.styl'];
+
 export function getInitOptions(env: 'node' | 'browser', typescript: any): LanguageClientOptions {
+	const cssModulesGlobs = CSSModuleExtensions.map((ext) => `**/*${ext}`).join(',');
 	return {
 		documentSelector: [{ scheme: 'file', language: 'astro' }],
 		synchronize: {
 			fileEvents: workspace.createFileSystemWatcher(
-				'{**/*.astro,**/*.js,**/*.ts,**/*.jsx,**/*.tsx,**/*.json,**/*.vue,**/*.svelte}',
+				`{**/*.astro,**/*.js,**/*.ts,**/*.jsx,**/*.tsx,**/*.json,**/*.vue,**/*.svelte,${cssModulesGlobs}}`,
 				false,
 				false,
 				false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,10 @@ importers:
       '@astrojs/svelte': ^1.0.0
       '@astrojs/vue': ^1.0.0
       '@types/chai': ^4.3.0
+      '@types/icss-utils': ^5.1.0
       '@types/mocha': ^9.1.0
       '@types/node': ^16.11.58
+      '@types/postcss-modules-scope': ^3.0.0
       '@types/prettier': ^2.7.0
       '@types/sinon': ^10.0.11
       '@vscode/emmet-helper': ^2.8.4
@@ -41,7 +43,11 @@ importers:
       chai: ^4.3.6
       cross-env: ^7.0.3
       events: ^3.3.0
+      icss-utils: ^5.1.0
       mocha: ^9.2.2
+      postcss: ^8.4.18
+      postcss-icss-selectors: ^2.0.3
+      postcss-modules-scope: ^3.0.0
       prettier: ^2.7.1
       prettier-plugin-astro: ^0.5.3
       sinon: ^13.0.1
@@ -71,18 +77,24 @@ importers:
       vscode-languageserver-types: 3.17.2
       vscode-uri: 3.0.3
     devDependencies:
-      '@astrojs/svelte': 1.0.0_26q3c2zrpbi2mnw6l2nanh2fhm
+      '@astrojs/svelte': 1.0.0_psjwc3l532jdtqgkbecpd2fxai
       '@astrojs/vue': 1.0.2_vue@3.2.39
       '@types/chai': 4.3.3
+      '@types/icss-utils': 5.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.11.58
+      '@types/postcss-modules-scope': 3.0.0
       '@types/prettier': 2.7.0
       '@types/sinon': 10.0.13
       astro: 1.2.2_ts-node@10.9.1
       astro-scripts: link:../../scripts
       chai: 4.3.6
       cross-env: 7.0.3
+      icss-utils: 5.1.0_postcss@8.4.18
       mocha: 9.2.2
+      postcss: 8.4.18
+      postcss-icss-selectors: 2.0.3
+      postcss-modules-scope: 3.0.0_postcss@8.4.18
       sinon: 13.0.2
       svelte: 3.50.1
       ts-node: 10.9.1_jo7canvdyegimszc24bn5dmoxi
@@ -243,16 +255,16 @@ packages:
       prismjs: 1.29.0
     dev: true
 
-  /@astrojs/svelte/1.0.0_26q3c2zrpbi2mnw6l2nanh2fhm:
+  /@astrojs/svelte/1.0.0_psjwc3l532jdtqgkbecpd2fxai:
     resolution: {integrity: sha512-WmvcEe86j/3wL2xWURo1Kxtgh+s0CVys2j7xQboHr0ZeH9TBlkQuacAT8mWccD1/MikhDVqL/1hnF/n+vRKuGw==}
     engines: {node: ^14.18.0 || >=16.12.0}
     peerDependencies:
       svelte: ^3.46.4
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.5_svelte@3.50.1+vite@3.1.0
-      postcss-load-config: 3.1.4_ts-node@10.9.1
+      postcss-load-config: 3.1.4_neo3lunb2qpadwxplzw7r2isgm
       svelte: 3.50.1
-      svelte-preprocess: 4.10.7_jx5myhn4b3esgabgeox34bzr6e
+      svelte-preprocess: 4.10.7_vqvoxrxgrfxyxikry5u6fiik7u
       svelte2tsx: 0.5.17_iprco5tylfmvffqgrvqxc46njy
       vite: 3.1.0
     transitivePeerDependencies:
@@ -1081,6 +1093,12 @@ packages:
     resolution: {integrity: sha512-OcJcvP3Yk8mjYwf/IdXZtTE1tb/u0WF0qa29ER07ZHCYUBZXSN29Z1mBS+/96+kNMGTFUAbSz9X+pHmHpZrTCw==}
     dev: true
 
+  /@types/icss-utils/5.1.0:
+    resolution: {integrity: sha512-qSigeBAs4UO2ce/G5OuDoOmBbnY+DgnZr4yBXcyg9uEhIjgie+YE0LY01Va7UCognwdukycO0RlQpYwgXe84aA==}
+    dependencies:
+      postcss: 8.4.18
+    dev: true
+
   /@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
@@ -1145,6 +1163,12 @@ packages:
 
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+    dev: true
+
+  /@types/postcss-modules-scope/3.0.0:
+    resolution: {integrity: sha512-aQd+/eZvbIK3XoCBMW6pwoCWlaoBm0+VRwUiJhIoPjHKpbjuJoBcfOsQrFXe5w7FxJf9mtebJXB/HZHHzW8lpQ==}
+    dependencies:
+      postcss: 8.4.18
     dev: true
 
   /@types/prettier/2.7.0:
@@ -1390,7 +1414,7 @@ packages:
       '@vue/shared': 3.2.39
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.16
+      postcss: 8.4.18
       source-map: 0.6.1
     dev: true
 
@@ -1637,8 +1661,8 @@ packages:
       ora: 6.1.2
       path-browserify: 1.0.1
       path-to-regexp: 6.2.1
-      postcss: 8.4.16
-      postcss-load-config: 3.1.4_57znarxsqwmnneadci5z5fd5gu
+      postcss: 8.4.18
+      postcss-load-config: 3.1.4_neo3lunb2qpadwxplzw7r2isgm
       preferred-pm: 3.0.3
       prompts: 2.4.2
       recast: 0.20.5
@@ -1688,6 +1712,10 @@ packages:
   /big-integer/1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
+    dev: true
+
+  /big.js/3.2.0:
+    resolution: {integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==}
     dev: true
 
   /binary-extensions/2.2.0:
@@ -2042,6 +2070,19 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /css-selector-tokenizer/0.7.3:
+    resolution: {integrity: sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==}
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+    dev: true
+
+  /cssesc/3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
     dev: true
@@ -2257,6 +2298,11 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
+
+  /emojis-list/2.1.0:
+    resolution: {integrity: sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==}
+    engines: {node: '>= 0.10'}
     dev: true
 
   /enquirer/2.3.6:
@@ -2995,6 +3041,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fastparse/1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
+    dev: true
+
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
@@ -3143,6 +3193,12 @@ packages:
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    dev: true
+
+  /generic-names/1.0.3:
+    resolution: {integrity: sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==}
+    dependencies:
+      loader-utils: 0.2.17
     dev: true
 
   /gensync/1.0.0-beta.2:
@@ -3482,6 +3538,21 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
+  /icss-utils/3.0.1:
+    resolution: {integrity: sha512-ANhVLoEfe0KoC9+z4yiTaXOneB49K6JIXdS+yAgH0NERELpdIT7kkj2XxUPuHafeHnn8umXnECSpsfk1RTaUew==}
+    dependencies:
+      postcss: 6.0.23
+    dev: true
+
+  /icss-utils/5.1.0_postcss@8.4.18:
+    resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      postcss: 8.4.18
+    dev: true
+
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
@@ -3799,6 +3870,11 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json5/0.5.1:
+    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
+    hasBin: true
+    dev: true
+
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
@@ -3875,6 +3951,15 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /loader-utils/0.2.17:
+    resolution: {integrity: sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==}
+    dependencies:
+      big.js: 3.2.0
+      emojis-list: 2.1.0
+      json5: 0.5.1
+      object-assign: 4.1.1
+    dev: true
+
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3899,6 +3984,10 @@ packages:
 
   /lodash.startcase/4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    dev: true
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
   /log-symbols/4.1.0:
@@ -4670,6 +4759,11 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /object-assign/4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
     dev: true
@@ -4926,7 +5020,17 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /postcss-load-config/3.1.4_57znarxsqwmnneadci5z5fd5gu:
+  /postcss-icss-selectors/2.0.3:
+    resolution: {integrity: sha512-dxFtq+wscbU9faJaH8kIi98vvCPDbt+qg1g9GoG0os1PY3UvgY1Y2G06iZrZb1iVC9cyFfafwSY1IS+IQpRQ4w==}
+    dependencies:
+      css-selector-tokenizer: 0.7.3
+      generic-names: 1.0.3
+      icss-utils: 3.0.1
+      lodash: 4.17.21
+      postcss: 6.0.23
+    dev: true
+
+  /postcss-load-config/3.1.4_neo3lunb2qpadwxplzw7r2isgm:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -4939,30 +5043,40 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.6
-      postcss: 8.4.16
+      postcss: 8.4.18
       ts-node: 10.9.1_jo7canvdyegimszc24bn5dmoxi
       yaml: 1.10.2
     dev: true
 
-  /postcss-load-config/3.1.4_ts-node@10.9.1:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
+  /postcss-modules-scope/3.0.0_postcss@8.4.18:
+    resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
+    engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
+      postcss: ^8.1.0
     dependencies:
-      lilconfig: 2.0.6
-      ts-node: 10.9.1_jo7canvdyegimszc24bn5dmoxi
-      yaml: 1.10.2
+      postcss: 8.4.18
+      postcss-selector-parser: 6.0.10
     dev: true
 
-  /postcss/8.4.16:
-    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
+  /postcss-selector-parser/6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /postcss/6.0.23:
+    resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      chalk: 2.4.2
+      source-map: 0.6.1
+      supports-color: 5.5.0
+    dev: true
+
+  /postcss/8.4.18:
+    resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -5719,7 +5833,7 @@ packages:
       svelte: 3.50.1
     dev: true
 
-  /svelte-preprocess/4.10.7_jx5myhn4b3esgabgeox34bzr6e:
+  /svelte-preprocess/4.10.7_vqvoxrxgrfxyxikry5u6fiik7u:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -5764,7 +5878,8 @@ packages:
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
       magic-string: 0.25.9
-      postcss-load-config: 3.1.4_ts-node@10.9.1
+      postcss: 8.4.18
+      postcss-load-config: 3.1.4_neo3lunb2qpadwxplzw7r2isgm
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.50.1
@@ -6347,7 +6462,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.54
-      postcss: 8.4.16
+      postcss: 8.4.18
       resolve: 1.22.1
       rollup: 2.77.3
     optionalDependencies:
@@ -6374,7 +6489,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.15.7
-      postcss: 8.4.16
+      postcss: 8.4.18
       resolve: 1.22.1
       rollup: 2.78.1
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,6 @@ importers:
       '@types/icss-utils': ^5.1.0
       '@types/mocha': ^9.1.0
       '@types/node': ^16.11.58
-      '@types/postcss-modules-scope': ^3.0.0
       '@types/prettier': ^2.7.0
       '@types/sinon': ^10.0.11
       '@vscode/emmet-helper': ^2.8.4
@@ -47,7 +46,6 @@ importers:
       mocha: ^9.2.2
       postcss: ^8.4.18
       postcss-icss-selectors: ^2.0.3
-      postcss-modules-scope: ^3.0.0
       prettier: ^2.7.1
       prettier-plugin-astro: ^0.5.3
       sinon: ^13.0.1
@@ -66,6 +64,9 @@ importers:
     dependencies:
       '@vscode/emmet-helper': 2.8.4
       events: 3.3.0
+      icss-utils: 5.1.0_postcss@8.4.18
+      postcss: 8.4.18
+      postcss-icss-selectors: 2.0.3
       prettier: 2.7.1
       prettier-plugin-astro: 0.5.4
       source-map: 0.7.4
@@ -83,18 +84,13 @@ importers:
       '@types/icss-utils': 5.1.0
       '@types/mocha': 9.1.1
       '@types/node': 16.11.58
-      '@types/postcss-modules-scope': 3.0.0
       '@types/prettier': 2.7.0
       '@types/sinon': 10.0.13
       astro: 1.2.2_ts-node@10.9.1
       astro-scripts: link:../../scripts
       chai: 4.3.6
       cross-env: 7.0.3
-      icss-utils: 5.1.0_postcss@8.4.18
       mocha: 9.2.2
-      postcss: 8.4.18
-      postcss-icss-selectors: 2.0.3
-      postcss-modules-scope: 3.0.0_postcss@8.4.18
       sinon: 13.0.2
       svelte: 3.50.1
       ts-node: 10.9.1_jo7canvdyegimszc24bn5dmoxi
@@ -1165,12 +1161,6 @@ packages:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
     dev: true
 
-  /@types/postcss-modules-scope/3.0.0:
-    resolution: {integrity: sha512-aQd+/eZvbIK3XoCBMW6pwoCWlaoBm0+VRwUiJhIoPjHKpbjuJoBcfOsQrFXe5w7FxJf9mtebJXB/HZHHzW8lpQ==}
-    dependencies:
-      postcss: 8.4.18
-    dev: true
-
   /@types/prettier/2.7.0:
     resolution: {integrity: sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==}
     dev: true
@@ -1546,7 +1536,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: true
 
   /ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1716,7 +1705,7 @@ packages:
 
   /big.js/3.2.0:
     resolution: {integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==}
-    dev: true
+    dev: false
 
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -1881,7 +1870,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: true
 
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1995,7 +1983,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: true
 
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2006,7 +1993,6 @@ packages:
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2075,13 +2061,13 @@ packages:
     dependencies:
       cssesc: 3.0.0
       fastparse: 1.1.2
-    dev: true
+    dev: false
 
   /cssesc/3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
+    dev: false
 
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
@@ -2303,7 +2289,7 @@ packages:
   /emojis-list/2.1.0:
     resolution: {integrity: sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==}
     engines: {node: '>= 0.10'}
-    dev: true
+    dev: false
 
   /enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -2790,7 +2776,6 @@ packages:
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3043,7 +3028,7 @@ packages:
 
   /fastparse/1.1.2:
     resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
-    dev: true
+    dev: false
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -3199,7 +3184,7 @@ packages:
     resolution: {integrity: sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==}
     dependencies:
       loader-utils: 0.2.17
-    dev: true
+    dev: false
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3348,7 +3333,6 @@ packages:
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3542,7 +3526,7 @@ packages:
     resolution: {integrity: sha512-ANhVLoEfe0KoC9+z4yiTaXOneB49K6JIXdS+yAgH0NERELpdIT7kkj2XxUPuHafeHnn8umXnECSpsfk1RTaUew==}
     dependencies:
       postcss: 6.0.23
-    dev: true
+    dev: false
 
   /icss-utils/5.1.0_postcss@8.4.18:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -3551,7 +3535,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.18
-    dev: true
+    dev: false
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3873,7 +3857,7 @@ packages:
   /json5/0.5.1:
     resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
     hasBin: true
-    dev: true
+    dev: false
 
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
@@ -3958,7 +3942,7 @@ packages:
       emojis-list: 2.1.0
       json5: 0.5.1
       object-assign: 4.1.1
-    dev: true
+    dev: false
 
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -3988,7 +3972,7 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
+    dev: false
 
   /log-symbols/4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -4687,7 +4671,6 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4762,7 +4745,7 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
+    dev: false
 
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
@@ -5028,7 +5011,7 @@ packages:
       icss-utils: 3.0.1
       lodash: 4.17.21
       postcss: 6.0.23
-    dev: true
+    dev: false
 
   /postcss-load-config/3.1.4_neo3lunb2qpadwxplzw7r2isgm:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -5048,24 +5031,6 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-modules-scope/3.0.0_postcss@8.4.18:
-    resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
-    engines: {node: ^10 || ^12 || >= 14}
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      postcss: 8.4.18
-      postcss-selector-parser: 6.0.10
-    dev: true
-
-  /postcss-selector-parser/6.0.10:
-    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
-    engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-    dev: true
-
   /postcss/6.0.23:
     resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==}
     engines: {node: '>=4.0.0'}
@@ -5073,7 +5038,7 @@ packages:
       chalk: 2.4.2
       source-map: 0.6.1
       supports-color: 5.5.0
-    dev: true
+    dev: false
 
   /postcss/8.4.18:
     resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
@@ -5082,7 +5047,6 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /preferred-pm/3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
@@ -5620,12 +5584,10 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map/0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
@@ -5797,7 +5759,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color/7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}


### PR DESCRIPTION
## Changes

This PR adds basic intellisense for CSS modules. I'm not super satisfied with how the CSS classes are extracted, PostCSS isn't necessarily heavy but it's still a big process. Volar uses a regex to do this, but it doesn't seems to work perfectly either, so not sure if there's a perfect lightweight solution or not

<img width="912" alt="image" src="https://user-images.githubusercontent.com/3019731/195632806-5cac4fe3-7aeb-47e2-b88e-c09ab981cf84.png">

## Testing

WIP

## Docs

N/A
