### PR TITLE
Fix completions of component props not working if a CSS file was imported before the component

### DIFF
--- a/.changeset/nervous-fishes-unite.md
+++ b/.changeset/nervous-fishes-unite.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix completions of component props not working if a CSS file was imported before the component

--- a/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/astro/features/CompletionsProvider.ts
@@ -230,7 +230,7 @@ export class CompletionsProviderImpl implements CompletionsProvider {
 			for (let node of list.getChildren()) {
 				if (this.ts.isImportDeclaration(node)) {
 					let clauses = node.importClause;
-					if (!clauses) return null;
+					if (!clauses) continue;
 					let namedImport = clauses.getChildAt(0);
 
 					if (this.ts.isNamedImports(namedImport)) {

--- a/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
+++ b/packages/language-server/test/plugins/astro/features/CompletionsProvider.test.ts
@@ -223,6 +223,23 @@ describe('Astro Plugin#CompletionsProvider', () => {
 		});
 	});
 
+	it('provide imports even if the first import in the file has no clauses', async () => {
+		const { provider, document } = setup('cssImport.astro');
+
+		const completions = await provider.getCompletions(document, Position.create(6, 14));
+		const item = completions?.items.find((completion) => completion.filterText === 'name');
+
+		expect(item).to.deep.equal({
+			label: 'name?',
+			detail: 'string',
+			insertText: 'name="$1"',
+			insertTextFormat: InsertTextFormat.Snippet,
+			commitCharacters: [],
+			sortText: '_',
+			filterText: 'name',
+		});
+	});
+
 	it('mark optional props with a ?', async () => {
 		const { provider, document } = setup('optional.astro');
 

--- a/packages/language-server/test/plugins/astro/fixtures/completions/cssImport.astro
+++ b/packages/language-server/test/plugins/astro/fixtures/completions/cssImport.astro
@@ -1,0 +1,7 @@
+---
+	import "style.css"
+
+	import OptionalProps from "./optionalProps.astro";
+---
+
+<OptionalProps ></OptionalProps>


### PR DESCRIPTION
## Changes

Previously when looking for the component import for props, we'd give up too early if we found an import with no clause (ex: `import 'thing.css'`), so we wouldn't properly get the type of the component. This fix that

## Testing

Added test

## Docs

N/A
