### PR TITLE
fix: crash with files with characters that can't be expressed with valid characters for TSX identifiers

### DIFF
--- a/.changeset/lazy-wolves-leave.md
+++ b/.changeset/lazy-wolves-leave.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix crash when a file named 404.astro was present in the project

--- a/packages/language-server/src/core/utils.ts
+++ b/packages/language-server/src/core/utils.ts
@@ -151,7 +151,12 @@ export function patchTSX(code: string, fileName: string) {
 	const basename = path.basename(fileName, path.extname(fileName));
 	const isDynamic = basename.startsWith('[') && basename.endsWith(']');
 
-	return code.replace(/\b(\S*)__AstroComponent_/, (_, m1: string) =>
-		isDynamic ? `_${m1}_` : m1[0].toUpperCase() + m1.slice(1)
-	);
+	return code.replace(/\b(\S*)__AstroComponent_/gm, (fullMatch, m1: string) => {
+		// If we don't have a match here, it usually means the file has a weird name that couldn't be expressed with valid identifier characters
+		if (!m1) {
+			if (basename === '404') return 'FourOhFour';
+			return fullMatch;
+		}
+		return isDynamic ? `_${m1}_` : m1[0].toUpperCase() + m1.slice(1);
+	});
 }


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
