### PR TITLE
fix(parseJS): Suffix inline attributes with a semicolon to avoid errors leaking

### DIFF
--- a/.changeset/chatty-dolls-itch.md
+++ b/.changeset/chatty-dolls-itch.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/check': patch
+'astro-vscode': patch
+---
+
+Fix errors spilling out of inline event attributes in certain cases

--- a/packages/language-server/src/core/parseJS.ts
+++ b/packages/language-server/src/core/parseJS.ts
@@ -173,7 +173,10 @@ function findEventAttributes(ast: ParseResult['ast']): JavaScriptContext[] {
 
 				if (eventAttribute && eventAttribute.position) {
 					eventAttrs.push({
-						content: eventAttribute.value,
+						// Add a semicolon to the end of the event attribute to attempt to prevent errors from spreading to the rest of the document
+						// This is not perfect, but it's better than nothing
+						// See: https://github.com/microsoft/vscode/blob/e8e04769ec817a3374c3eaa26a08d3ae491820d5/extensions/html-language-features/server/src/modes/embeddedSupport.ts#L192
+						content: eventAttribute.value + ';',
 						startOffset: eventAttribute.position.start.offset + `${eventAttribute.name}="`.length,
 					});
 				}


### PR DESCRIPTION
## Changes

What the title says! This is not perfect, but then again, it's not perfect in VS Code's HTML support either:

<img width="605" alt="image" src="https://github.com/withastro/language-tools/assets/3019731/506eaa94-e87e-4c52-94d6-2135e551fc8f">

If this is enough for VS Code, it's enough for me. At least, for now.

Fix https://github.com/withastro/language-tools/issues/587

## Testing

Tested manually

## Docs

N/A
