### PR TITLE
fix(check): Skip Vue and Svelte files

### DIFF
--- a/.changeset/mighty-mayflies-tell.md
+++ b/.changeset/mighty-mayflies-tell.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/check": patch
+---
+
+Avoid checking Svelte and Vue files when running astro check

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -59,7 +59,13 @@ export class AstroCheck {
 			  }
 			| undefined;
 	}): Promise<CheckResult> {
-		let files = fileNames !== undefined ? fileNames : this.linter.languageHost.getScriptFileNames();
+		let files = (
+			fileNames !== undefined ? fileNames : this.linter.languageHost.getScriptFileNames()
+		).filter((file) => {
+			// We don't have the same understanding of Svelte and Vue files as their own respective tools (vue-tsc, svelte-check)
+			// So we don't want to check them here
+			return !file.endsWith('.vue') && !file.endsWith('.svelte');
+		});
 
 		const result: CheckResult = {
 			status: undefined,


### PR DESCRIPTION
## Changes

We were wrongfully including Svelte and Vue in the list of files to check by `astro check`. Since we don't really have a proper understanding of those files (we mostly fake understanding them, especially Vue), we can't check them ourselves and shouldn't be trying to.

## Testing

WIP

## Docs

N/A
