### PR TITLE
Fix `workspace/configuration` request parameter type

### DIFF
--- a/.changeset/modern-months-stare.md
+++ b/.changeset/modern-months-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fix type for `scopeUri` in workspace/configuration request

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -3,7 +3,7 @@ import type ts from 'typescript';
 import type { TextDocumentContentChangeEvent } from 'vscode-languageserver';
 import type { ConfigManager, LSTypescriptConfig } from '../../core/config';
 import type { AstroDocument } from '../../core/documents';
-import { getAstroInstall, normalizePath, urlToPath } from '../../utils';
+import { getAstroInstall, normalizePath, urlToPath, pathToUrl } from '../../utils';
 import { createAstroModuleLoader } from './module-loader';
 import {
 	AstroSnapshot,
@@ -107,11 +107,11 @@ async function createLanguageService(
 	const tsconfigRoot = tsconfigPath ? dirname(tsconfigPath) : process.cwd();
 
 	const workspacePaths = workspaceUris.map((uri) => urlToPath(uri) as string);
-	const workspacePath = workspacePaths.find((uri: string) => tsconfigRoot.startsWith(uri)) || workspacePaths[0];
+	const workspacePath = workspacePaths.find((p: string) => tsconfigRoot.startsWith(p)) || workspacePaths[0];
 	const astroInstall = getAstroInstall([tsconfigRoot, workspacePath]);
 
 	const config =
-		(await docContext.configManager.getConfig<LSTypescriptConfig>('astro.typescript', workspacePath)) ?? {};
+		(await docContext.configManager.getConfig<LSTypescriptConfig>('astro.typescript', pathToUrl(workspacePath))) ?? {};
 	const allowArbitraryAttrs = config.allowArbitraryAttributes ?? false;
 
 	// `raw` here represent the tsconfig merged with any extended config

--- a/packages/language-server/src/plugins/typescript/language-service.ts
+++ b/packages/language-server/src/plugins/typescript/language-service.ts
@@ -109,9 +109,9 @@ async function createLanguageService(
 	const workspacePaths = workspaceUris.map((uri) => urlToPath(uri) as string);
 	const workspacePath = workspacePaths.find((p: string) => tsconfigRoot.startsWith(p)) || workspacePaths[0];
 	const astroInstall = getAstroInstall([tsconfigRoot, workspacePath]);
+	const workspaceUri = workspacePath ? pathToUrl(workspacePath) : '';
 
-	const config =
-		(await docContext.configManager.getConfig<LSTypescriptConfig>('astro.typescript', pathToUrl(workspacePath))) ?? {};
+	const config = (await docContext.configManager.getConfig<LSTypescriptConfig>('astro.typescript', workspaceUri)) ?? {};
 	const allowArbitraryAttrs = config.allowArbitraryAttributes ?? false;
 
 	// `raw` here represent the tsconfig merged with any extended config


### PR DESCRIPTION
Closes https://github.com/withastro/language-tools/issues/526

## Changes

The [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration) dictates that the `workspace/configuration` method request contains a `scopeUri` which should be of type `DocumentUri`. This request was sometimes being sent with a path instead.

## Testing

Bugfix, not sure how to test

## Docs

No documentation update necessary
