### PR TITLE
fix `tmLanguage`: text.astro pattern

### DIFF
--- a/.changeset/wet-beers-change.md
+++ b/.changeset/wet-beers-change.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+text.astro pattern matches text at the beginning and end of the document

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta source)": {
       "patterns": [
@@ -213,8 +215,8 @@
           "include": "#entities"
         },
         {
-          "begin": "(?<=>|})",
-          "end": "(?=<|{)",
+          "begin": "(?<=^|>|})",
+          "end": "(?=<|{|$)",
           "name": "text.astro",
           "patterns": [
             {

--- a/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -195,8 +195,8 @@ repository:
       - include: '#entities'
       # Content text.
       # This matches only in-between all the nodes - nothing inside of them.
-      - begin: (?<=>|})
-        end: (?=<|{)
+      - begin: (?<=^|>|})
+        end: (?=<|{|$)
         name: text.astro
         patterns:
           - include: '#entities'

--- a/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -194,7 +194,7 @@ repository:
       - include: '#interpolation'
       - include: '#entities'
       # Content text.
-      # This matches only in-between all the nodes - nothing inside of them.
+      # This matches nothing inside of tags, only in-between them and at the beginning/end of the file.
       - begin: (?<=^|>|})
         end: (?=<|{|$)
         name: text.astro

--- a/packages/vscode/test/grammar/fixtures/text.astro
+++ b/packages/vscode/test/grammar/fixtures/text.astro
@@ -1,0 +1,4 @@
+text<div>text</div>
+<div>text</div>text
+text{"text"}
+{"text"}text

--- a/packages/vscode/test/grammar/fixtures/text.astro.snap
+++ b/packages/vscode/test/grammar/fixtures/text.astro.snap
@@ -1,0 +1,28 @@
+>text<div>text</div>
+#^^^^ source.astro text.astro
+#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+#     ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
+#        ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#         ^^^^ source.astro text.astro
+#             ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#               ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
+#                  ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+><div>text</div>text
+#^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+# ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
+#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#     ^^^^ source.astro text.astro
+#         ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#           ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
+#              ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+#               ^^^^ source.astro text.astro
+>text{"text"}
+#^^^^ source.astro text.astro
+#    ^ source.astro punctuation.section.embedded.begin.astro
+#     ^^^^^^ source.astro meta.embedded.expression.astro source.tsx
+#           ^ source.astro punctuation.section.embedded.end.astro
+>{"text"}text
+#^ source.astro punctuation.section.embedded.begin.astro
+# ^^^^^^ source.astro meta.embedded.expression.astro source.tsx
+#       ^ source.astro punctuation.section.embedded.end.astro
+#        ^^^^ source.astro text.astro


### PR DESCRIPTION
## Changes

In this case : 
```jsx
blabla<div>word</div>
{true && <div>word</div>}blabla
```

Both `blabla` have the scope `source.astro` instead of `text.astro`, which is the scope in HTML. Fixed the `text.astro` pattern to match that.

## Testing

Snap test -> `packages/vscode/test/grammar/fixtures/text.astro.snap`

## Docs

N/A, this PR will match the documented behaviour.
