### PR TITLE
Prettier: fix usage of plugins without prettier-plugin-astro

### DIFF
--- a/.changeset/hot-months-promise.md
+++ b/.changeset/hot-months-promise.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix usage of prettier plugins without prettier-plugin-astro

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -103,9 +103,9 @@ export const plugin: LanguageServerPlugin = (
 						];
 
 						return {
+							...resolvedConfig,
 							plugins: plugins,
 							parser: 'astro',
-							...resolvedConfig,
 						};
 					},
 				});


### PR DESCRIPTION
fix #668

## Changes

One line fix : in `packages/language-server/src/languageServerPlugin.ts`, `resolvedConfig` overwrite our plugins array.

## Testing

Module not tested.

## Docs

N/A.
