### PR TITLE
feat: Add new completions for getStaticPaths, interface Props and prerender

### DIFF
--- a/.changeset/soft-humans-check.md
+++ b/.changeset/soft-humans-check.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': minor
+'astro-vscode': minor
+---
+
+Add completions snippets for getStaticPaths, the Props interface and prerender statements

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -13,6 +13,7 @@ import { getVueLanguageModule } from './core/vue.js';
 import { getPrettierPluginPath, importPrettier } from './importPackage.js';
 import createAstroService from './plugins/astro.js';
 import createHtmlService from './plugins/html.js';
+import { createTypescriptAddonsService } from './plugins/typescript-addons/index.js';
 import createTypeScriptService from './plugins/typescript/index.js';
 import { getAstroInstall } from './utils.js';
 
@@ -62,6 +63,7 @@ export const plugin: LanguageServerPlugin = (
 		config.services.emmet ??= createEmmetService();
 		config.services.typescript ??= createTypeScriptService();
 		config.services.typescripttwoslash ??= createTypeScriptTwoSlashService();
+		config.services.typescriptaddons ??= createTypescriptAddonsService();
 		config.services.astro ??= createAstroService();
 
 		if (ctx) {

--- a/packages/language-server/src/plugins/typescript-addons/index.ts
+++ b/packages/language-server/src/plugins/typescript-addons/index.ts
@@ -1,0 +1,46 @@
+import type { CompletionList, Service } from '@volar/language-server';
+import { AstroFile } from '../../core/index.js';
+import { isInsideFrontmatter, isJSDocument } from '../utils.js';
+import { getSnippetCompletions } from './snippets.js';
+
+export const createTypescriptAddonsService =
+	(): Service =>
+	(context): ReturnType<Service> => {
+		return {
+			isAdditionalCompletion: true,
+			// Q: Why the empty transform and resolve functions?
+			// A: Volar will skip mapping the completion items if those functions are defined, as such we can return the snippets
+			// completions as-is, this is notably useful for snippets that insert to the frontmatter, since we don't need to map anything.
+			transformCompletionItem(item) {
+				return item;
+			},
+			provideCompletionItems(document, position, completionContext, token) {
+				if (
+					!context ||
+					!isJSDocument ||
+					token.isCancellationRequested ||
+					completionContext.triggerKind === 2
+				)
+					return null;
+
+				const [_, source] = context.documents.getVirtualFileByUri(document.uri);
+				const file = source?.root;
+				if (!(file instanceof AstroFile)) return undefined;
+
+				if (!isInsideFrontmatter(document.offsetAt(position), file.astroMeta.frontmatter))
+					return null;
+
+				const completionList: CompletionList = {
+					items: [],
+					isIncomplete: false,
+				};
+
+				completionList.items.push(...getSnippetCompletions(file.astroMeta.frontmatter));
+
+				return completionList;
+			},
+			resolveCompletionItem(item) {
+				return item;
+			},
+		};
+	};

--- a/packages/language-server/src/plugins/typescript-addons/snippets.ts
+++ b/packages/language-server/src/plugins/typescript-addons/snippets.ts
@@ -1,0 +1,65 @@
+import { CompletionItemKind, TextEdit, type CompletionItem } from '@volar/language-server';
+import type { FrontmatterStatus } from '../../core/parseAstro.js';
+
+export function getSnippetCompletions(frontmatter: FrontmatterStatus): CompletionItem[] {
+	if (frontmatter.status === 'doesnt-exist') return [];
+
+	const frontmatterStartPosition = {
+		line: frontmatter.position.start.line,
+		character: frontmatter.position.start.column - 1,
+	};
+
+	return [
+		{
+			label: 'interface Props',
+			kind: CompletionItemKind.Snippet,
+			labelDetails: { description: 'Create a new interface to type your props' },
+			documentation: {
+				kind: 'markdown',
+				value: [
+					'Create a new interface to type your props.',
+					'\n',
+					'[Astro reference](https://docs.astro.build/en/guides/typescript/#component-props)',
+				].join('\n'),
+			},
+			insertTextFormat: 2,
+			filterText: 'interface props',
+			insertText: 'interface Props {\n\t$1\n}',
+		},
+		{
+			label: 'getStaticPaths',
+			kind: CompletionItemKind.Snippet,
+			labelDetails: { description: 'Create a new getStaticPaths function' },
+			documentation: {
+				kind: 'markdown',
+				value: [
+					'Create a new getStaticPaths function.',
+					'\n',
+					'[Astro reference](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)',
+				].join('\n'),
+			},
+			insertText:
+				'export const getStaticPaths = (() => {\n\t$1\n\treturn [];\n}) satisfies GetStaticPaths;',
+			additionalTextEdits: [
+				TextEdit.insert(frontmatterStartPosition, 'import type { GetStaticPaths } from "astro";\n'),
+			],
+			filterText: 'getstaticpaths',
+			insertTextFormat: 2,
+		},
+		{
+			label: 'prerender',
+			kind: CompletionItemKind.Snippet,
+			labelDetails: { description: 'Add prerender export' },
+			documentation: {
+				kind: 'markdown',
+				value: [
+					'Add prerender export. When [using server-side rendering](https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project), this value will be used to determine whether to prerender the page or not.',
+					'\n',
+					'[Astro reference](https://docs.astro.build/en/guides/server-side-rendering/#configuring-individual-routes)',
+				].join('\n'),
+			},
+			insertText: 'export const prerender = ${1|true,false,import.meta.env.|}',
+			insertTextFormat: 2,
+		},
+	];
+}

--- a/packages/language-server/test/typescript-addons/completions.test.ts
+++ b/packages/language-server/test/typescript-addons/completions.test.ts
@@ -1,0 +1,21 @@
+import { Position } from '@volar/language-server';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+import { LanguageServer, getLanguageServer } from '../server.js';
+
+describe('TypeScript Addons - Completions', async () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+	it('Can provide neat snippets', async () => {
+		const document = await languageServer.helpers.openFakeDocument('---\nprerender\n---');
+		const completions = await languageServer.helpers.requestCompletion(
+			document,
+			Position.create(1, 10)
+		);
+
+		const prerenderCompletions = completions.items.filter((item) => item.label === 'prerender');
+		expect(prerenderCompletions).to.not.be.empty;
+		expect(prerenderCompletions[0].data.serviceId).to.equal('typescriptaddons');
+	});
+});


### PR DESCRIPTION
## Changes

Some cute snippets completions for a neat DX.

https://github.com/withastro/language-tools/assets/3019731/87d97b15-ce68-4161-8130-7e5a66ecd42c

For the moment this only work in Astro files. We need to make some changes to our TS plugin before we can make that work there

## Testing

Added a test

## Docs

N/A
