### PR TITLE
fix(ast): Don't crash language-server if the compiler fails to parse a file

### DIFF
--- a/.changeset/curly-rabbits-rush.md
+++ b/.changeset/curly-rabbits-rush.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/language-server': patch
+'astro-vscode': patch
+'@astrojs/check': patch
+---
+
+Fix language server crashing when encountering malformed files in certain cases

--- a/packages/language-server/src/core/astro2tsx.ts
+++ b/packages/language-server/src/core/astro2tsx.ts
@@ -29,7 +29,7 @@ function safeConvertToTSX(content: string, options: ConvertToTSXOptions) {
 					code: 1000,
 					location: { file: options.filename!, line: 1, column: 1, length: content.length },
 					severity: 1,
-					text: `The Astro compiler encountered an unknown error while parsing this file. Please create an issue with your code and the error shown in the server's logs: https://github.com/withastro/language-tools/issues`,
+					text: `The Astro compiler encountered an unknown error while transform this file to TSX. Please create an issue with your code and the error shown in the server's logs: https://github.com/withastro/language-tools/issues`,
 				},
 			],
 		} satisfies TSXResult;

--- a/packages/language-server/src/core/index.ts
+++ b/packages/language-server/src/core/index.ts
@@ -118,7 +118,10 @@ export class AstroFile implements VirtualFile {
 			},
 		];
 
-		this.astroMeta = getAstroMetadata(this.snapshot.getText(0, this.snapshot.getLength()));
+		this.astroMeta = getAstroMetadata(
+			this.fileName,
+			this.snapshot.getText(0, this.snapshot.getLength())
+		);
 
 		const { htmlDocument, virtualFile: htmlVirtualFile } = parseHTML(
 			this.fileName,

--- a/packages/language-server/src/core/index.ts
+++ b/packages/language-server/src/core/index.ts
@@ -117,11 +117,16 @@ export class AstroFile implements VirtualFile {
 				data: FileRangeCapabilities.full,
 			},
 		];
+		this.compilerDiagnostics = [];
 
 		this.astroMeta = getAstroMetadata(
 			this.fileName,
 			this.snapshot.getText(0, this.snapshot.getLength())
 		);
+
+		if (this.astroMeta.diagnostics.length > 0) {
+			this.compilerDiagnostics.push(...this.astroMeta.diagnostics);
+		}
 
 		const { htmlDocument, virtualFile: htmlVirtualFile } = parseHTML(
 			this.fileName,
@@ -156,7 +161,7 @@ export class AstroFile implements VirtualFile {
 			htmlDocument
 		);
 
-		this.compilerDiagnostics = tsx.diagnostics;
+		this.compilerDiagnostics.push(...tsx.diagnostics);
 		this.embeddedFiles.push(tsx.virtualFile);
 	}
 }

--- a/packages/language-server/src/core/parseAstro.ts
+++ b/packages/language-server/src/core/parseAstro.ts
@@ -1,15 +1,45 @@
 import { parse } from '@astrojs/compiler/sync';
-import type { ParseResult, Point } from '@astrojs/compiler/types';
+import type { ParseOptions, ParseResult, Point } from '@astrojs/compiler/types';
 
 type AstroMetadata = ParseResult & { frontmatter: FrontmatterStatus };
 
-export function getAstroMetadata(input: string, position = true): AstroMetadata {
-	const parseResult = parse(input, { position: position });
+export function getAstroMetadata(
+	fileName: string,
+	input: string,
+	options: ParseOptions = { position: true }
+): AstroMetadata {
+	const parseResult = safeParseAstro(fileName, input, options);
 
 	return {
 		...parseResult,
 		frontmatter: getFrontmatterStatus(parseResult.ast, input),
 	};
+}
+
+function safeParseAstro(fileName: string, input: string, parseOptions: ParseOptions): ParseResult {
+	try {
+		const parseResult = parse(input, parseOptions);
+		return parseResult;
+	} catch (e) {
+		console.error(
+			`There was an error parsing ${fileName}'s AST. An empty AST will be returned instead to avoid breaking the server. Please create an issue: https://github.com/withastro/language-tools/issues\nError: ${e}.`
+		);
+
+		return {
+			ast: {
+				type: 'root',
+				children: [],
+			},
+			diagnostics: [
+				{
+					code: 1000,
+					location: { file: fileName, line: 1, column: 1, length: input.length },
+					severity: 1,
+					text: `The Astro compiler encountered an unknown error while parsing this file's AST. Please create an issue with your code and the error shown in the server's logs: https://github.com/withastro/language-tools/issues`,
+				},
+			],
+		};
+	}
 }
 
 interface FrontmatterOpen {

--- a/packages/language-server/src/core/parseAstro.ts
+++ b/packages/language-server/src/core/parseAstro.ts
@@ -8,7 +8,7 @@ export function getAstroMetadata(
 	input: string,
 	options: ParseOptions = { position: true }
 ): AstroMetadata {
-	const parseResult = safeParseAstro(fileName, input, options);
+	const parseResult = safeParseAst(fileName, input, options);
 
 	return {
 		...parseResult,
@@ -16,7 +16,7 @@ export function getAstroMetadata(
 	};
 }
 
-function safeParseAstro(fileName: string, input: string, parseOptions: ParseOptions): ParseResult {
+function safeParseAst(fileName: string, input: string, parseOptions: ParseOptions): ParseResult {
 	try {
 		const parseResult = parse(input, parseOptions);
 		return parseResult;

--- a/packages/language-server/test/units/parseAstro.test.ts
+++ b/packages/language-server/test/units/parseAstro.test.ts
@@ -6,7 +6,7 @@ import { createCompilerPoint, createCompilerPosition } from '../utils.js';
 describe('parseAstro - Can parse astro files', () => {
 	it('Can parse files', () => {
 		const input = `---\n--- <div>Astro!</div>`;
-		const metadata = getAstroMetadata(input);
+		const metadata = getAstroMetadata('file.astro', input);
 
 		expect(metadata.ast).to.deep.equal({
 			children: [
@@ -60,12 +60,12 @@ describe('parseAstro - Can parse astro files', () => {
 
 	it('properly return frontmatter states', () => {
 		const inputClosed = `---\n--- <div>Astro!</div>`;
-		expect(getAstroMetadata(inputClosed).frontmatter.status).to.equal('closed');
+		expect(getAstroMetadata('file.astro', inputClosed).frontmatter.status).to.equal('closed');
 
 		const inputOpen = `---\n<div>Astro!</div>`;
-		expect(getAstroMetadata(inputOpen).frontmatter.status).to.equal('open');
+		expect(getAstroMetadata('file.astro', inputOpen).frontmatter.status).to.equal('open');
 
 		const inputNull = `<div>Astro!</div>`;
-		expect(getAstroMetadata(inputNull).frontmatter.status).to.equal('doesnt-exist');
+		expect(getAstroMetadata('file.astro', inputNull).frontmatter.status).to.equal('doesnt-exist');
 	});
 });

--- a/packages/language-server/test/units/parseCSS.test.ts
+++ b/packages/language-server/test/units/parseCSS.test.ts
@@ -9,7 +9,7 @@ describe('parseCSS - Can find all the styles in an Astro file', () => {
 		const input = `<style>h1{color: blue;}</style><div><style>h2{color: red;}</style></div>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
 		const html = parseHTML('something/style/hello.astro', snapshot, 0);
-		const astroAst = getAstroMetadata(input).ast;
+		const astroAst = getAstroMetadata('file.astro', input).ast;
 
 		const styleTags = extractStylesheets(
 			'something/style/hello.astro',

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -9,7 +9,7 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 		const input = `<script>console.log('hi')</script><div><script>console.log('hi2')</script></div>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
 		const html = parseHTML('something/something/hello.astro', snapshot, 0);
-		const astroAst = getAstroMetadata(input).ast;
+		const astroAst = getAstroMetadata('file.astro', input).ast;
 
 		const scriptTags = extractScriptTags(
 			'something/something/hello.astro',
@@ -25,7 +25,7 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 		const input = `<script type="application/json">{foo: "bar"}</script>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
 		const html = parseHTML('something/something/hello.astro', snapshot, 0);
-		const astroAst = getAstroMetadata(input).ast;
+		const astroAst = getAstroMetadata('file.astro', input).ast;
 
 		const scriptTags = extractScriptTags(
 			'something/something/hello.astro',
@@ -41,7 +41,7 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 		const input = `<script is:inline>console.log('hi')</script>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
 		const html = parseHTML('something/something/hello.astro', snapshot, 0);
-		const astroAst = getAstroMetadata(input).ast;
+		const astroAst = getAstroMetadata('file.astro', input).ast;
 
 		const scriptTags = extractScriptTags(
 			'something/something/hello.astro',

--- a/packages/language-server/test/units/utils.test.ts
+++ b/packages/language-server/test/units/utils.test.ts
@@ -2,8 +2,8 @@ import type { Point } from '@astrojs/compiler/types.js';
 import { Range } from '@volar/language-server';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import * as html from 'vscode-html-languageservice';
 import type { Node } from 'vscode-html-languageservice';
+import * as html from 'vscode-html-languageservice';
 import * as compilerUtils from '../../src/core/compilerUtils.js';
 import { getAstroMetadata } from '../../src/core/parseAstro.js';
 import * as utils from '../../src/plugins/utils.js';
@@ -49,16 +49,16 @@ describe('Utilities', async () => {
 	});
 
 	it('isInsideFrontmatter - properly return if a given offset is inside the frontmatter', () => {
-		const hasFrontmatter = getAstroMetadata('---\nfoo\n---\n');
+		const hasFrontmatter = getAstroMetadata('file.astro', '---\nfoo\n---\n');
 		expect(utils.isInsideFrontmatter(0, hasFrontmatter.frontmatter)).to.be.false;
 		expect(utils.isInsideFrontmatter(6, hasFrontmatter.frontmatter)).to.be.true;
 		expect(utils.isInsideFrontmatter(15, hasFrontmatter.frontmatter)).to.be.false;
 
-		const noFrontmatter = getAstroMetadata('<div></div>');
+		const noFrontmatter = getAstroMetadata('file.astro', '<div></div>');
 		expect(utils.isInsideFrontmatter(0, noFrontmatter.frontmatter)).to.be.false;
 		expect(utils.isInsideFrontmatter(6, noFrontmatter.frontmatter)).to.be.false;
 
-		const openFrontmatter = getAstroMetadata('---\nfoo\n');
+		const openFrontmatter = getAstroMetadata('file.astro', '---\nfoo\n');
 		expect(utils.isInsideFrontmatter(0, openFrontmatter.frontmatter)).to.be.false;
 		expect(utils.isInsideFrontmatter(6, openFrontmatter.frontmatter)).to.be.true;
 	});
@@ -77,7 +77,7 @@ describe('Utilities', async () => {
 
 	it('ensureRangeIsInFrontmatter - properly return a range inside the frontmatter', () => {
 		const beforeFrontmatterRange = html.Range.create(0, 0, 0, 0);
-		const hasFrontmatter = getAstroMetadata('---\nfoo\n---\n');
+		const hasFrontmatter = getAstroMetadata('file.astro', '---\nfoo\n---\n');
 		expect(
 			utils.ensureRangeIsInFrontmatter(beforeFrontmatterRange, hasFrontmatter.frontmatter)
 		).to.deep.equal(Range.create(1, 0, 1, 0));

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta source)": {
       "patterns": [


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/language-tools/issues/702
Fix https://github.com/withastro/language-tools/issues/698
Fix https://github.com/withastro/language-tools/issues/623

To be clear, it doesn't fix those issues upstream, it just prevents the language server from crashing when those issues happens. We'll be tracking the status of those upstream, as having duplicate issues in both repos has resulted in inefficiencies in our processes

## Testing

Tested manually

## Docs

N/A
