### PR TITLE
Fix incorrectly highlighted escaped interpolation in template literal attributes

### DIFF
--- a/.changeset/hot-donuts-beg.md
+++ b/.changeset/hot-donuts-beg.md
@@ -1,0 +1,5 @@
+---
+'astro-vscode': patch
+---
+
+Fixes incorrectly highlighted escaped interpolation in template literal attributes

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -509,6 +509,9 @@
           "patterns": [
             {
               "include": "source.tsx#template-substitution-element"
+            },
+            {
+              "include": "source.tsx#string-character-escape"
             }
           ]
         }

--- a/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -350,6 +350,7 @@ repository:
         name: string.template.astro
         patterns:
           - include: 'source.tsx#template-substitution-element'
+          - include: 'source.tsx#string-character-escape'
 
   # ------
   #  TAGS

--- a/packages/vscode/test/grammar/fixtures/attributes.astro
+++ b/packages/vscode/test/grammar/fixtures/attributes.astro
@@ -6,3 +6,5 @@
 <div i18nReady></div>
 
 <div onclick="console.log()"></div>
+
+<div class=`\${not-a-variable}`></div>

--- a/packages/vscode/test/grammar/fixtures/attributes.astro.snap
+++ b/packages/vscode/test/grammar/fixtures/attributes.astro.snap
@@ -54,3 +54,20 @@
 #                               ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
 #                                  ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
 >
+><div class=`\${not-a-variable}`></div>
+#^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
+#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
+#     ^^^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro meta.attribute.class.astro entity.other.attribute-name.astro
+#          ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro meta.attribute.class.astro punctuation.separator.key-value.astro
+#           ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro meta.attribute.class.astro
+#            ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
+#             ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro meta.attribute.$.astro entity.other.attribute-name.astro
+#              ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
+#               ^^^^^^^^^^^^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro meta.embedded.expression.astro source.tsx
+#                             ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
+#                              ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro
+#                               ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#                                ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#                                  ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
+#                                     ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro


### PR DESCRIPTION
## Changes

This turns escaped interpolations from
![Screenshot from 2023-12-29 01-37-00](https://github.com/withastro/language-tools/assets/81974850/ff19e639-a143-4cca-ab76-a507a5626923)

To 
![Screenshot from 2023-12-29 01-37-06](https://github.com/withastro/language-tools/assets/81974850/56113c26-e8d6-4d61-a041-c7eaf83add64)


## Testing

- Added a snapshot test

## Docs

N/A bug fix
