### PR TITLE
fix(html): Load custom data the proper way

### DIFF
--- a/.changeset/thirty-peas-turn.md
+++ b/.changeset/thirty-peas-turn.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Fixes completions for Astro-specific attributes not working in certain contexts

--- a/packages/language-server/test/html/custom-data.test.ts
+++ b/packages/language-server/test/html/custom-data.test.ts
@@ -1,0 +1,22 @@
+import { Position } from '@volar/language-server';
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { type LanguageServer, getLanguageServer } from '../server.js';
+
+describe('HTML - Custom Data', () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+
+	it('Can properly get completions for attributes added by our custom data', async () => {
+		const document = await languageServer.openFakeDocument(`<div class></div>`, 'astro');
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 10)
+		);
+
+		const labels = completions!.items.map((i) => i.label);
+		expect(completions!.items).to.not.be.empty;
+		expect(labels).to.include('class:list');
+	});
+});


### PR DESCRIPTION
## Changes

The API for loading custom data changed, but we didn't have a test for custom data, only normal completions. This makes it so we use the proper API now.

Fixes https://github.com/withastro/language-tools/issues/840

## Testing

Added a test!

## Docs

N/A
