### PR TITLE
Fix ignored minimal severity flag

### DIFF
--- a/.changeset/popular-shirts-fix.md
+++ b/.changeset/popular-shirts-fix.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fix ignored minimal severity flag

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -83,7 +83,7 @@ export class AstroCheck {
 				const severity = diag.severity ?? DiagnosticSeverity.Error;
 				switch (logErrors?.level ?? 'error') {
 					case 'error':
-						return true;
+						return severity <= DiagnosticSeverity.Error;
 					case 'warning':
 						return severity <= DiagnosticSeverity.Warning;
 					case 'hint':

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -81,7 +81,7 @@ export class AstroCheck {
 			// Filter diagnostics based on the logErrors level
 			const fileDiagnosticsToPrint = fileDiagnostics.filter((diag) => {
 				const severity = diag.severity ?? DiagnosticSeverity.Error;
-				switch (logErrors?.level ?? 'error') {
+				switch (logErrors?.level ?? 'hint') {
 					case 'error':
 						return severity <= DiagnosticSeverity.Error;
 					case 'warning':


### PR DESCRIPTION
## Changes

When you use `astro check --minimumSeverity error`, it's supposed to filter logs based on the severity level, but it's showing all logs, regardless of this setting. 

I've tweaked it so that the default is now `hint`, which keeps things as they were. But when you set `--minimumSeverity error`, it'll only show the logs that are errors, just like you'd expect.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

There aren't any automated tests for this feature yet, so I just tested this manually.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

This update is more about fixing the behavior to match what we say in the `--help` output, and I didn't find any specific documentation that needs updating for this.
