### PR TITLE
Makes astro check --tsconfig understand relative file names

### DIFF
--- a/.changeset/chilled-adults-invite.md
+++ b/.changeset/chilled-adults-invite.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/check": patch
+---
+
+Makes astro check --tsconfig understand relative file names

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import * as kit from '@volar/kit';
 import { Diagnostic, DiagnosticSeverity } from '@volar/language-server';
@@ -159,13 +159,7 @@ export class AstroCheck {
 
 	private getTsconfig() {
 		if (this.tsconfigPath) {
-			let tsconfig = this.tsconfigPath
-			if (tsconfig.startsWith('~')) {
-				tsconfig = tsconfig.replace('~', homedir());
-			}
-			if (!isAbsolute(tsconfig)) {
-				tsconfig = resolve(this.workspacePath, tsconfig);
-			}
+			const tsconfig = resolve(this.workspacePath, this.tsconfigPath.replace(/^~/, homedir()));
 			if (!existsSync(tsconfig)) {
 				throw new Error(`Specified tsconfig file \`${tsconfig}\` does not exist.`);
 			}

--- a/packages/language-server/src/check.ts
+++ b/packages/language-server/src/check.ts
@@ -1,4 +1,6 @@
 import { existsSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import * as kit from '@volar/kit';
 import { Diagnostic, DiagnosticSeverity } from '@volar/language-server';
@@ -157,11 +159,17 @@ export class AstroCheck {
 
 	private getTsconfig() {
 		if (this.tsconfigPath) {
-			if (!existsSync(this.tsconfigPath)) {
-				throw new Error(`Specified tsconfig file \`${this.tsconfigPath}\` does not exist.`);
+			let tsconfig = this.tsconfigPath
+			if (tsconfig.startsWith('~')) {
+				tsconfig = tsconfig.replace('~', homedir());
 			}
-
-			return this.tsconfigPath;
+			if (!isAbsolute(tsconfig)) {
+				tsconfig = resolve(this.workspacePath, tsconfig);
+			}
+			if (!existsSync(tsconfig)) {
+				throw new Error(`Specified tsconfig file \`${tsconfig}\` does not exist.`);
+			}
+			return tsconfig;
 		}
 
 		const searchPath = this.workspacePath;


### PR DESCRIPTION
## Changes

`astro check` has an `--tsconfig` option that takes a file parameter.
Now it also understands relative file names.

## Testing

Manually tested

## Docs

bugfix / n.a.