### PR TITLE
fix: improve Astro detection to avoid false warnings

### DIFF
--- a/.changeset/rich-adults-sparkle.md
+++ b/.changeset/rich-adults-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+---
+
+Improve detection of Astro in complex monorepos

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -130,9 +130,13 @@ export class AstroCheck {
 		this.ts = this.typescriptPath ? require(this.typescriptPath) : require('typescript');
 		const tsconfigPath = this.getTsconfig();
 
+		const astroInstall = getAstroInstall([this.workspacePath]);
 		const config: kit.Config = {
 			languages: {
-				astro: getLanguageModule(getAstroInstall([this.workspacePath]), this.ts),
+				astro: getLanguageModule(
+					typeof astroInstall === 'string' ? undefined : astroInstall,
+					this.ts
+				),
 				svelte: getSvelteLanguageModule(),
 				vue: getVueLanguageModule(),
 			},

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -11,9 +11,43 @@ export interface AstroInstall {
 	};
 }
 
-export function getAstroInstall(basePaths: string[]): AstroInstall | undefined {
+export function getAstroInstall(
+	basePaths: string[],
+	checkForAstro?: {
+		nearestPackageJson: string | undefined;
+		readDirectory: typeof import('typescript/lib/tsserverlibrary.js').sys.readDirectory;
+	}
+): AstroInstall | 'not-an-astro-project' | 'not-found' {
 	let astroPath;
 	let version;
+
+	if (checkForAstro && checkForAstro.nearestPackageJson) {
+		basePaths.push(path.dirname(checkForAstro.nearestPackageJson));
+
+		let deps: Set<string> = new Set();
+		try {
+			const packageJSON = require(checkForAstro.nearestPackageJson);
+			[
+				...Object.keys(packageJSON.dependencies ?? {}),
+				...Object.keys(packageJSON.devDependencies ?? {}),
+				...Object.keys(packageJSON.peerDependencies ?? {}),
+			].forEach((dep) => deps.add(dep));
+		} catch {}
+
+		if (!deps.has('astro')) {
+			const directoryContent = checkForAstro.readDirectory(
+				path.dirname(checkForAstro.nearestPackageJson),
+				['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
+				undefined,
+				undefined,
+				1
+			);
+
+			if (!directoryContent.some((file) => path.basename(file).startsWith('astro.config'))) {
+				return 'not-an-astro-project';
+			}
+		}
+	}
 
 	try {
 		astroPath = getPackagePath('astro', basePaths);
@@ -39,7 +73,7 @@ export function getAstroInstall(basePaths: string[]): AstroInstall | undefined {
 				`${basePaths[0]} seems to be an Astro project, but we couldn't find Astro or Astro is not installed`
 			);
 
-			return undefined;
+			return 'not-found';
 		}
 	}
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -77,6 +77,10 @@ export function getAstroInstall(
 		}
 	}
 
+	if (!version) {
+		return 'not-found';
+	}
+
 	let [major, minor, patch] = version.split('.');
 
 	if (patch.includes('-')) {


### PR DESCRIPTION
## Changes

Improve the Astro detection to only attempt to find Astro in relevant contexts and better handle incomplete packages

Fix https://github.com/withastro/language-tools/issues/704
Fix https://github.com/withastro/language-tools/issues/644 (as far as I could tell? I tried reproducing it in both npm and pnpm and couldn't, everything worked perfectly fine.)

## Testing

Tested manually, we can't really test this in the monorepo because `astro` is a devDep of some things and so resolution isn't really accurate compared to a normal Astro project.

## Docs

N/A
