### PR TITLE
Fix Organize Imports adding virtual code to script tags

### DIFF
--- a/.changeset/mighty-teachers-sneeze.md
+++ b/.changeset/mighty-teachers-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix Organize Imports sometimes adding code to script tags

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -287,7 +287,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 					// Since our last line is a (virtual) export, organize imports will try to rewrite it, so let's only take
 					// changes that actually happens inside the script tag
 					.filter((change) => {
-						return scriptTagSnapshot.isInGenerated(document.positionAt(change.span.start));
+						return (
+							scriptTagSnapshot.isInGenerated(document.positionAt(change.span.start)) &&
+							!change.newText.includes('export { }')
+						);
 					});
 
 				return edit;

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -398,9 +398,52 @@ describe('TypeScript Plugin#CodeActionsProvider', () => {
 									version: null,
 								},
 							},
+							{
+								edits: [
+									{
+										newText: '',
+										range: Range.create(11, 0, 12, 0),
+									},
+								],
+								textDocument: {
+									uri: document.uri,
+									version: null,
+								},
+							},
 						],
 					},
 					kind: CodeActionKind.SourceOrganizeImports,
+					title: 'Organize Imports',
+				},
+			]);
+		});
+
+		it('can organize imports without virtual code showing', async () => {
+			const { provider, document } = setup('onelineScriptTag.astro');
+
+			const codeActions = await provider.getCodeActions(
+				document,
+				Range.create(Position.create(6, 0), Position.create(6, 0)),
+				{
+					diagnostics: [],
+					only: [CodeActionKind.SourceOrganizeImports],
+				}
+			);
+
+			expect(codeActions).to.deep.equal([
+				{
+					edit: {
+						documentChanges: [
+							{
+								edits: [],
+								textDocument: {
+									uri: document.uri,
+									version: null,
+								},
+							},
+						],
+					},
+					kind: 'source.organizeImports',
 					title: 'Organize Imports',
 				},
 			]);

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/onelineScriptTag.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/onelineScriptTag.astro
@@ -1,0 +1,16 @@
+---
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+		<script></script>
+	</head>
+	<body>
+		<h1>Astro</h1>
+	</body>
+</html>

--- a/packages/language-server/test/plugins/typescript/fixtures/codeActions/scriptTagImports.astro
+++ b/packages/language-server/test/plugins/typescript/fixtures/codeActions/scriptTagImports.astro
@@ -6,3 +6,8 @@
 
 	ImportMe()
 </script>
+
+
+<script>
+	import { Astro } from "./components/import"
+</script>


### PR DESCRIPTION
## Changes

In order to make them modules in TypeScript eyes, our script tags have some virtual code at the end. This does not cause issues in most cases, as we'll usually check to make sure positions are "in the real code" before doing anything. 

However, this doesn't always work for Organize Imports because it'll sometimes collapse code in a way where the beginning of the edit it gives is actually inside the real code, despite it mostly affecting virtual code. This goes both ways (edits to real imports will sometimes end in virtual code), so we can't check if both the start and the end of the edit is inside the real code without creating some situations where it wouldn't work

This PR works around this with our most reliable tool: `includes`.

Fix https://github.com/withastro/language-tools/issues/433

## Testing

Added tests for the specific issue and other possible edge cases

## Docs

N/A
