### PR TITLE
fix: formatting messing up inline scripts

### DIFF
--- a/.changeset/chilly-bananas-repeat.md
+++ b/.changeset/chilly-bananas-repeat.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Fix formatting sometimes causing the code to become invalid inside inline events (onclick, onload...)

--- a/packages/language-server/src/core/parseJS.ts
+++ b/packages/language-server/src/core/parseJS.ts
@@ -1,11 +1,6 @@
 import type { ParentNode, ParseResult } from '@astrojs/compiler/types';
 import { is } from '@astrojs/compiler/utils';
-import {
-	FileCapabilities,
-	FileKind,
-	FileRangeCapabilities,
-	VirtualFile,
-} from '@volar/language-core';
+import { FileKind, FileRangeCapabilities, VirtualFile } from '@volar/language-core';
 import * as SourceMap from '@volar/source-map';
 import * as muggle from 'muggle-string';
 import type ts from 'typescript/lib/tsserverlibrary';
@@ -225,7 +220,14 @@ function mergeJSContexts(fileName: string, javascriptContexts: JavaScriptContext
 			getLength: () => text.length,
 			getChangeRange: () => undefined,
 		},
-		capabilities: FileCapabilities.full,
+		capabilities: {
+			codeAction: true,
+			diagnostic: true,
+			documentFormatting: false,
+			documentSymbol: true,
+			foldingRange: true,
+			inlayHint: true,
+		},
 		embeddedFiles: [],
 		kind: FileKind.TypeScriptHostFile,
 		mappings,

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -37,7 +37,7 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 		expect(scriptTags.length).to.equal(0);
 	});
 
-	it('returns the proper capabilities for inline script tags zzzz', () => {
+	it('returns the proper capabilities for inline script tags', () => {
 		const input = `<script is:inline>console.log('hi')</script>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
 		const html = parseHTML('something/something/hello.astro', snapshot, 0);

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -36,4 +36,27 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 
 		expect(scriptTags.length).to.equal(0);
 	});
+
+	it('returns the proper capabilities for inline script tags zzzz', () => {
+		const input = `<script is:inline>console.log('hi')</script>`;
+		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const html = parseHTML('something/something/hello.astro', snapshot, 0);
+		const astroAst = getAstroMetadata(input).ast;
+
+		const scriptTags = extractScriptTags(
+			'something/something/hello.astro',
+			snapshot,
+			html.htmlDocument,
+			astroAst
+		);
+
+		expect(scriptTags[0].capabilities).to.deep.equal({
+			diagnostic: true,
+			foldingRange: true,
+			documentFormatting: false,
+			documentSymbol: true,
+			codeAction: true,
+			inlayHint: true,
+		});
+	});
 });


### PR DESCRIPTION
## Changes

Formatting was wrongly enabled inside inline script tags capabilities, we don't want formatting on virtual files because Prettier handles the entire `.astro` file itself

## Testing

Added a test

## Docs

N/A
