### PR TITLE
fix(syntax): Fix autoclosing not working inside of tags sometimes

### DIFF
--- a/.changeset/famous-panthers-carry.md
+++ b/.changeset/famous-panthers-carry.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fix autoclosing of brackets not working inside tags in certain cases

--- a/packages/vscode/languages/astro-language-configuration.json
+++ b/packages/vscode/languages/astro-language-configuration.json
@@ -18,7 +18,7 @@
     { "open": "<!--", "close": " -->", "notIn": ["comment", "string"] },
     { "open": "/**", "close": " */", "notIn": ["string"] }
   ],
-  "autoCloseBefore": ";:.,=}])>` \n\t",
+  "autoCloseBefore": ";:.,=}])><` \n\t",
   "surroundingPairs": [
     { "open": "'", "close": "'" },
     { "open": "\"", "close": "\"" },


### PR DESCRIPTION
## Changes

We weren't allowing autoclosing before `<`, so inside tags sometimes it didn't work.

Fix https://github.com/withastro/language-tools/issues/703

## Testing

Tested manually

## Docs

N/A
