### PR TITLE
map compiler location to LSP range

### DIFF
--- a/.changeset/smart-cycles-join.md
+++ b/.changeset/smart-cycles-join.md
@@ -1,5 +1,7 @@
 ---
 "@astrojs/language-server": patch
+"@astrojs/check": patch
+"astro-vscode": patch
 ---
 
 Fixes mapping from compiler location to LSP range.

--- a/.changeset/smart-cycles-join.md
+++ b/.changeset/smart-cycles-join.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/language-server": patch
+---
+
+Fixes mapping from compiler location to LSP range.

--- a/packages/language-server/src/plugins/astro.ts
+++ b/packages/language-server/src/plugins/astro.ts
@@ -49,14 +49,11 @@ export const create = (ts: typeof import('typescript')): ServicePlugin => {
 					return file.compilerDiagnostics.map(compilerMessageToDiagnostic);
 
 					function compilerMessageToDiagnostic(message: DiagnosticMessage): Diagnostic {
+						const start = Position.create(message.location.line - 1, message.location.column - 1);
+						const end = document.positionAt(document.offsetAt(start) + message.location.length);
 						return {
 							message: message.text + (message.hint ? '\n\n' + message.hint : ''),
-							range: Range.create(
-								message.location.line - 1,
-								message.location.column - 1,
-								message.location.line,
-								message.location.length
-							),
+							range: Range.create(start, end),
 							code: message.code,
 							severity: message.severity,
 							source: 'astro',


### PR DESCRIPTION
## Changes

For compiler warnings, the visual markers were also displayed on some characters in the following line. Maybe I misunderstood something here, but I fixed it to the best of my knowledge :)
 
## Testing

Manually tested.
There are test for Compiler Points but those functions seem to be outdated not to be in use anywhere?

## Docs

n.a., bug fix