### PR TITLE
1.0 for the VS Code extension, the TypeScript plugin and the Astro language server

### DIFF
--- a/.changeset/happy-dancers-exist.md
+++ b/.changeset/happy-dancers-exist.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/language-server': major
+'@astrojs/ts-plugin': major
+'astro-vscode': major
+---
+
+1.0! This release includes no new changes by itself, but symbolize the official release of what was previously the pre-release version of the extension. For changelogs, please refer to the changelog from `0.29.0` to now.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,15 @@ jobs:
         working-directory: ./packages/vscode
         run: |
           npm run build:ci:node
-          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --pre-release --target win32-x64 win32-ia32 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --target win32-x64 win32-ia32 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
           npm run build:ci:browser
-          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --pre-release --target web
+          npx vsce publish -p ${{ secrets.VSCE_TOKEN }} --target web
 
       - name: Publish to OpenVSX
         if: steps.changesets.outputs.published == 'true'
         working-directory: ./packages/vscode
         run: |
           npm run build:ci:node
-          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --pre-release --target win32-x64 win32-ia32 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
+          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --target win32-x64 win32-ia32 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64
           npm run build:ci:browser
-          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --pre-release --target web
+          npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --target web


### PR DESCRIPTION
## Changes

**Blocked by the following compiler issue:**
- https://github.com/withastro/compiler/issues/714

and the release of the 1.0 of the Prettier plugin:
- https://github.com/withastro/prettier-plugin-astro/pull/329

---

After a few months in pre-release squashing bugs left and right and making sure everything is stable, it's time to cut an official 1.0 release of all the packages in this repo! 

There's still a lot of work to be done in the language server, both on bugs and on features, but we generally consider the current experience to be stable and featureful enough to release a 1.0 and start looking toward the future.

After this, you can expect the packages in this repo to follow semver and adhere more officially to the process the core Astro follow for releasing new versions.

## Testing

N/A

## Docs

N/A