### PR TITLE
add when-clause for commands

### DIFF
--- a/.changeset/kind-flowers-rush.md
+++ b/.changeset/kind-flowers-rush.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixed Astro commands showing even outside Astro files

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -92,18 +92,22 @@
     "commands": [
       {
         "command": "astro.restartLanguageServer",
+        "when": "resourceExtName == .astro",
         "title": "Astro: Restart Language Server"
       },
       {
         "command": "astro.showTSXOutput",
+        "when": "resourceExtName == .astro",
         "title": "Astro: Debug: Show TSX Output"
       },
       {
         "command": "astro.selectTypescriptVersion",
+        "when": "resourceExtName == .astro",
         "title": "Astro: Select Typescript Version..."
       },
       {
         "command": "astro.findFileReferences",
+        "when": "resourceExtName == .astro",
         "title": "Astro: Find File References"
       }
     ],

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -92,26 +92,40 @@
     "commands": [
       {
         "command": "astro.restartLanguageServer",
-        "when": "resourceExtName == .astro",
         "title": "Astro: Restart Language Server"
       },
       {
         "command": "astro.showTSXOutput",
-        "when": "resourceExtName == .astro",
         "title": "Astro: Debug: Show TSX Output"
       },
       {
         "command": "astro.selectTypescriptVersion",
-        "when": "resourceExtName == .astro",
         "title": "Astro: Select Typescript Version..."
       },
       {
         "command": "astro.findFileReferences",
-        "when": "resourceExtName == .astro",
         "title": "Astro: Find File References"
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "astro.restartLanguageServer",
+          "when": "editorLangId == astro"
+        },
+        {
+          "command": "astro.showTSXOutput",
+          "when": "editorLangId == astro"
+        },
+        {
+          "command": "astro.selectTypescriptVersion",
+          "when": "editorLangId == astro"
+        },
+        {
+          "command": "astro.findFileReferences",
+          "when": "editorLangId == astro"
+        }
+      ],
       "editor/context": [
         {
           "command": "astro.findFileReferences",


### PR DESCRIPTION
Closes #477

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

Adds a `when` clause to the commands so that they are only shown when browsing `.astro` files - which matches the behavior of the TypeScript plugin.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

TBD

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only - no docs needed
