### PR TITLE
fix(dev): Don't bundle Synckit to avoid weird issue

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -26,7 +26,7 @@
     "events": "^3.3.0",
     "prettier": "^2.7.1",
     "prettier-plugin-astro": "^0.7.0",
-    "synckit": "^0.7.2",
+    "synckit": "^0.8.4",
     "vscode-css-languageservice": "^6.0.1",
     "vscode-html-languageservice": "^5.0.0",
     "vscode-languageserver": "^8.0.1",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@astrojs/compiler": "^0.29.16",
+    "synckit": "0.8.4",
     "@astrojs/ts-plugin": "0.4.1",
     "prettier": "^2.7.1",
     "prettier-plugin-astro": "^0.7.0"

--- a/packages/vscode/scripts/build-node.js
+++ b/packages/vscode/scripts/build-node.js
@@ -16,7 +16,7 @@ require('esbuild')
 		bundle: true,
 		sourcemap: isDev ? true : false,
 		outdir: './dist/node',
-		external: ['vscode', './TSXWorker'],
+		external: ['vscode', './TSXWorker', 'synckit'],
 		format: 'cjs',
 		platform: 'node',
 		tsconfig: './tsconfig.json',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
       prettier-plugin-astro: ^0.7.0
       sinon: ^13.0.1
       svelte: ^3.49.0
-      synckit: ^0.7.2
+      synckit: ^0.8.4
       ts-node: ^10.7.0
       typescript: ~4.8.2
       vscode-css-languageservice: ^6.0.1
@@ -66,7 +66,7 @@ importers:
       events: 3.3.0
       prettier: 2.7.1
       prettier-plugin-astro: 0.7.0
-      synckit: 0.7.3
+      synckit: 0.8.4
       vscode-css-languageservice: 6.1.0
       vscode-html-languageservice: 5.0.1
       vscode-languageserver: 8.0.2
@@ -140,6 +140,7 @@ importers:
       path-browserify: ^1.0.1
       prettier: ^2.7.1
       prettier-plugin-astro: ^0.7.0
+      synckit: 0.8.4
       typescript: ~4.8.2
       vscode-languageclient: ^8.0.1
       vscode-tmgrammar-test: ^0.1.1
@@ -148,6 +149,7 @@ importers:
       '@astrojs/ts-plugin': link:../ts-plugin
       prettier: 2.7.1
       prettier-plugin-astro: 0.7.0
+      synckit: 0.8.4
     devDependencies:
       '@astrojs/language-server': link:../language-server
       '@types/mocha': 9.1.1
@@ -6125,14 +6127,6 @@ packages:
       svelte: 3.50.1
       typescript: 4.8.3
     dev: true
-
-  /synckit/0.7.3:
-    resolution: {integrity: sha512-jNroMv7Juy+mJ/CHW5H6TzsLWpa1qck6sCHbkv8YTur+irSq2PjbvmGnm2gy14BUQ6jF33vyR4DPssHqmqsDQw==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    dependencies:
-      '@pkgr/utils': 2.3.1
-      tslib: 2.4.0
-    dev: false
 
   /synckit/0.8.4:
     resolution: {integrity: sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==}


### PR DESCRIPTION
## Changes

I am not sure why, but when I started working on the extension today, despite having made absolutely no changes at all, I started getting weird errors that would crash the dev server. 

Logs were very cryptic which lead me to try a lot of things: Downgrade VS Code, Restart my computer, turn on and off macOS file indexing, update/downgrade dependencies etc. Nothing work, skimming through the bundled code where the error was, it seemed to be related to `synckit`. Reverting the TSX output (so also removing synckit) fixed it, so next thing I tried was going back to `main` and not bundling `synckit`, which fixes it. 

No idea what happened

## Testing

Tested manually

## Docs

N/A
