### PR TITLE
fix(formatting): Fix Prettier not importing the right file when formatting 

### DIFF
--- a/.changeset/five-rings-explode.md
+++ b/.changeset/five-rings-explode.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix formatting not working in certain situations

--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -11,14 +11,23 @@ export function setIsTrusted(_isTrusted: boolean) {
 	isTrusted = _isTrusted;
 }
 
-export function getPackagePath(packageName: string, fromPath: string[]): string | undefined {
+/**
+ * Get the path of a package's directory from the paths in `fromPath`, if `root` is set to false, it will return the path of the package's entry point
+ */
+export function getPackagePath(
+	packageName: string,
+	fromPath: string[],
+	root = true
+): string | undefined {
 	const paths = [];
 	if (isTrusted) {
 		paths.unshift(...fromPath);
 	}
 
 	try {
-		return dirname(require.resolve(packageName + '/package.json', { paths }));
+		return root
+			? dirname(require.resolve(packageName + '/package.json', { paths }))
+			: require.resolve(packageName, { paths });
 	} catch (e) {
 		return undefined;
 	}
@@ -63,7 +72,7 @@ export function importPrettier(fromPath: string): typeof prettier | undefined {
 }
 
 export function getPrettierPluginPath(fromPath: string): string | undefined {
-	const prettierPluginPath = getPackagePath('prettier-plugin-astro', [fromPath, __dirname]);
+	const prettierPluginPath = getPackagePath('prettier-plugin-astro', [fromPath, __dirname], false);
 
 	if (!prettierPluginPath) {
 		return undefined;

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -75,8 +75,7 @@ export const plugin: LanguageServerPlugin = (
 					languages: ['astro'],
 					ignoreIdeOptions: true,
 					resolveConfigOptions: {
-						// Prettier's cache is a bit cumbersome, because you need to reload the config yourself on change
-						// TODO: Upstream a fix for this
+						// This seems to be broken since Prettier 3, and it'll always use its cumbersome cache. Hopefully it works one day.
 						useCache: false,
 					},
 					additionalOptions: async (resolvedConfig) => {
@@ -85,9 +84,9 @@ export const plugin: LanguageServerPlugin = (
 								return [];
 							}
 
-							const hasPluginLoadedAlready = (await prettier.getSupportInfo()).languages.some(
-								(l: any) => l.name === 'astro'
-							);
+							const hasPluginLoadedAlready =
+								(await prettier.getSupportInfo()).languages.some((l: any) => l.name === 'astro') ||
+								resolvedConfig.plugins?.includes('prettier-plugin-astro'); // getSupportInfo doesn't seems to work very well in Prettier 3 for plugins
 
 							return hasPluginLoadedAlready ? [] : [prettierPluginPath];
 						}

--- a/packages/language-server/test/misc/format.test.ts
+++ b/packages/language-server/test/misc/format.test.ts
@@ -1,0 +1,27 @@
+import { Range } from '@volar/language-server';
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { LanguageServer, getLanguageServer } from '../server.js';
+
+describe('Formatting', () => {
+	let languageServer: LanguageServer;
+
+	before(async () => {
+		languageServer = await getLanguageServer();
+	});
+
+	it('Can format document', async () => {
+		const document = await languageServer.helpers.openFakeDocument(`---\n\n\n---`);
+		const formatEdits = await languageServer.helpers.requestFormatting(document, {
+			tabSize: 2,
+			insertSpaces: true,
+		});
+
+		expect(formatEdits).to.deep.equal([
+			{
+				range: Range.create(0, 0, 3, 3),
+				newText: '---\n\n---\n',
+			},
+		]);
+	});
+});

--- a/packages/language-server/test/server.ts
+++ b/packages/language-server/test/server.ts
@@ -27,6 +27,10 @@ export interface LanguageServer {
 		) => Promise<protocol.CompletionList>;
 		requestDiagnostics: (document: TextDocument) => Promise<protocol.FullDocumentDiagnosticReport>;
 		requestHover: (document: TextDocument, position: protocol.Position) => Promise<protocol.Hover>;
+		requestFormatting(
+			document: TextDocument,
+			options?: protocol.FormattingOptions
+		): Promise<protocol.TextEdit[]>;
 	};
 }
 
@@ -140,6 +144,17 @@ async function initLanguageServer() {
 					},
 					position: position,
 				});
+			},
+			async requestFormatting(document, options) {
+				return await connection.sendRequest<protocol.TextEdit[]>(
+					protocol.DocumentFormattingRequest.method,
+					{
+						textDocument: {
+							uri: document.uri,
+						},
+						options: options,
+					}
+				);
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

`getPackagePath` returns the root of the package (since that's what we want for editor integrations), however since Prettier plugins are now ESM, what we need is the specific file to import, so this fix that

Fix https://github.com/withastro/language-tools/issues/616

## Testing

I added a test 

## Docs

N/A
