### PR TITLE
fix: don't generate mappings for Svelte and Vue files

### DIFF
--- a/.changeset/eleven-pears-switch.md
+++ b/.changeset/eleven-pears-switch.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Fixes certain code actions corrupting Vue and Svelte files in specific situations

--- a/packages/language-server/src/core/svelte.ts
+++ b/packages/language-server/src/core/svelte.ts
@@ -65,21 +65,7 @@ class SvelteVirtualCode implements VirtualCode {
 	}
 
 	private onSnapshotUpdated() {
-		this.mappings = [
-			{
-				sourceOffsets: [0],
-				generatedOffsets: [0],
-				lengths: [this.snapshot.getLength()],
-				data: {
-					verification: true,
-					completion: true,
-					semantic: true,
-					navigation: true,
-					structure: true,
-					format: true,
-				},
-			},
-		];
+		this.mappings = [];
 
 		this.embeddedCodes = [];
 		this.embeddedCodes.push(

--- a/packages/language-server/src/core/utils.ts
+++ b/packages/language-server/src/core/utils.ts
@@ -29,21 +29,7 @@ export function framework2tsx(
 				getLength: () => content.length,
 				getChangeRange: () => undefined,
 			},
-			mappings: [
-				{
-					sourceOffsets: [0],
-					generatedOffsets: [0],
-					lengths: [content.length],
-					data: {
-						verification: true,
-						completion: true,
-						semantic: true,
-						navigation: true,
-						structure: true,
-						format: true,
-					},
-				},
-			],
+			mappings: [],
 			embeddedCodes: [],
 		};
 	}

--- a/packages/language-server/src/core/vue.ts
+++ b/packages/language-server/src/core/vue.ts
@@ -65,21 +65,7 @@ class VueVirtualCode implements VirtualCode {
 	}
 
 	private onSnapshotUpdated() {
-		this.mappings = [
-			{
-				sourceOffsets: [0],
-				generatedOffsets: [0],
-				lengths: [this.snapshot.getLength()],
-				data: {
-					verification: true,
-					completion: true,
-					semantic: true,
-					navigation: true,
-					structure: true,
-					format: true,
-				},
-			},
-		];
+		this.mappings = [];
 
 		this.embeddedCodes = [];
 		this.embeddedCodes.push(


### PR DESCRIPTION
## Changes

We wrongfully had mappings for Vue and Svelte files, so when we updated files, we could sometimes try to update Svelte and Vue files, but really, we don't know what to do there, so we shouldn't.

Fixes https://github.com/withastro/language-tools/issues/869

## Testing

Tested manually, this is quite tough to test in the testing suite because we can't quite mock what the client does

## Docs

N/A