### PR TITLE
ci(node): Remove Node 14 from CI, Add Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [14, 16]
+        node_version: [16, 18]
         include:
           - os: windows-latest
+            node_version: 16
+          - os: macos-latest
             node_version: 16
       fail-fast: false
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
           # Needs access to push to main
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0 # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Changes

Remove Node 14 in favor of [16, 18]. Also attempt to add macOS to see if it works now. Our minimum VS Code version has been a version with Node 16 for a long time now, so the only environnement running Node 14 were through `astro check`. Since Astro is looking toward dropping Node 14, so can we!

Fix https://github.com/withastro/language-tools/issues/270

## Testing

We'll see! Re-ran the macOS CI three times to make sure the previous issue isn't there, seems like it doesn't happen anymore!

## Docs

N/A