### PR TITLE
Prevent type checking `define:vars` scripts

### DIFF
--- a/.changeset/early-fireants-leave.md
+++ b/.changeset/early-fireants-leave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/language-server': patch
+---
+
+Fixes an issue where type checking errors were shown on define:vars scripts when "type=module" attribute was also present.

--- a/.changeset/early-fireants-leave.md
+++ b/.changeset/early-fireants-leave.md
@@ -1,5 +1,7 @@
 ---
 '@astrojs/language-server': patch
+'@astrojs/check': patch
+'astro-vscode': patch
 ---
 
 Fixes an issue where type checking errors were shown on define:vars scripts when "type=module" attribute was also present.


### PR DESCRIPTION
## Changes

- Closes #711

## Testing


<details>
<summary>Manually tested against this snippet:</summary>

```astro
---
export interface Props {
  server: string;
}

const { server } = Astro.props;
---

<div id="waline"></div>
<script>
  import { init } from "https://unpkg.com/@waline/client@v2/dist/waline.mjs";
  const x = 43
  init({
    el: "#waline",
    serverURL,
  });
</script>
<script define:vars={{ serverURL: server }} type="module">
  import { init } from "https://unpkg.com/@waline/client@v2/dist/waline.mjs";
  const x = 42
  init({
    el: "#waline",
    serverURL,
  });
</script>
<script is:inline>
	const x = 43
</script>
<script is:inline>
	const x = 44
</script>

```

</details>

## Docs

Does not affect usage
