### PR TITLE
[bugfix] Executing `pnpm test` on workspace folder with a space on the name doesn't work `ENOENT: no such file or directory`

### DIFF
--- a/packages/vscode/test/grammar/test.mjs
+++ b/packages/vscode/test/grammar/test.mjs
@@ -17,6 +17,7 @@ const allGrammars = [...grammars, ...dummyGrammars];
 
 /**
  * @param  {Parameters<typeof spawn>} arg
+ * @returns {Promise<number | null>}
  */
 function promisifySpawn(...arg) {
 	const childProcess = spawn(...arg);
@@ -45,10 +46,9 @@ async function snapShotTest() {
 
 	const code = await promisifySpawn(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', args, {
 		stdio: 'inherit',
-		shell: true,
 	});
 
-	if (code > 0) {
+	if (code && code > 0) {
 		process.exit(code);
 	}
 }


### PR DESCRIPTION
## Changes

- My workspace folder had a space `External Projecs` and executing `pnpm test`, and with shell:true, arguments of `child_process.spawn` are not escaped.
- I believe that shell: true might be unnecessary. If it isn't, another solution would have to be to do manual escaping of each command argument...


```bash

packages/vscode
astro-vscode:test: > node scripts/build-grammar.mjs
astro-vscode:test: 
astro-vscode:test: [09:54 AM] ✔ updated /Workspace/External Projects/language-tools/packages/vscode/syntaxes/astro.tmLanguage.json
astro-vscode:test: node:fs:581
astro-vscode:test:   return binding.open(
astro-vscode:test:                  ^
astro-vscode:test: 
astro-vscode:test: Error: ENOENT: no such file or directory, open '/Workspace/External'

```

## Testing

If the tests don't run successfully on the test matrix on all systems, this is clearly wrong.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only on a test script
