### PR TITLE
feat: highlight Astro code blocks in MDX

### DIFF
--- a/.changeset/warm-lemons-search.md
+++ b/.changeset/warm-lemons-search.md
@@ -1,0 +1,5 @@
+---
+"astro-vscode": patch
+---
+
+Add syntax highlighting for `astro` tagged code block inside MDX files.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -186,6 +186,14 @@
           "meta.embedded.block.astro": "astro",
           "meta.embedded.block.astro.frontmatter": "typescriptreact"
         }
+      },
+      {
+        "scopeName": "text.mdx.astro.codeblock",
+        "path": "./syntaxes/mdx.astro.tmLanguage.json",
+        "injectTo": ["source.mdx"],
+        "embeddedLanguages": {
+          "mdx.embedded.astro": "astro"
+        }
       }
     ]
   },

--- a/packages/vscode/syntaxes/mdx.astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/mdx.astro.tmLanguage.json
@@ -4,113 +4,79 @@
   "injectionSelector": "L:source.mdx",
   "patterns": [
     {
-      "include": "#astro-code-block"
+      "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.other.begin.code.fenced.mdx"
+        },
+        "2": {
+          "name": "entity.name.function.mdx"
+        }
+      },
+      "contentName": "meta.embedded.astro",
+      "end": "(\\1)(?:[\\t ]*$)",
+      "endCaptures": {
+        "1": {
+          "name": "string.other.end.code.fenced.mdx"
+        }
+      },
+      "name": "markup.code.astro.mdx",
+      "patterns": [
+        {
+          "include": "#astro-code-block"
+        }
+      ]
+    },
+    {
+      "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.other.begin.code.fenced.mdx"
+        },
+        "2": {
+          "name": "entity.name.function.mdx"
+        }
+      },
+      "contentName": "meta.embedded.astro",
+      "end": "(\\1)(?:[\\t ]*$)",
+      "endCaptures": {
+        "1": {
+          "name": "string.other.end.code.fenced.mdx"
+        }
+      },
+      "name": "markup.code.astro.mdx",
+      "patterns": [
+        {
+          "include": "#astro-code-block"
+        }
+      ]
     }
   ],
   "repository": {
     "astro-code-block": {
       "patterns": [
         {
-          "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+          "begin": "^\\s*---\\s*$",
+          "end": "^\\s*---\\s*$",
           "beginCaptures": {
-            "1": {
-              "name": "string.other.begin.code.fenced.mdx"
-            },
-            "2": {
-              "name": "entity.name.function.mdx"
+            "0": {
+              "name": "punctuation.definition.tag.xi.begin.t"
             }
           },
-          "contentName": "meta.embedded.astro",
-          "end": "(\\1)(?:[\\t ]*$)",
           "endCaptures": {
-            "1": {
-              "name": "string.other.end.code.fenced.mdx"
+            "0": {
+              "name": "punctuation.definition.tag.xi.end.t"
             }
           },
-          "name": "markup.code.astro.mdx",
+          "contentName": "meta.embedded.block.astro.frontmatter",
           "patterns": [
             {
-              "begin": "(^|\\G)(\\s*)(.*)",
-              "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-              "patterns": [
-                {
-                  "begin": "^\\s*---\\s*$",
-                  "end": "^\\s*---\\s*$",
-                  "beginCaptures": {
-                    "0": {
-                      "name": "punctuation.definition.tag.xi.begin.t"
-                    }
-                  },
-                  "endCaptures": {
-                    "0": {
-                      "name": "punctuation.definition.tag.xi.end.t"
-                    }
-                  },
-                  "contentName": "meta.embedded.block.astro.frontmatter",
-                  "patterns": [
-                    {
-                      "include": "source.tsx"
-                    }
-                  ]
-                },
-                {
-                  "contentName": "meta.embedded.block.astro",
-                  "include": "source.astro"
-                }
-              ]
+              "include": "source.tsx"
             }
           ]
         },
         {
-          "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
-          "beginCaptures": {
-            "1": {
-              "name": "string.other.begin.code.fenced.mdx"
-            },
-            "2": {
-              "name": "entity.name.function.mdx"
-            }
-          },
-          "contentName": "meta.embedded.astro",
-          "end": "(\\1)(?:[\\t ]*$)",
-          "endCaptures": {
-            "1": {
-              "name": "string.other.end.code.fenced.mdx"
-            }
-          },
-          "name": "markup.code.astro.mdx",
-          "patterns": [
-            {
-              "begin": "(^|\\G)(\\s*)(.*)",
-              "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-              "patterns": [
-                {
-                  "begin": "^\\s*---\\s*$",
-                  "end": "^\\s*---\\s*$",
-                  "beginCaptures": {
-                    "0": {
-                      "name": "punctuation.definition.tag.xi.begin.t"
-                    }
-                  },
-                  "endCaptures": {
-                    "0": {
-                      "name": "punctuation.definition.tag.xi.end.t"
-                    }
-                  },
-                  "contentName": "meta.embedded.block.astro.frontmatter",
-                  "patterns": [
-                    {
-                      "include": "source.tsx"
-                    }
-                  ]
-                },
-                {
-                  "contentName": "meta.embedded.block.astro",
-                  "include": "source.astro"
-                }
-              ]
-            }
-          ]
+          "include": "source.astro"
         }
       ]
     }

--- a/packages/vscode/syntaxes/mdx.astro.tmLanguage.json
+++ b/packages/vscode/syntaxes/mdx.astro.tmLanguage.json
@@ -1,0 +1,118 @@
+{
+  "fileTypes": [],
+  "scopeName": "text.mdx.astro.codeblock",
+  "injectionSelector": "L:source.mdx",
+  "patterns": [
+    {
+      "include": "#astro-code-block"
+    }
+  ],
+  "repository": {
+    "astro-code-block": {
+      "patterns": [
+        {
+          "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.other.begin.code.fenced.mdx"
+            },
+            "2": {
+              "name": "entity.name.function.mdx"
+            }
+          },
+          "contentName": "meta.embedded.astro",
+          "end": "(\\1)(?:[\\t ]*$)",
+          "endCaptures": {
+            "1": {
+              "name": "string.other.end.code.fenced.mdx"
+            }
+          },
+          "name": "markup.code.astro.mdx",
+          "patterns": [
+            {
+              "begin": "(^|\\G)(\\s*)(.*)",
+              "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+              "patterns": [
+                {
+                  "begin": "^\\s*---\\s*$",
+                  "end": "^\\s*---\\s*$",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.tag.xi.begin.t"
+                    }
+                  },
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.tag.xi.end.t"
+                    }
+                  },
+                  "contentName": "meta.embedded.block.astro.frontmatter",
+                  "patterns": [
+                    {
+                      "include": "source.tsx"
+                    }
+                  ]
+                },
+                {
+                  "contentName": "meta.embedded.block.astro",
+                  "include": "source.astro"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?astro))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.other.begin.code.fenced.mdx"
+            },
+            "2": {
+              "name": "entity.name.function.mdx"
+            }
+          },
+          "contentName": "meta.embedded.astro",
+          "end": "(\\1)(?:[\\t ]*$)",
+          "endCaptures": {
+            "1": {
+              "name": "string.other.end.code.fenced.mdx"
+            }
+          },
+          "name": "markup.code.astro.mdx",
+          "patterns": [
+            {
+              "begin": "(^|\\G)(\\s*)(.*)",
+              "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+              "patterns": [
+                {
+                  "begin": "^\\s*---\\s*$",
+                  "end": "^\\s*---\\s*$",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.tag.xi.begin.t"
+                    }
+                  },
+                  "endCaptures": {
+                    "0": {
+                      "name": "punctuation.definition.tag.xi.end.t"
+                    }
+                  },
+                  "contentName": "meta.embedded.block.astro.frontmatter",
+                  "patterns": [
+                    {
+                      "include": "source.tsx"
+                    }
+                  ]
+                },
+                {
+                  "contentName": "meta.embedded.block.astro",
+                  "include": "source.astro"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Changes

This adds support for syntax highlighting `astro` tagged code blocks inside MDX files.

````mdx
This is MDX

```astro
---
const frontmatter = 'This is Astro frontmatter'
---

<div>This is an Astro template</div>
```
````

![image](https://github.com/withastro/language-tools/assets/779047/23e1ab92-980c-452d-a33d-0bcb48d25bdd)

## Testing

With the [MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) installed, open the Astro language tools repo and create an Astro code block inside an MDX file.

## Docs

I don’t know what documentation would be needed for this.