### PR TITLE
Fix prettier plugins not being loaded when formatting

### DIFF
--- a/.changeset/lovely-kings-draw.md
+++ b/.changeset/lovely-kings-draw.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix Prettier plugins not being loaded when formatting

--- a/packages/language-server/src/plugins/astro/AstroPlugin.ts
+++ b/packages/language-server/src/plugins/astro/AstroPlugin.ts
@@ -79,7 +79,7 @@ export class AstroPlugin implements Plugin {
 
 		const result = prettier.format(document.getText(), {
 			...resultConfig,
-			plugins: getAstroPrettierPlugin(),
+			plugins: [...getAstroPrettierPlugin(), ...(resultConfig.plugins ?? [])],
 			parser: 'astro',
 		});
 


### PR DESCRIPTION
## Changes

Previously we'd only load our own plugin when formatting, this PR make sure we also load other plugins. Notably, this fix compatibility with `prettier-plugin-tailwindcss`

## Testing

Tested manually

## Docs

N/A
