### PR TITLE
fix(completions): Fix completions not showing up in VS Code in certain cases

### DIFF
--- a/.changeset/chilly-points-sniff.md
+++ b/.changeset/chilly-points-sniff.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix completions of strings not showing in certain cases

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -28,6 +28,7 @@ import { getMarkdownDocumentation } from '../previewer';
 import type { AstroSnapshot, DocumentSnapshot, ScriptTagDocumentSnapshot } from '../snapshots/DocumentSnapshot';
 import {
 	convertRange,
+	convertToLocationRange,
 	ensureFrontmatterInsert,
 	getCommitCharactersForScriptElement,
 	getScriptTagSnapshot,
@@ -158,13 +159,6 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			// PERF: Getting TS completions is fairly slow and I am currently not sure how to speed it up
 			// As such, we'll try to avoid getting them when unneeded, such as when we're doing HTML stuff
 
-			// When at the root of the document TypeScript offer all kinds of completions, because it doesn't know yet that
-			// it's JSX and not JS. As such, people who are using Emmet to write their template suffer from a very degraded experience
-			// from what they're used to in HTML files (which is instant completions). So let's disable ourselves when we're at the root
-			if (!isCompletionInsideFrontmatter && !node.parent && !isCompletionInsideExpression) {
-				return null;
-			}
-
 			// If the user just typed `<` with nothing else, let's disable ourselves until we're more sure if the user wants TS completions
 			if (!isCompletionInsideFrontmatter && node.parent && node.tag === undefined && !isCompletionInsideExpression) {
 				return null;
@@ -191,14 +185,6 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			return null;
 		}
 
-		const wordRange = completions.optionalReplacementSpan
-			? Range.create(
-					document.positionAt(completions.optionalReplacementSpan.start),
-					document.positionAt(completions.optionalReplacementSpan.start + completions.optionalReplacementSpan.length)
-			  )
-			: undefined;
-		const wordRangeStartPosition = wordRange?.start;
-
 		const existingImports = this.getExistingImports(document);
 		const completionItems = completions.entries
 			.filter((completion) => this.isValidCompletion(completion, this.ts))
@@ -213,8 +199,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 					existingImports
 				)
 			)
-			.filter(isNotNullOrUndefined)
-			.map((comp) => this.fixTextEditRange(wordRangeStartPosition, comp));
+			.filter(isNotNullOrUndefined);
 
 		const completionList = CompletionList.create(completionItems, true);
 		this.lastCompletion = { key: document.getFilePath() || '', position, completionList };
@@ -369,7 +354,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 			item.insertText = comp.insertText ? removeAstroComponentSuffix(comp.insertText) : undefined;
 			item.insertTextFormat = comp.isSnippet ? InsertTextFormat.Snippet : InsertTextFormat.PlainText;
 			item.textEdit = comp.replacementSpan
-				? TextEdit.replace(convertRange(snapshot, comp.replacementSpan), item.insertText ?? item.label)
+				? TextEdit.replace(convertToLocationRange(snapshot, comp.replacementSpan), item.insertText ?? item.label)
 				: undefined;
 		}
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionsProvider.ts
@@ -390,49 +390,6 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionIt
 		};
 	}
 
-	/**
-	 * If the textEdit is out of the word range of the triggered position
-	 * vscode would refuse to show the completions
-	 * split those edits into additionalTextEdit to fix it
-	 */
-	private fixTextEditRange(wordRangePosition: Position | undefined, completionItem: CompletionItem) {
-		const { textEdit } = completionItem;
-		if (!textEdit || !TextEdit.is(textEdit) || !wordRangePosition) {
-			return completionItem;
-		}
-
-		const {
-			newText,
-			range: { start },
-		} = textEdit;
-
-		const wordRangeStartCharacter = wordRangePosition.character;
-		if (wordRangePosition.line !== wordRangePosition.line || start.character > wordRangePosition.character) {
-			return completionItem;
-		}
-
-		textEdit.newText = newText.substring(wordRangeStartCharacter - start.character);
-		textEdit.range.start = {
-			line: start.line,
-			character: wordRangeStartCharacter,
-		};
-
-		completionItem.additionalTextEdits = [
-			TextEdit.replace(
-				{
-					start,
-					end: {
-						line: start.line,
-						character: wordRangeStartCharacter,
-					},
-				},
-				newText.substring(0, wordRangeStartCharacter - start.character)
-			),
-		];
-
-		return completionItem;
-	}
-
 	private canReuseLastCompletion(
 		lastCompletion: LastCompletion | undefined,
 		triggerKind: number | undefined,


### PR DESCRIPTION
## Changes

VS Code filters completions on the client, both to avoid the server doing unnecessary work and also because it believes it can do it better than the servers (which is true in most cases). One of the way it filters them is by excluding any completions whose replacement value is somewhere unrelated to where the completion was asked. 

As expected, this filtering happens while building the completion list, which in the case of languages that needs to be mapped, the positions of the completions also needs to be mapped, or VS Code just won't show them. Mapping the list isn't super expensive and only happens in certain cases, so it should mostly be fine. The most of the completion is still spent inside TS itself, so, there's bigger fishes to fry for sure. If it turns out to be a problem, there's other ways to achieve a similar result that could be faster, I think

I believe this issue might be older than the new TSX output, but since the change to the output weren't as drastic back then, it was rarer.

This PR additionally remove some code that isn't needed with the new output that slipped through the initial PR for it

## Testing

This is unfortunately a case where we can't test it ourselves, because the issue inherently is in VS Code itself and not in our code. Our current tests covers our part, though.

## Docs

N/A
