### PR TITLE
Add `@astrojs/check` README

### DIFF
--- a/.changeset/friendly-jars-cover.md
+++ b/.changeset/friendly-jars-cover.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/check": patch
+---
+
+Adds a README with helpful links

--- a/packages/astro-check/README.md
+++ b/packages/astro-check/README.md
@@ -1,6 +1,6 @@
 # @astrojs/check ✅
 
-Type checking and diagnostics for your Astro project.
+Type checking and diagnostics for Astro projects.
 
 ## Documentation
 

--- a/packages/astro-check/README.md
+++ b/packages/astro-check/README.md
@@ -1,0 +1,36 @@
+# @astrojs/check ✅
+
+Type checking and diagnostics for your Astro project.
+
+## Documentation
+
+Read [the Astro type checking docs][docs].
+
+## Support
+
+- Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#editors` channel to discuss current development and more!
+
+- Submit bug reports and feature requests as [GitHub issues][issues].
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR! These links will help you get started:
+
+- [Contributor Manual][contributing]
+- [Code of Conduct][coc]
+- [Community Guide][community]
+
+## License
+
+MIT
+
+Copyright (c) 2022–present [Astro][astro]
+
+[astro]: https://astro.build/
+[docs]: https://docs.astro.build/en/guides/typescript/#type-checking
+[contributing]: https://github.com/withastro/language-tools/blob/main/CONTRIBUTING.md
+[coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
+[community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
+[discord]: https://astro.build/chat/
+[issues]: https://github.com/withastro/language-tools/issues
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/astro-check/README.md
+++ b/packages/astro-check/README.md
@@ -1,6 +1,8 @@
 # @astrojs/check ✅
 
-Type checking and diagnostics for Astro projects.
+This package powers the `astro check` CLI command for running type checking and diagnostics in Astro projects.
+
+This package's internal logic is powered by [the Astro language server](https://github.com/withastro/language-tools/blob/main/packages/language-server/src/check.ts).
 
 ## Documentation
 

--- a/packages/astro-check/package.json
+++ b/packages/astro-check/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@astrojs/check",
+  "description": "Type checking and diagnostics for Astro projects",
   "version": "0.7.0",
   "author": "withastro",
   "license": "MIT",
+  "homepage": "https://github.com/withastro/language-tools/tree/main/packages/astro-check",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/language-tools",


### PR DESCRIPTION
## Changes

- Adds a README to the `@astrojs/check` package similar to the ones we use for Astro integrations (inspired by someone who found the package on npm and didn’t know what it was)
- Adds `description` and `homepage` fields to `package.json` too

## Testing

n/a metadata change only

## Docs

It’s all docs I guess.
