### PR TITLE
feat: upgrade compiler version

### DIFF
--- a/.changeset/tall-comics-give.md
+++ b/.changeset/tall-comics-give.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/ts-plugin': patch
+'astro-vscode': patch
+---
+
+Update compiler version to fix Windows mapping issue

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -26,6 +26,7 @@
     "events": "^3.3.0",
     "prettier": "^2.8.8",
     "prettier-plugin-astro": "^0.8.0",
+    "synckit": "^0.8.4",
     "vscode-css-languageservice": "^6.2.1",
     "vscode-html-languageservice": "^5.0.0",
     "vscode-languageserver": "^8.0.1",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -20,13 +20,12 @@
     "test:match": "pnpm run test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^1.1.1",
+    "@astrojs/compiler": "^1.3.2",
     "@jridgewell/trace-mapping": "^0.3.14",
     "@vscode/emmet-helper": "^2.8.4",
     "events": "^3.3.0",
-    "prettier": "^2.7.1",
-    "prettier-plugin-astro": "^0.7.0",
-    "synckit": "^0.8.4",
+    "prettier": "^2.8.8",
+    "prettier-plugin-astro": "^0.8.0",
     "vscode-css-languageservice": "^6.2.1",
     "vscode-html-languageservice": "^5.0.0",
     "vscode-languageserver": "^8.0.1",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -18,7 +18,7 @@
   "author": "withastro",
   "license": "MIT",
   "dependencies": {
-    "@astrojs/compiler": "^1.1.1",
+    "@astrojs/compiler": "^1.3.2",
     "@jridgewell/trace-mapping": "^0.3.15",
     "synckit": "^0.8.4"
   },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -48,11 +48,11 @@
     "workspaceContains:astro.config.*"
   ],
   "dependencies": {
-    "@astrojs/compiler": "^1.1.1",
+    "@astrojs/compiler": "^1.3.2",
     "synckit": "0.8.4",
     "@astrojs/ts-plugin": "0.4.4",
-    "prettier": "^2.7.1",
-    "prettier-plugin-astro": "^0.7.0"
+    "prettier": "^2.8.8",
+    "prettier-plugin-astro": "^0.8.0"
   },
   "devDependencies": {
     "@astrojs/language-server": "0.29.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,7 @@ importers:
       prettier-plugin-astro: ^0.8.0
       sinon: ^13.0.1
       svelte: ^3.49.0
+      synckit: ^0.8.4
       ts-node: ^10.7.0
       typescript: ~4.8.2
       vscode-css-languageservice: ^6.2.1
@@ -65,6 +66,7 @@ importers:
       events: 3.3.0
       prettier: 2.8.8
       prettier-plugin-astro: 0.8.0
+      synckit: 0.8.4
       vscode-css-languageservice: 6.2.1
       vscode-html-languageservice: 5.0.1
       vscode-languageserver: 8.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
   packages/language-server:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@jridgewell/trace-mapping':
         specifier: ^0.3.14
         version: 0.3.15
@@ -50,11 +50,11 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       prettier:
-        specifier: ^2.7.1
-        version: 2.7.1
+        specifier: ^2.8.8
+        version: 2.8.8
       prettier-plugin-astro:
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       synckit:
         specifier: ^0.8.4
         version: 0.8.4
@@ -135,8 +135,8 @@ importers:
   packages/ts-plugin:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@jridgewell/trace-mapping':
         specifier: ^0.3.15
         version: 0.3.15
@@ -178,17 +178,17 @@ importers:
   packages/vscode:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@astrojs/ts-plugin':
         specifier: 0.4.4
         version: link:../ts-plugin
       prettier:
-        specifier: ^2.7.1
-        version: 2.7.1
+        specifier: ^2.8.8
+        version: 2.8.8
       prettier-plugin-astro:
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       synckit:
         specifier: 0.8.4
         version: 0.8.4
@@ -274,8 +274,8 @@ packages:
     resolution: {integrity: sha512-1CCf+dktc8IQCdmsNNSIor3rcJE5OIirFnFtQWp1VUxqCacefqRRlsl9lH7JcKKpRvz1taL43yHYJP8dxNfVww==}
     dev: true
 
-  /@astrojs/compiler@1.1.1:
-    resolution: {integrity: sha512-JRDEARnuUUOlKUE4XVu8+NoeNWpOHtYQW39uWjqTbpefMjL95og54vTKLHqeUajXWeY115zZtO7jIVdOmQ1IPQ==}
+  /@astrojs/compiler@1.3.2:
+    resolution: {integrity: sha512-W/2Mdsq75ruK31dPVlXLdvAoknYDcm6+zXiFToSzQWI7wZqqR+51XTFgx90ojYbefk7z4VOJSVtZBz2pA82F5A==}
     dev: false
 
   /@astrojs/language-server@0.28.3:
@@ -665,7 +665,7 @@ packages:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.7.1
+      prettier: 2.8.8
       resolve-from: 5.0.0
       semver: 5.7.1
     dev: true
@@ -832,7 +832,7 @@ packages:
       '@changesets/types': 5.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.7.1
+      prettier: 2.8.8
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -5381,7 +5381,7 @@ packages:
       synckit: 0.8.4
     dev: true
 
-  /prettier-plugin-astro/0.8.0:
+  /prettier-plugin-astro@0.8.0:
     resolution: {integrity: sha512-kt9wk33J7HvFGwFaHb8piwy4zbUmabC8Nu+qCw493jhe96YkpjscqGBPy4nJ9TPy9pd7+kEx1zM81rp+MIdrXg==}
     engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
     dependencies:
@@ -5397,7 +5397,7 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier/2.8.8:
+  /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
 
   packages/language-server:
     specifiers:
-      '@astrojs/compiler': ^1.1.1
+      '@astrojs/compiler': ^1.3.2
       '@astrojs/svelte': ^1.0.0
       '@astrojs/vue': ^1.0.0
       '@jridgewell/trace-mapping': ^0.3.14
@@ -44,11 +44,10 @@ importers:
       cross-env: ^7.0.3
       events: ^3.3.0
       mocha: ^9.2.2
-      prettier: ^2.7.1
-      prettier-plugin-astro: ^0.7.0
+      prettier: ^2.8.8
+      prettier-plugin-astro: ^0.8.0
       sinon: ^13.0.1
       svelte: ^3.49.0
-      synckit: ^0.8.4
       ts-node: ^10.7.0
       typescript: ~4.8.2
       vscode-css-languageservice: ^6.2.1
@@ -60,13 +59,12 @@ importers:
       vscode-uri: ^3.0.3
       vue: ^3.2.37
     dependencies:
-      '@astrojs/compiler': 1.1.1
+      '@astrojs/compiler': 1.3.2
       '@jridgewell/trace-mapping': 0.3.15
       '@vscode/emmet-helper': 2.8.4
       events: 3.3.0
-      prettier: 2.7.1
-      prettier-plugin-astro: 0.7.0
-      synckit: 0.8.4
+      prettier: 2.8.8
+      prettier-plugin-astro: 0.8.0
       vscode-css-languageservice: 6.2.1
       vscode-html-languageservice: 5.0.1
       vscode-languageserver: 8.0.2
@@ -95,7 +93,7 @@ importers:
 
   packages/ts-plugin:
     specifiers:
-      '@astrojs/compiler': ^1.1.1
+      '@astrojs/compiler': ^1.3.2
       '@jridgewell/trace-mapping': ^0.3.15
       '@types/chai': ^4.3.0
       '@types/mocha': ^9.1.1
@@ -109,7 +107,7 @@ importers:
       synckit: ^0.8.4
       typescript: ~4.8.2
     dependencies:
-      '@astrojs/compiler': 1.1.1
+      '@astrojs/compiler': 1.3.2
       '@jridgewell/trace-mapping': 0.3.15
       synckit: 0.8.4
     devDependencies:
@@ -126,7 +124,7 @@ importers:
 
   packages/vscode:
     specifiers:
-      '@astrojs/compiler': ^1.1.1
+      '@astrojs/compiler': ^1.3.2
       '@astrojs/language-server': 0.29.6
       '@astrojs/ts-plugin': 0.4.4
       '@types/mocha': ^9.1.0
@@ -139,17 +137,17 @@ importers:
       kleur: ^4.1.5
       mocha: ^9.2.2
       path-browserify: ^1.0.1
-      prettier: ^2.7.1
-      prettier-plugin-astro: ^0.7.0
+      prettier: ^2.8.8
+      prettier-plugin-astro: ^0.8.0
       synckit: 0.8.4
       typescript: ~4.8.2
       vscode-languageclient: ^8.0.1
       vscode-tmgrammar-test: ^0.1.1
     dependencies:
-      '@astrojs/compiler': 1.1.1
+      '@astrojs/compiler': 1.3.2
       '@astrojs/ts-plugin': link:../ts-plugin
-      prettier: 2.7.1
-      prettier-plugin-astro: 0.7.0
+      prettier: 2.8.8
+      prettier-plugin-astro: 0.8.0
       synckit: 0.8.4
     devDependencies:
       '@astrojs/language-server': link:../language-server
@@ -197,9 +195,10 @@ packages:
 
   /@astrojs/compiler/0.29.16:
     resolution: {integrity: sha512-1CCf+dktc8IQCdmsNNSIor3rcJE5OIirFnFtQWp1VUxqCacefqRRlsl9lH7JcKKpRvz1taL43yHYJP8dxNfVww==}
+    dev: true
 
-  /@astrojs/compiler/1.1.1:
-    resolution: {integrity: sha512-JRDEARnuUUOlKUE4XVu8+NoeNWpOHtYQW39uWjqTbpefMjL95og54vTKLHqeUajXWeY115zZtO7jIVdOmQ1IPQ==}
+  /@astrojs/compiler/1.3.2:
+    resolution: {integrity: sha512-W/2Mdsq75ruK31dPVlXLdvAoknYDcm6+zXiFToSzQWI7wZqqR+51XTFgx90ojYbefk7z4VOJSVtZBz2pA82F5A==}
     dev: false
 
   /@astrojs/language-server/0.28.3:
@@ -208,7 +207,7 @@ packages:
     dependencies:
       '@vscode/emmet-helper': 2.8.4
       events: 3.3.0
-      prettier: 2.7.1
+      prettier: 2.8.8
       prettier-plugin-astro: 0.7.0
       source-map: 0.7.4
       vscode-css-languageservice: 6.2.1
@@ -5317,12 +5316,29 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0, npm: '>=6.14.0'}
     dependencies:
       '@astrojs/compiler': 0.29.16
-      prettier: 2.7.1
+      prettier: 2.8.8
       sass-formatter: 0.7.5
       synckit: 0.8.4
+    dev: true
+
+  /prettier-plugin-astro/0.8.0:
+    resolution: {integrity: sha512-kt9wk33J7HvFGwFaHb8piwy4zbUmabC8Nu+qCw493jhe96YkpjscqGBPy4nJ9TPy9pd7+kEx1zM81rp+MIdrXg==}
+    engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
+    dependencies:
+      '@astrojs/compiler': 1.3.2
+      prettier: 2.8.8
+      sass-formatter: 0.7.5
+      synckit: 0.8.4
+    dev: false
 
   /prettier/2.7.1:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prettier/2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 


### PR DESCRIPTION
## Changes

This only upgrades the compiler version, I tried to use the sync entrypoint and the bundling was breaking in weird ways. It works in the Volar PR though, so not sure what's up there...

Also updated Prettier stuff while I was there, since the version was behind

## Testing

CI should pass!

## Docs

N/A
