### PR TITLE
fix: Fixes text edits inside script tags not being mapped correctly

### DIFF
--- a/.changeset/rotten-poets-repeat.md
+++ b/.changeset/rotten-poets-repeat.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Fixes auto imports through completions and code actions inside script tags sometimes not updating the text correctly

--- a/packages/language-server/src/plugins/typescript/codeActions.ts
+++ b/packages/language-server/src/plugins/typescript/codeActions.ts
@@ -1,7 +1,7 @@
 import { TextDocumentEdit } from '@volar/language-server';
 import type { CodeAction, ServiceContext } from '@volar/language-service';
 import { AstroVirtualCode } from '../../core/index.js';
-import { editShouldBeInFrontmatter, ensureProperEditForFrontmatter } from '../utils.js';
+import { mapEdit } from './utils.js';
 
 export function enhancedProvideCodeActions(codeActions: CodeAction[], context: ServiceContext) {
 	return codeActions.map((codeAction) => mapCodeAction(codeAction, context));
@@ -25,15 +25,7 @@ function mapCodeAction(codeAction: CodeAction, context: ServiceContext) {
 			const code = source?.generated?.code;
 			if (!virtualFile || !(code instanceof AstroVirtualCode)) return change;
 
-			change.edits = change.edits.map((edit) => {
-				const shouldModifyEdit = editShouldBeInFrontmatter(edit.range, code.astroMeta);
-
-				if (shouldModifyEdit.itShould) {
-					edit = ensureProperEditForFrontmatter(edit, code.astroMeta, '\n');
-				}
-
-				return edit;
-			});
+			change.edits = change.edits.map((edit) => mapEdit(edit, code, virtualFile.languageId));
 		}
 
 		return change;

--- a/packages/language-server/src/plugins/typescript/completions.ts
+++ b/packages/language-server/src/plugins/typescript/completions.ts
@@ -5,7 +5,7 @@ import {
 	ServiceContext,
 } from '@volar/language-server';
 import { AstroVirtualCode } from '../../core/index.js';
-import { editShouldBeInFrontmatter, ensureProperEditForFrontmatter } from '../utils.js';
+import { mapEdit } from './utils.js';
 
 export function enhancedProvideCompletionItems(completions: CompletionList): CompletionList {
 	completions.items = completions.items.filter(isValidCompletion).map((completion) => {
@@ -50,13 +50,9 @@ export function enhancedResolveCompletionItem(
 		const code = source?.generated?.code;
 		if (!virtualFile || !(code instanceof AstroVirtualCode)) return resolvedCompletion;
 
-		resolvedCompletion.additionalTextEdits = resolvedCompletion.additionalTextEdits.map((edit) => {
-			if (editShouldBeInFrontmatter(edit.range, code.astroMeta).itShould) {
-				edit = ensureProperEditForFrontmatter(edit, code.astroMeta, '\n');
-			}
-
-			return edit;
-		});
+		resolvedCompletion.additionalTextEdits = resolvedCompletion.additionalTextEdits.map((edit) =>
+			mapEdit(edit, code, virtualFile.languageId)
+		);
 	}
 
 	return resolvedCompletion;

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -1,0 +1,19 @@
+import type { TextEdit } from 'vscode-html-languageservice';
+import type { AstroVirtualCode } from '../../core/index.js';
+import { editShouldBeInFrontmatter, ensureProperEditForFrontmatter } from '../utils.js';
+
+export function mapEdit(edit: TextEdit, code: AstroVirtualCode, languageId: string) {
+	// Don't attempt to move the edit to the frontmatter if the file isn't the root TSX file, it means it's a script tag
+	if (languageId === 'typescriptreact') {
+		if (editShouldBeInFrontmatter(edit.range, code.astroMeta).itShould) {
+			edit = ensureProperEditForFrontmatter(edit, code.astroMeta, '\n');
+		}
+	} else {
+		// If the edit is at the start of the file, add a newline before it, otherwise we'll get `<script>text`
+		if (edit.range.start.line === 0 && edit.range.start.character === 0) {
+			edit.newText = '\n' + edit.newText;
+		}
+	}
+
+	return edit;
+}

--- a/packages/language-server/test/fixture/env.d.ts
+++ b/packages/language-server/test/fixture/env.d.ts
@@ -1,3 +1,6 @@
+/// <reference types="astro/client" />
+
+
 declare module 'im-a-super-module' {
 	export const hello: string;
 }

--- a/packages/language-server/test/fixture/scriptImport.astro
+++ b/packages/language-server/test/fixture/scriptImport.astro
@@ -1,0 +1,3 @@
+<script>
+
+</script>

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -86,7 +86,7 @@ describe('TypeScript - Completions', async () => {
 
 		// Why `import type`? I... don't know. TypeScript return this in some contexts and somehow in the editor it's not a problem.
 		// This issue affects all imports, even outside of Astro.
-		expect(edits?.additionalTextEdits?.[0].newText.trim).to.equal(
+		expect(edits?.additionalTextEdits?.[0].newText).to.equal(
 			`\nimport type { Image } from "astro:assets";${EOL}`
 		);
 		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -1,7 +1,11 @@
+import { EOL } from 'node:os';
+import path from 'node:path';
 import { Position } from '@volar/language-server';
 import { expect } from 'chai';
 import { before, describe, it } from 'mocha';
 import { type LanguageServer, getLanguageServer } from '../server.js';
+
+const fixtureDir = path.join(__dirname, '../fixture');
 
 describe('TypeScript - Completions', async () => {
 	let languageServer: LanguageServer;
@@ -60,5 +64,31 @@ describe('TypeScript - Completions', async () => {
 			expect(completions?.items).to.not.be.empty;
 			expect(allLabels).to.include('log');
 		}
+	});
+
+	it('properly maps edits for completions in script tags', async () => {
+		const document = await languageServer.handle.openTextDocument(
+			path.join(fixtureDir, 'scriptImport.astro'),
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(1, 0)
+		);
+
+		const imageConfigCompletion = completions?.items.find(
+			(item) => item.label === 'Image' && item.labelDetails?.description === 'astro:assets'
+		);
+		expect(imageConfigCompletion).to.not.be.undefined;
+
+		const edits = await languageServer.handle.sendCompletionResolveRequest(imageConfigCompletion!);
+		expect(edits).to.not.be.empty;
+
+		// Why `import type`? I... don't know. TypeScript return this in some contexts and somehow in the editor it's not a problem.
+		// This issue affects all imports, even outside of Astro.
+		expect(edits?.additionalTextEdits?.[0].newText).to.equal(
+			`${EOL}import type { Image } from "astro:assets";${EOL}`
+		);
+		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);
 	});
 });

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -87,7 +87,7 @@ describe('TypeScript - Completions', async () => {
 		// Why `import type`? I... don't know. TypeScript return this in some contexts and somehow in the editor it's not a problem.
 		// This issue affects all imports, even outside of Astro.
 		expect(edits?.additionalTextEdits?.[0].newText).to.equal(
-			`\nimport type { Image } from "astro:assets";${EOL}`
+			`\nimport type { Image } from "astro:assets";\n`
 		);
 		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);
 	});

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -86,8 +86,8 @@ describe('TypeScript - Completions', async () => {
 
 		// Why `import type`? I... don't know. TypeScript return this in some contexts and somehow in the editor it's not a problem.
 		// This issue affects all imports, even outside of Astro.
-		expect(edits?.additionalTextEdits?.[0].newText).to.equal(
-			`${EOL}import type { Image } from "astro:assets";${EOL}`
+		expect(edits?.additionalTextEdits?.[0].newText.trim).to.equal(
+			`\nimport type { Image } from "astro:assets";${EOL}`
 		);
 		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);
 	});


### PR DESCRIPTION
## Changes

In some cases, we were wrongly trying to map text edits inside script tags as if they were in the template, this PR fixes this. This mostly affects completions.

Fixes https://github.com/withastro/language-tools/issues/805

## Testing

Added a test!

## Docs

N/A