### PR TITLE
Don’t congratulate the formatter 😠

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   congrats:
-    if: ${{ github.repository_owner == 'withastro' }}
+    if: ${{ github.repository_owner == 'withastro' && github.event.head_commit.message != '[ci] format' }}
     uses: withastro/automation/.github/workflows/congratsbot.yml@main
     with:
       EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,😤,🛠️,<:houston_astronaut:1052320929327349873>,<:houston_love:1047893778796662824>'


### PR DESCRIPTION
## Changes

Adds a condition to the congrats bot CI job, which causes the job to be skipped if the commit message is `[ci] format`.

## Testing
Same logic as in https://github.com/withastro/astro/blob/cc8e9de88179d2ed4b70980c60b41448db393429/.github/workflows/main.yml#L20

## Docs

N/A.