### PR TITLE
Use editor formatting settings as fallback when there's no Prettier config

### DIFF
--- a/.changeset/tiny-paws-design.md
+++ b/.changeset/tiny-paws-design.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Use editor formatting settings as a fallback when there's no Prettier config

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -76,6 +76,7 @@ export const plugin: LanguageServerPlugin = (
 					prettier: prettier,
 					languages: ['astro'],
 					ignoreIdeOptions: true,
+					useIdeOptionsFallback: true,
 					resolveConfigOptions: {
 						// This seems to be broken since Prettier 3, and it'll always use its cumbersome cache. Hopefully it works one day.
 						useCache: false,


### PR DESCRIPTION
## Changes

I added that option myself to Volar and then promptly forgot to use it here. Derp.

Fix https://github.com/withastro/language-tools/issues/635

## Testing

Tested manually, testing formatting settings is only vaguely possible in the monorepo because Prettier tends to find the monorepo's formatting config

## Docs

N/A
