### PR TITLE
parseJS will now ignore JSON scripts 

### DIFF
--- a/.changeset/cool-pumpkins-invent.md
+++ b/.changeset/cool-pumpkins-invent.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix errors on JSON script tags

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ package-lock.json
 .vscode-test/
 *.vsix
 packages/vscode/meta.json
+.tool-versions
 
 # .vscode files other than at top-level
 **/.vscode

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -20,4 +20,20 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 
 		expect(scriptTags.length).to.equal(2);
 	});
+
+	it('Ignore JSON scripts', () => {
+		const input = `<script type="application/json">{foo: "bar"}</script>`;
+		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const html = parseHTML('something/something/hello.astro', snapshot, 0);
+		const astroAst = getAstroMetadata(input).ast;
+
+		const scriptTags = extractScriptTags(
+			'something/something/hello.astro',
+			snapshot,
+			html.htmlDocument,
+			astroAst
+		);
+
+		expect(scriptTags.length).to.equal(0);
+	});
 });


### PR DESCRIPTION
Fix #513

## Changes

- `parseJS` will now ignore JSON scripts, including both MIME JSON types and `importmap` and `speculationrules` script types

## Testing

- Add a test "Ignore JSON scripts" in `packages/language-server/test/units/parseJS.test.ts`

## Docs

N/A
