### PR TITLE
Fix TypeScript plugin crash

### DIFF
--- a/.changeset/new-goats-lie.md
+++ b/.changeset/new-goats-lie.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/ts-plugin': patch
+'astro-vscode': patch
+---
+
+Fix TSServer crashing in certain situations

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -18,6 +18,18 @@ const init: ts.server.PluginModuleFactory = (modules) => {
 			decorateLanguageService(virtualFiles, info.languageService, true);
 			decorateLanguageServiceHost(virtualFiles, info.languageServiceHost, ts, ['.astro']);
 
+			const getScriptKind = info.languageServiceHost.getScriptKind?.bind(
+				info.languageServiceHost.getScriptKind
+			);
+			if (getScriptKind) {
+				info.languageServiceHost.getScriptKind = (fileName) => {
+					if (fileName.endsWith('.astro')) {
+						return ts.ScriptKind.TSX;
+					}
+					return getScriptKind(fileName);
+				};
+			}
+
 			return info.languageService;
 		},
 		getExternalFiles(project) {


### PR DESCRIPTION
## Changes

Workaround for an upstream bug in TypeScript

Fix https://github.com/withastro/language-tools/issues/622
Fix https://github.com/withastro/language-tools/issues/614

## Testing

I'm... not sure how to test this. We have some tests for the TypeScript plugin, and they still pass. I was never able to reproduce any crashes in local, so. I ran around a repo using `moduleResolution: 'bundler'` and everything seemed to work.

## Docs

N/A
