### PR TITLE
fix: temporarily disable checking `.js(x)` files

### DIFF
--- a/.changeset/tricky-wasps-check.md
+++ b/.changeset/tricky-wasps-check.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/check': patch
+---
+
+Temporarily disable checking `.jsx` and `.tsx` files using `astro check` until https://github.com/withastro/language-tools/issues/727 is fixed

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -60,8 +60,16 @@ export class AstroCheck {
 			  }
 			| undefined;
 	}): Promise<CheckResult> {
-		const files =
+		let files =
 			fileNames !== undefined ? fileNames : this.project.languageHost.getScriptFileNames();
+
+		if (files.some((file) => file.endsWith('.jsx') || file.endsWith('.tsx'))) {
+			console.warn(
+				'Checking `.jsx` and `.tsx` files is currently disabled due to an issue in the Astro language server and TypeScript. See https://github.com/withastro/language-tools/issues/727 for more details. In the meantime, such files can be checked using `tsc --noEmit`.'
+			);
+
+			files = files.filter((file) => !file.endsWith('.jsx') && !file.endsWith('.tsx'));
+		}
 
 		const result: CheckResult = {
 			status: undefined,

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -33,6 +33,9 @@ export class AstroCheck {
 	public project!: ReturnType<typeof kit.createProject>;
 	private linter!: ReturnType<typeof kit.createLinter>;
 
+	// TODO: Remove this when the JSX typing issue is fixed
+	private skipJSX = false;
+
 	constructor(
 		private readonly workspacePath: string,
 		private readonly typescriptPath: string | undefined,
@@ -63,11 +66,7 @@ export class AstroCheck {
 		let files =
 			fileNames !== undefined ? fileNames : this.project.languageHost.getScriptFileNames();
 
-		if (files.some((file) => file.endsWith('.jsx') || file.endsWith('.tsx'))) {
-			console.warn(
-				'Checking `.jsx` and `.tsx` files is currently disabled due to an issue in the Astro language server and TypeScript. See https://github.com/withastro/language-tools/issues/727 for more details. In the meantime, such files can be checked using `tsc --noEmit`.'
-			);
-
+		if (this.skipJSX) {
 			files = files.filter((file) => !file.endsWith('.jsx') && !file.endsWith('.tsx'));
 		}
 
@@ -168,6 +167,14 @@ export class AstroCheck {
 					absolute: true,
 				});
 			});
+		}
+
+		const files = this.project.languageHost.getScriptFileNames();
+		if (files.some((file) => file.endsWith('.jsx') || file.endsWith('.tsx'))) {
+			console.warn(
+				'\x1b[33;1mWARNING:\x1b[0m Checking `.jsx` and `.tsx` files is temporarily disabled due to an issue in the Astro language server and TypeScript. See https://github.com/withastro/language-tools/issues/727 for more details. In the meantime, such files can be checked using `tsc --noEmit`.'
+			);
+			this.skipJSX = true;
 		}
 
 		this.linter = kit.createLinter(config, this.project.languageHost);


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
