### PR TITLE
Add a congrats bot workflow that posts to Discord

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -9,6 +9,6 @@ jobs:
     if: ${{ github.repository_owner == 'withastro' }}
     uses: withastro/automation/.github/workflows/congratsbot.yml@main
     with:
-      EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,😤,<:houston_astronaut:1052320929327349873>,<:houston_love:1047893778796662824>'
+      EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,😤,🛠️,<:houston_astronaut:1052320929327349873>,<:houston_love:1047893778796662824>'
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}

--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -1,0 +1,14 @@
+name: Congratsbot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  congrats:
+    if: ${{ github.repository_owner == 'withastro' }}
+    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    with:
+      EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,😤,<:houston_astronaut:1052320929327349873>,<:houston_love:1047893778796662824>'
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}


### PR DESCRIPTION
## Changes

Adds a workflow that uses our CongratsBot action to post to `#dev-tooling` on Discord.

Picks from the following emoji to open the message:
<img width="250" alt="image" src="https://github.com/withastro/language-tools/assets/357379/91ad000e-8ed9-4cbc-8284-e3652dbdb7fd">


### To-do
- [x] Add a `DISCORD_WEBHOOK_CONGRATS` secret to this repo on GitHub.

## Testing

Worked so far in other repos 🤞 

## Docs

N/A