### PR TITLE
fix(syntax): Apply JSX latest rules for our language

### DIFF
--- a/.changeset/forty-flowers-drum.md
+++ b/.changeset/forty-flowers-drum.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+Fixes commenting shortcut not using the proper comments inside expressions in certain cases

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -163,14 +163,19 @@
           "source.js": "javascript",
           "source.ts": "typescript",
           "source.json": "json",
-          "source.tsx": "typescriptreact"
+          "source.tsx": "typescriptreact",
+          "meta.tag.tsx": "jsx-tags",
+          "meta.tag.without-attributes.tsx": "jsx-tags",
+          "meta.tag.attributes.tsx": "typescriptreact",
+          "meta.embedded.expression.tsx": "typescriptreact"
         },
         "unbalancedBracketScopes": [
           "keyword.operator.relational",
           "storage.type.function.arrow",
           "keyword.operator.bitwise.shift",
           "meta.brace.angle",
-          "punctuation.definition.tag"
+          "punctuation.definition.tag",
+          "keyword.operator.assignment.compound.bitwise.ts"
         ]
       },
       {

--- a/packages/vscode/test/grammar/test.mjs
+++ b/packages/vscode/test/grammar/test.mjs
@@ -45,6 +45,7 @@ async function snapShotTest() {
 
 	const code = await promisifySpawn(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', args, {
 		stdio: 'inherit',
+		shell: true,
 	});
 
 	if (code > 0) {


### PR DESCRIPTION
## Changes

Add a few more things from TSX's syntax to our rules that are not inherited due to a VS Code bug. 

Fixes https://github.com/withastro/language-tools/issues/713 and a few unreported issues (ex: `>>>=` wasn't properly highlighted

## Testing

Tested manually, you can't test this inside grammar tests because you don't see the underlying language being applied, just the `source.tsx` scope.

## Docs

N/A