### PR TITLE
feat(completions): Order `astro:` completions higher

### DIFF
--- a/.changeset/pink-geese-design.md
+++ b/.changeset/pink-geese-design.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Order `astro:*` completions higher than other completions

--- a/packages/language-server/src/plugins/typescript/completions.ts
+++ b/packages/language-server/src/plugins/typescript/completions.ts
@@ -4,11 +4,16 @@ export function enhancedProvideCompletionItems(completions: CompletionList): Com
 	completions.items = completions.items.filter(isValidCompletion).map((completion) => {
 		const source = completion?.data?.originalItem?.source;
 		if (source) {
-			// For components import, use the file kind and sort them higher, as they're often what the user want over something else
+			// Sort completions starting with `astro:` higher than other imports
+			if (source.startsWith('astro:')) {
+				completion.sortText = '\u0000' + (completion.sortText ?? completion.label);
+			}
+
+			// For components import, use the file kind and sort them first, as they're often what the user want over something else
 			if (['.astro', '.svelte', '.vue'].some((ext) => source.endsWith(ext))) {
 				completion.kind = CompletionItemKind.File;
 				completion.detail = completion.detail + '\n\n' + source;
-				completion.sortText = '\0';
+				completion.sortText = '\u0001' + (completion.sortText ?? completion.label);
 				completion.data.isComponent = true;
 			}
 		}

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -7,6 +7,7 @@ describe('TypeScript - Completions', async () => {
 	let languageServer: LanguageServer;
 
 	before(async () => (languageServer = await getLanguageServer()));
+
 	it('Can get completions in the frontmatter', async () => {
 		const document = await languageServer.helpers.openFakeDocument('---\nc\n---');
 		const completions = await languageServer.helpers.requestCompletion(
@@ -16,6 +17,7 @@ describe('TypeScript - Completions', async () => {
 
 		expect(completions.items).to.not.be.empty;
 	});
+
 	it('Can get completions in the template', async () => {
 		const document = await languageServer.helpers.openFakeDocument('{c}');
 		const completions = await languageServer.helpers.requestCompletion(
@@ -24,5 +26,19 @@ describe('TypeScript - Completions', async () => {
 		);
 
 		expect(completions.items).to.not.be.empty;
+	});
+
+	it('sort completions starting with `astro:` higher than other imports', async () => {
+		const document = await languageServer.helpers.openFakeDocument('<Image');
+		const completions = await languageServer.helpers.requestCompletion(
+			document,
+			Position.create(0, 6)
+		);
+
+		const imageCompletion = completions.items.find(
+			(item) => item.labelDetails?.description === 'astro:assets'
+		);
+
+		expect(imageCompletion?.sortText).to.equal('\x00￿16');
 	});
 });


### PR DESCRIPTION
## Changes

What the title says. Also a small fix to other completions to make sure their normal sorting order is still considered while sorting, despite being sorted higher. I'm not sure if it matters in VS Code, but other editors might use the full sorting text more

## Testing

Added a test

## Docs

N/A
