### PR TITLE
fix: changed the LanguageClient.id because trace.server is not working

### DIFF
--- a/.changeset/happy-geese-invent.md
+++ b/.changeset/happy-geese-invent.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix `astro.trace.server` not working

--- a/packages/vscode/src/client.ts
+++ b/packages/vscode/src/client.ts
@@ -66,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Export
 		initializationOptions,
 	};
 	client = new lsp.LanguageClient(
-		'astro-language-server',
+		'astro',
 		'Astro Language Server',
 		serverOptions,
 		clientOptions


### PR DESCRIPTION
## Changes

Regarding the configuration of `astro.trace.server`. 

https://github.com/withastro/language-tools/blob/eb2ce0b3effd00e49294be57ef0f3d1cb5f8f454/packages/vscode/package.json#L141

I have made modifications because there seems to be a difference between the configured LanguageClient.id and the actual behavior.

https://github.com/withastro/language-tools/blob/eb2ce0b3effd00e49294be57ef0f3d1cb5f8f454/packages/vscode/src/client.ts#L69

## Testing

None

## Docs

None
