### PR TITLE
fix(parser): nested <script> tags are not extracted

### DIFF
--- a/.changeset/cold-llamas-compare.md
+++ b/.changeset/cold-llamas-compare.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix intellisense not working in nested script and style tags

--- a/packages/language-server/src/core/parseJS.ts
+++ b/packages/language-server/src/core/parseJS.ts
@@ -17,7 +17,7 @@ export function extractScriptTags(
 	htmlDocument: HTMLDocument,
 	ast: ParseResult['ast']
 ): VirtualFile[] {
-	const embeddedJSFiles: VirtualFile['embeddedFiles'] = extractEmbeddedJSFilesRecursively(
+	const embeddedJSFiles: VirtualFile[] = findIsolatedScripts(
 		fileName,
 		snapshot,
 		htmlDocument.roots
@@ -29,90 +29,83 @@ export function extractScriptTags(
 	].sort((a, b) => a.startOffset - b.startOffset);
 
 	if (javascriptContexts.length > 0) {
-		const codes: muggle.Segment<FileRangeCapabilities>[] = [];
-
-		for (const javascriptContext of javascriptContexts) {
-			codes.push([
-				javascriptContext.content,
-				undefined,
-				javascriptContext.startOffset,
-				FileRangeCapabilities.full,
-			]);
-		}
-
-		const mappings = SourceMap.buildMappings(codes);
-		const text = muggle.toString(codes);
-
-		embeddedJSFiles.push({
-			fileName: fileName + '.inline.mjs',
-			codegenStacks: [],
-			snapshot: {
-				getText: (start, end) => text.substring(start, end),
-				getLength: () => text.length,
-				getChangeRange: () => undefined,
-			},
-			capabilities: FileCapabilities.full,
-			embeddedFiles: [],
-			kind: FileKind.TypeScriptHostFile,
-			mappings,
-		});
+		embeddedJSFiles.push(mergeJSContexts(fileName, javascriptContexts));
 	}
 
 	return embeddedJSFiles;
 }
 
-function extractEmbeddedJSFilesRecursively(
-	fileName: string,
-	snapshot: ts.IScriptSnapshot,
-	roots: Node[],
-	array: VirtualFile['embeddedFiles'] = [],
-	level: string[] = []
-): VirtualFile['embeddedFiles'] {
-	for (const [index, root] of roots.entries()) {
-		const currentLevel = [...level, index.toString()]; // Append current index to the level
-		const newFileName = `${fileName}.${currentLevel.join('.')}`;
-
-		if (
-			root.tag === 'script' &&
-			root.startTagEnd !== undefined &&
-			root.endTagStart !== undefined &&
-			isIsolatedScriptTag(root)
-		) {
-			const scriptText = snapshot.getText(root.startTagEnd, root.endTagStart);
-
-			array.push({
-				fileName: newFileName + '.mts',
-				kind: FileKind.TypeScriptHostFile,
-				snapshot: {
-					getText: (start, end) => scriptText.substring(start, end),
-					getLength: () => scriptText.length,
-					getChangeRange: () => undefined,
-				},
-				codegenStacks: [],
-				mappings: [
-					{
-						sourceRange: [root.startTagEnd, root.endTagStart],
-						generatedRange: [0, scriptText.length],
-						data: FileRangeCapabilities.full,
-					},
-				],
-				capabilities: {
-					diagnostic: true,
-					codeAction: true,
-					inlayHint: true,
-					documentSymbol: true,
-					foldingRange: true,
-					documentFormatting: false,
-				},
-				embeddedFiles: [],
-			});
-		}
-
-		if (!root.children?.length) continue; // Early return if no children (no need to recurse)
-		extractEmbeddedJSFilesRecursively(newFileName, snapshot, root.children, array, currentLevel);
+function isIsolatedScriptTag(scriptTag: Node): boolean {
+	// Using any kind of attributes on the script tag will disable hoisting
+	if (
+		!scriptTag.attributes ||
+		(scriptTag.attributes && Object.entries(scriptTag.attributes).length === 0) ||
+		scriptTag.attributes['type']?.includes('module')
+	) {
+		return true;
 	}
 
-	return array;
+	return false;
+}
+
+/**
+ * Get all the isolated scripts in the HTML document
+ * Isolated scripts are scripts that are hoisted by Astro and as such, are isolated from the rest of the code because of the implicit `type="module"`
+ * All the isolated scripts are passed to the TypeScript language server as separate `.mts` files.
+ */
+function findIsolatedScripts(
+	fileName: string,
+	snapshot: ts.IScriptSnapshot,
+	roots: Node[]
+): VirtualFile[] {
+	const embeddedScripts: VirtualFile[] = [];
+	let scriptIndex = 0;
+
+	getEmbeddedScriptsInNodes(roots);
+
+	function getEmbeddedScriptsInNodes(nodes: Node[]) {
+		for (const [_, node] of nodes.entries()) {
+			if (
+				node.tag === 'script' &&
+				node.startTagEnd !== undefined &&
+				node.endTagStart !== undefined &&
+				isIsolatedScriptTag(node)
+			) {
+				const scriptText = snapshot.getText(node.startTagEnd, node.endTagStart);
+				embeddedScripts.push({
+					fileName: fileName + `.${scriptIndex}.mts`,
+					kind: FileKind.TypeScriptHostFile,
+					snapshot: {
+						getText: (start, end) => scriptText.substring(start, end),
+						getLength: () => scriptText.length,
+						getChangeRange: () => undefined,
+					},
+					codegenStacks: [],
+					mappings: [
+						{
+							sourceRange: [node.startTagEnd, node.endTagStart],
+							generatedRange: [0, scriptText.length],
+							data: FileRangeCapabilities.full,
+						},
+					],
+					capabilities: {
+						diagnostic: true,
+						codeAction: true,
+						inlayHint: true,
+						documentSymbol: true,
+						foldingRange: true,
+						documentFormatting: false,
+					},
+					embeddedFiles: [],
+				});
+				scriptIndex++;
+			}
+
+			if (node.children) getEmbeddedScriptsInNodes(node.children);
+		}
+	}
+
+	return embeddedScripts;
 }
 
 interface JavaScriptContext {
@@ -120,23 +113,35 @@ interface JavaScriptContext {
 	startOffset: number;
 }
 
+/**
+ * Get all the inline scripts in the HTML document
+ * Inline scripts are scripts that are not hoisted by Astro and as such, are isolated from the rest of the code.
+ * All the inline scripts are concatenated into a single `.mjs` file and passed to the TypeScript language server.
+ */
 function findInlineScripts(
 	htmlDocument: HTMLDocument,
 	snapshot: ts.IScriptSnapshot
 ): JavaScriptContext[] {
 	const inlineScripts: JavaScriptContext[] = [];
-	for (const [_, root] of htmlDocument.roots.entries()) {
-		if (
-			root.tag === 'script' &&
-			root.startTagEnd !== undefined &&
-			root.endTagStart !== undefined &&
-			!isIsolatedScriptTag(root)
-		) {
-			const scriptText = snapshot.getText(root.startTagEnd, root.endTagStart);
-			inlineScripts.push({
-				startOffset: root.startTagEnd,
-				content: scriptText,
-			});
+
+	getInlineScriptsInNodes(htmlDocument.roots);
+
+	function getInlineScriptsInNodes(nodes: Node[]) {
+		for (const [_, node] of nodes.entries()) {
+			if (
+				node.tag === 'script' &&
+				node.startTagEnd !== undefined &&
+				node.endTagStart !== undefined &&
+				!isIsolatedScriptTag(node)
+			) {
+				const scriptText = snapshot.getText(node.startTagEnd, node.endTagStart);
+				inlineScripts.push({
+					startOffset: node.startTagEnd,
+					content: scriptText,
+				});
+			}
+
+			if (node.children) getInlineScriptsInNodes(node.children);
 		}
 	}
 
@@ -175,20 +180,40 @@ function findEventAttributes(ast: ParseResult['ast']): JavaScriptContext[] {
 	return eventAttrs;
 }
 
-export function isIsolatedScriptTag(scriptTag: Node): boolean {
-	// Using any kind of attributes on the script tag will disable hoisting
-	if (
-		!scriptTag.attributes ||
-		(scriptTag.attributes && Object.entries(scriptTag.attributes).length === 0) ||
-		scriptTag.attributes['type']?.includes('module')
-	) {
-		return true;
+/**
+ * Merge all the inline and non-hoisted scripts into a single `.mjs` file
+ */
+function mergeJSContexts(fileName: string, javascriptContexts: JavaScriptContext[]): VirtualFile {
+	const codes: muggle.Segment<FileRangeCapabilities>[] = [];
+
+	for (const javascriptContext of javascriptContexts) {
+		codes.push([
+			javascriptContext.content,
+			undefined,
+			javascriptContext.startOffset,
+			FileRangeCapabilities.full,
+		]);
 	}
 
-	return false;
+	const mappings = SourceMap.buildMappings(codes);
+	const text = muggle.toString(codes);
+
+	return {
+		fileName: fileName + '.inline.mjs',
+		codegenStacks: [],
+		snapshot: {
+			getText: (start, end) => text.substring(start, end),
+			getLength: () => text.length,
+			getChangeRange: () => undefined,
+		},
+		capabilities: FileCapabilities.full,
+		embeddedFiles: [],
+		kind: FileKind.TypeScriptHostFile,
+		mappings,
+	};
 }
 
-export const htmlEventAttributes = [
+const htmlEventAttributes = [
 	'onabort',
 	'onafterprint',
 	'onauxclick',

--- a/packages/language-server/test/units/parseCSS.test.ts
+++ b/packages/language-server/test/units/parseCSS.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import ts from 'typescript/lib/tsserverlibrary.js';
+import { getAstroMetadata } from '../../src/core/parseAstro.js';
+import { extractStylesheets } from '../../src/core/parseCSS.js';
+import { parseHTML } from '../../src/core/parseHTML.js';
+
+describe('parseCSS - Can find all the styles in an Astro file', () => {
+	it('Can find all the styles in an Astro file, including nested tags', () => {
+		const input = `<style>h1{color: blue;}</style><div><style>h2{color: red;}</style></div>`;
+		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const html = parseHTML('something/style/hello.astro', snapshot, 0);
+		const astroAst = getAstroMetadata(input).ast;
+
+		const styleTags = extractStylesheets(
+			'something/style/hello.astro',
+			snapshot,
+			html.htmlDocument,
+			astroAst
+		);
+
+		expect(styleTags.length).to.equal(2);
+	});
+});

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import ts from 'typescript/lib/tsserverlibrary.js';
+import { getAstroMetadata } from '../../src/core/parseAstro.js';
+import { parseHTML } from '../../src/core/parseHTML.js';
+import { extractScriptTags } from '../../src/core/parseJS.js';
+
+describe('parseJS - Can find all the scripts in an Astro file', () => {
+	it('Can find all the scripts in an Astro file, including nested tags', () => {
+		const input = `<script>console.log('hi')</script><div><script>console.log('hi2')</script></div>`;
+		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const html = parseHTML('something/something/hello.astro', snapshot, 0);
+		const astroAst = getAstroMetadata(input).ast;
+
+		const scriptTags = extractScriptTags(
+			'something/something/hello.astro',
+			snapshot,
+			html.htmlDocument,
+			astroAst
+		);
+
+		expect(scriptTags.length).to.equal(2);
+	});
+});


### PR DESCRIPTION
## Changes

The `language-server` only embedded `<script>`&`<style>` tags on root level. This PR adds recursion on extracting/embedding all `<script>`&`<style>` tags from the `htmlDocument`. Using `.children` recursively.

## Testing

Added tests. Additionally, the change was tested by nesting multiple `<div>`'s and then trying to autocomplete in an `<script>` or `<style>` tag. I didn't find any relevant tests for that sort of case, if wanted I could add one.

## Docs

bug fix only
