### PR TITLE
fix: Fix TypeScript plugin compatibility with TS 5.0

### DIFF
--- a/.changeset/late-coins-tan.md
+++ b/.changeset/late-coins-tan.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/ts-plugin': patch
+'astro-vscode': patch
+---
+
+Fix importing `.astro` files in `.ts` files not working with TypeScript 5.0+

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import type ts from 'typescript/lib/tsserverlibrary';
 import { AstroSnapshotManager } from './astro-snapshots.js';
-import { decorateLanguageService } from './language-service/index.js';
+import { decorateLanguageService, isPatched } from './language-service/index.js';
 import { Logger } from './logger.js';
 import { patchModuleLoader } from './module-loader.js';
 import { ProjectAstroFilesManager } from './project-astro-files.js';
@@ -15,6 +15,10 @@ function init(modules: { typescript: typeof import('typescript/lib/tsserverlibra
 
 		if (!isAstroProject(info.project, parsedCommandLine)) {
 			logger.log('Detected that this is not an Astro project, abort patching TypeScript');
+			return info.languageService;
+		}
+
+		if (isPatched(info.languageService)) {
 			return info.languageService;
 		}
 

--- a/packages/ts-plugin/src/language-service/index.ts
+++ b/packages/ts-plugin/src/language-service/index.ts
@@ -10,19 +10,47 @@ import { decorateGetImplementation } from './implementation.js';
 import { decorateLineColumnOffset } from './line-column-offset.js';
 import { decorateRename } from './rename.js';
 
+const astroPluginPatchSymbol = Symbol('astroPluginPatchSymbol');
+
+export function isPatched(ls: ts.LanguageService) {
+	return (ls as any)[astroPluginPatchSymbol] === true;
+}
+
 export function decorateLanguageService(
 	ls: ts.LanguageService,
 	snapshotManager: AstroSnapshotManager,
 	logger: Logger
 ): ts.LanguageService {
-	decorateLineColumnOffset(ls, snapshotManager);
-	decorateRename(ls, snapshotManager, logger);
-	decorateDiagnostics(ls);
-	decorateFindReferences(ls, snapshotManager, logger);
-	decorateCompletions(ls, logger);
-	decorateGetDefinition(ls, snapshotManager);
-	decorateGetImplementation(ls, snapshotManager);
-	decorateGetFileReferences(ls, snapshotManager);
+	const proxy = new Proxy(ls, createProxyHandler());
 
-	return ls;
+	decorateLineColumnOffset(proxy, snapshotManager);
+	decorateRename(proxy, snapshotManager, logger);
+	decorateDiagnostics(proxy);
+	decorateFindReferences(proxy, snapshotManager, logger);
+	decorateCompletions(proxy, logger);
+	decorateGetDefinition(proxy, snapshotManager);
+	decorateGetImplementation(proxy, snapshotManager);
+	decorateGetFileReferences(proxy, snapshotManager);
+
+	return proxy;
+}
+
+function createProxyHandler(): ProxyHandler<ts.LanguageService> {
+	const decorated: Partial<ts.LanguageService> = {};
+
+	return {
+		get(target, p) {
+			// always return patch symbol whether the plugin is enabled or not
+			if (p === astroPluginPatchSymbol) {
+				return true;
+			}
+
+			return decorated[p as keyof ts.LanguageService] ?? target[p as keyof ts.LanguageService];
+		},
+		set(_, p, value) {
+			decorated[p as keyof ts.LanguageService] = value;
+
+			return true;
+		},
+	};
 }

--- a/packages/ts-plugin/src/language-service/index.ts
+++ b/packages/ts-plugin/src/language-service/index.ts
@@ -40,7 +40,6 @@ function createProxyHandler(): ProxyHandler<ts.LanguageService> {
 
 	return {
 		get(target, p) {
-			// always return patch symbol whether the plugin is enabled or not
 			if (p === astroPluginPatchSymbol) {
 				return true;
 			}

--- a/packages/ts-plugin/src/utils.ts
+++ b/packages/ts-plugin/src/utils.ts
@@ -1,3 +1,5 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+
 export function isAstroFilePath(filePath: string) {
 	return filePath.endsWith('.astro');
 }


### PR DESCRIPTION
## Changes

Our plugin was broken in TS 5.0+ due to internal changes to TS. This PR fixes this by using the recommended method for patching language services inside TypeScript plugins and patching the right method for resolving modules

Fix https://github.com/withastro/language-tools/issues/519

## Testing

Tests should pass!

## Docs

N/A
