### PR TITLE
refactor(tmLanguage): text pattern

### DIFF
--- a/.changeset/two-worms-cover.md
+++ b/.changeset/two-worms-cover.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+text pattern is now after scope & frontmatter patterns

--- a/packages/vscode/syntaxes/astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/astro.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "Astro",
   "scopeName": "source.astro",
-  "fileTypes": ["astro"],
+  "fileTypes": [
+    "astro"
+  ],
   "injections": {
     "L:(meta.script.astro) (meta.lang.json) - (meta source)": {
       "patterns": [
@@ -175,6 +177,9 @@
     },
     {
       "include": "#frontmatter"
+    },
+    {
+      "include": "#text"
     }
   ],
   "repository": {
@@ -211,16 +216,6 @@
         },
         {
           "include": "#entities"
-        },
-        {
-          "begin": "(?<=^|>|})",
-          "end": "(?=<|{|$)",
-          "name": "text.astro",
-          "patterns": [
-            {
-              "include": "#entities"
-            }
-          ]
         }
       ]
     },
@@ -823,6 +818,20 @@
         }
       },
       "name": "meta.scope.tag.$2.astro"
+    },
+    "text": {
+      "patterns": [
+        {
+          "begin": "(?<=^|---|>|})",
+          "end": "(?=<|{|$)",
+          "name": "text.astro",
+          "patterns": [
+            {
+              "include": "#entities"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
+++ b/packages/vscode/syntaxes/astro.tmLanguage.src.yaml
@@ -165,6 +165,7 @@ injections:
 patterns:
   - include: '#scope'
   - include: '#frontmatter'
+  - include: '#text'
 
 # Contains all of our patterns.
 repository:
@@ -193,13 +194,6 @@ repository:
       - include: '#tags'
       - include: '#interpolation'
       - include: '#entities'
-      # Content text.
-      # This matches nothing inside of tags, only in-between them and at the beginning/end of the file.
-      - begin: (?<=^|>|})
-        end: (?=<|{|$)
-        name: text.astro
-        patterns:
-          - include: '#entities'
 
   # ----------
   #  COMMENTS
@@ -516,3 +510,17 @@ repository:
     endCaptures:
       1: { name: meta.tag.end.astro punctuation.definition.tag.end.astro }
     name: meta.scope.tag.$2.astro
+
+  # ------
+  # TEXT
+  # This will match any text outside frontmatter and scopes patterns.
+
+  text:
+    patterns:
+      # Content text.
+      # This matches nothing inside of tags, only in-between them and at the beginning/end of the file.
+      - begin: (?<=^|---|>|})
+        end: (?=<|{|$)
+        name: text.astro
+        patterns:
+          - include: '#entities'

--- a/packages/vscode/test/grammar/fixtures/text.astro
+++ b/packages/vscode/test/grammar/fixtures/text.astro
@@ -1,4 +1,15 @@
-text<div>text</div>
-<div>text</div>text
-text{"text"}
-{"text"}text
+---
+const cool = "our frontmatter"
+console.log("Hello, World!")
+console.log(`This is ${cool}!`)
+---
+
+This is some text<div>
+  <p>
+    Some text in HTML tags
+    <strong> and some text in nested tags </strong>
+  </p>
+  Watch this &nbsp; html entity!
+  {true && <p>Some more text in expression</p>}
+  <!-- Wow, we even have an HTML comment -->
+</div>This is the final text

--- a/packages/vscode/test/grammar/fixtures/text.astro.snap
+++ b/packages/vscode/test/grammar/fixtures/text.astro.snap
@@ -1,28 +1,58 @@
->text<div>text</div>
+>---
+#^^^ source.astro comment
+>const cool = "our frontmatter"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
+>console.log("Hello, World!")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
+>console.log(`This is ${cool}!`)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro source.ts
+>---
+#^^^ source.astro comment
+>
+>This is some text<div>
+#^^^^^^^^^^^^^^^^^ source.astro text.astro
+#                 ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+#                  ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
+#                     ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>  <p>
+#^^ source.astro text.astro
+#  ^ source.astro meta.scope.tag.p.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+#   ^ source.astro meta.scope.tag.p.astro meta.tag.start.astro entity.name.tag.astro
+#    ^ source.astro meta.scope.tag.p.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+>    Some text in HTML tags
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro text.astro
+>    <strong> and some text in nested tags </strong>
 #^^^^ source.astro text.astro
-#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
-#     ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
-#        ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
-#         ^^^^ source.astro text.astro
-#             ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
-#               ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
-#                  ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
-><div>text</div>text
-#^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
-# ^^^ source.astro meta.scope.tag.div.astro meta.tag.start.astro entity.name.tag.astro
-#    ^ source.astro meta.scope.tag.div.astro meta.tag.start.astro punctuation.definition.tag.end.astro
-#     ^^^^ source.astro text.astro
-#         ^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
-#           ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
-#              ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
-#               ^^^^ source.astro text.astro
->text{"text"}
-#^^^^ source.astro text.astro
-#    ^ source.astro punctuation.section.embedded.begin.astro
-#     ^^^^^^ source.astro meta.embedded.expression.astro source.tsx
-#           ^ source.astro punctuation.section.embedded.end.astro
->{"text"}text
-#^ source.astro punctuation.section.embedded.begin.astro
-# ^^^^^^ source.astro meta.embedded.expression.astro source.tsx
-#       ^ source.astro punctuation.section.embedded.end.astro
-#        ^^^^ source.astro text.astro
+#    ^ source.astro meta.scope.tag.strong.astro meta.tag.start.astro punctuation.definition.tag.begin.astro
+#     ^^^^^^ source.astro meta.scope.tag.strong.astro meta.tag.start.astro entity.name.tag.astro
+#           ^ source.astro meta.scope.tag.strong.astro meta.tag.start.astro punctuation.definition.tag.end.astro
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro text.astro
+#                                          ^^ source.astro meta.scope.tag.strong.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#                                            ^^^^^^ source.astro meta.scope.tag.strong.astro meta.tag.end.astro entity.name.tag.astro
+#                                                  ^ source.astro meta.scope.tag.strong.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>  </p>
+#^^ source.astro text.astro
+#  ^^ source.astro meta.scope.tag.p.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#    ^ source.astro meta.scope.tag.p.astro meta.tag.end.astro entity.name.tag.astro
+#     ^ source.astro meta.scope.tag.p.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+>  Watch this &nbsp; html entity!
+#^^^^^^^^^^^^^ source.astro text.astro
+#             ^ source.astro text.astro constant.character.entity.named.nbsp.astro punctuation.definition.entity.astro
+#              ^^^^ source.astro text.astro constant.character.entity.named.nbsp.astro
+#                  ^ source.astro text.astro constant.character.entity.named.nbsp.astro punctuation.definition.entity.astro
+#                   ^^^^^^^^^^^^^ source.astro text.astro
+>  {true && <p>Some more text in expression</p>}
+#^^ source.astro text.astro
+#  ^ source.astro punctuation.section.embedded.begin.astro
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro meta.embedded.expression.astro source.tsx
+#                                              ^ source.astro punctuation.section.embedded.end.astro
+>  <!-- Wow, we even have an HTML comment -->
+#^^ source.astro text.astro
+#  ^^^^ source.astro comment.block.astro punctuation.definition.comment.astro
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.astro comment.block.astro
+#                                         ^^^ source.astro comment.block.astro punctuation.definition.comment.astro
+></div>This is the final text
+#^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.begin.astro
+#  ^^^ source.astro meta.scope.tag.div.astro meta.tag.end.astro entity.name.tag.astro
+#     ^ source.astro meta.scope.tag.div.astro meta.tag.end.astro punctuation.definition.tag.end.astro
+#      ^^^^^^^^^^^^^^^^^^^^^^ source.astro text.astro


### PR DESCRIPTION
## Changes

- Fix regression from #826 , breaking frontmatter highlighting in `.astro` files
- Create a `text` pattern after `scope` & `frontmatter` patterns, so it only match what's left
 
## Testing

- Add a better text & frontmatter snap test

## Docs

N/A, this PR try to match the documented behaviour.
