### PR TITLE
Support prettier-plugin-astro v0.12 in language-server

### DIFF
--- a/.changeset/lazy-pugs-melt.md
+++ b/.changeset/lazy-pugs-melt.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Support prettier-plugin-astro v0.12 and higher in language-server

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "prettier": "^3.0.0",
-    "prettier-plugin-astro": "^0.11.0 || ^0.12.0"
+    "prettier-plugin-astro": ">=0.11.0"
   },
   "peerDependenciesMeta": {
     "prettier": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "prettier": "^3.0.0",
-    "prettier-plugin-astro": "^0.11.0"
+    "prettier-plugin-astro": "^0.11.0 || ^0.12.0"
   },
   "peerDependenciesMeta": {
     "prettier": {


### PR DESCRIPTION
## Changes

Bump peer dep range to support prettier-plugin-astro 0.12. Encountered this while bumping deps in core.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran formatting and checks in core with 0.12 and it works.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
n/a. bump range only.