### PR TITLE
feat: add full reason for editor integration failing to load

### DIFF
--- a/.changeset/late-horses-call.md
+++ b/.changeset/late-horses-call.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Show full reason why an editor integration might have failed loading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing
 
-> See the [overview video](https://www.loom.com/share/609f7b61795349328730f14e1ae2166e) on how the extension works.
-
 ## Setup
 
 All Astro projects use [pnpm](https://pnpm.io/) and [Turbo](https://turborepo.org/) to enable development in a monorepo. Once you've cloned the project install dependencies and do an initial build:
@@ -20,6 +18,8 @@ During the normal course of development on the VSCode extension you'll want to r
 ```shell
 pnpm dev
 ```
+
+> Note: If you haven't ran `pnpm build` or `pnpm dev` already, you may see some errors related to some files being missing. This is normal on a first run, and you can safely ignore these errors.
 
 ### Start Debugger
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ During the normal course of development on the VSCode extension you'll want to r
 pnpm dev
 ```
 
-> Note: If you haven't ran `pnpm build` or `pnpm dev` already, you may see some errors related to some files being missing. This is normal on a first run, and you can safely ignore these errors.
+> [!NOTE] 
+> If you haven't ran `pnpm build` or `pnpm dev` already, you may see some errors related to some files being missing. This is normal on a first run, and you can safely ignore these errors.
 
 ### Start Debugger
 

--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -43,7 +43,7 @@ function importEditorIntegration<T>(packageName: string, fromPath: string): T | 
 			return require(main) as T;
 		} catch (e) {
 			console.error(
-				`Couldn't load editor module from ${pkgPath}. Make sure you're using at least version v0.2.1 of the corresponding integration`
+				`Couldn't load editor module from ${pkgPath}. Make sure you're using at least version v0.2.1 of the corresponding integration. Reason: ${e}`
 			);
 
 			return undefined;


### PR DESCRIPTION
## Changes

Just a small thing. Editor integrations from Vue and Svelte can fail to load sometimes, previously we'd just output a generic message when we can show the entire error. This prevented users from debugging https://github.com/withastro/language-tools/issues/652 on their end

## Testing

N/A

## Docs

N/A