### PR TITLE
fix(js/css): Fixes intellisense inside inline styles and scripts

### DIFF
--- a/.changeset/weak-kiwis-rule.md
+++ b/.changeset/weak-kiwis-rule.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/check": patch
+"astro-vscode": patch
+---
+
+Fixes intellisense not working correctly inside HTML events and style attributes when multi bytes characters were present in the file

--- a/packages/language-server/src/core/index.ts
+++ b/packages/language-server/src/core/index.ts
@@ -9,6 +9,7 @@ import {
 import type { TypeScriptExtraServiceScript } from '@volar/typescript';
 import type ts from 'typescript';
 import type { HTMLDocument } from 'vscode-html-languageservice';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { URI } from 'vscode-uri';
 import { type AstroInstall, getLanguageServerTypesDir } from '../utils.js';
 import { astro2tsx } from './astro2tsx';
@@ -161,6 +162,13 @@ export class AstroVirtualCode implements VirtualCode {
 		];
 		this.compilerDiagnostics = [];
 
+		const astroDocument = TextDocument.create(
+			fileName + '.astro',
+			'astro',
+			0,
+			snapshot.getText(0, snapshot.getLength())
+		);
+
 		const astroMetadata = getAstroMetadata(
 			this.fileName,
 			this.snapshot.getText(0, this.snapshot.getLength())
@@ -178,13 +186,17 @@ export class AstroVirtualCode implements VirtualCode {
 		);
 		this.htmlDocument = htmlDocument;
 
-		const scriptTags = extractScriptTags(this.snapshot, htmlDocument, astroMetadata.ast);
+		const scriptTags = extractScriptTags(
+			this.snapshot,
+			astroDocument,
+			htmlDocument,
+			astroMetadata.ast
+		);
 
 		this.scriptCodeIds = scriptTags.map((scriptTag) => scriptTag.id);
-
 		htmlVirtualCode.embeddedCodes = [];
 		htmlVirtualCode.embeddedCodes.push(
-			...extractStylesheets(this.snapshot, htmlDocument, astroMetadata.ast),
+			...extractStylesheets(this.snapshot, astroDocument, htmlDocument, astroMetadata.ast),
 			...scriptTags
 		);
 

--- a/packages/language-server/src/core/parseCSS.ts
+++ b/packages/language-server/src/core/parseCSS.ts
@@ -3,12 +3,13 @@ import { is } from '@astrojs/compiler/utils';
 import type { CodeInformation, VirtualCode } from '@volar/language-core';
 import { Segment, toString } from 'muggle-string';
 import type ts from 'typescript';
-import type { HTMLDocument, Node } from 'vscode-html-languageservice';
+import type { HTMLDocument, Node, TextDocument } from 'vscode-html-languageservice';
 import { buildMappings } from '../buildMappings.js';
-import type { AttributeNodeWithPosition } from './compilerUtils.js';
+import { type AttributeNodeWithPosition, PointToPosition } from './compilerUtils.js';
 
 export function extractStylesheets(
 	snapshot: ts.IScriptSnapshot,
+	astroDocument: TextDocument,
 	htmlDocument: HTMLDocument,
 	ast: ParseResult['ast']
 ): VirtualCode[] {
@@ -22,7 +23,7 @@ export function extractStylesheets(
 			codes.push([
 				inlineStyle.value,
 				undefined,
-				inlineStyle.position.start.offset + 'style="'.length,
+				astroDocument.offsetAt(PointToPosition(inlineStyle.position.start)) + 'style="'.length,
 				{
 					completion: true,
 					verification: false,

--- a/packages/language-server/test/css/completions.test.ts
+++ b/packages/language-server/test/css/completions.test.ts
@@ -41,4 +41,18 @@ describe('CSS - Completions', () => {
 		expect(completions!.items).to.not.be.empty;
 		expect(completions?.items.map((i) => i.label)).to.include('aliceblue');
 	});
+
+	it('Can provide completions inside inline styles with multi-bytes characters in the file', async () => {
+		const document = await languageServer.openFakeDocument(
+			`<div>あ</div><div style="color: ;"></div>`,
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 30)
+		);
+
+		expect(completions!.items).to.not.be.empty;
+		expect(completions?.items.map((i) => i.label)).to.include('aliceblue');
+	});
 });

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -105,4 +105,21 @@ describe('TypeScript - Completions', async () => {
 		const allLabels = completions?.items.map((item) => item.label);
 		expect(allLabels).to.include('alert');
 	});
+
+	it('Can get completions inside HTML events with multi-bytes characters in the file', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<div>あ</div><div onload="a"></div>',
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 24)
+		);
+
+		expect(completions?.items).to.not.be.empty;
+
+		// Make sure we have the `alert` completion, which is a global function
+		const allLabels = completions?.items.map((item) => item.label);
+		expect(allLabels).to.include('alert');
+	});
 });

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -91,4 +91,17 @@ describe('TypeScript - Completions', async () => {
 		);
 		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);
 	});
+
+	it('Can get completions inside HTML events', async () => {
+		const document = await languageServer.openFakeDocument('<div onload="a"', 'astro');
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 13)
+		);
+
+		expect(completions?.items).to.not.be.empty;
+
+		const allLabels = completions?.items.map((item) => item.label);
+		expect(allLabels).to.include('alert');
+	});
 });

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -93,7 +93,7 @@ describe('TypeScript - Completions', async () => {
 	});
 
 	it('Can get completions inside HTML events', async () => {
-		const document = await languageServer.openFakeDocument('<div onload="a"', 'astro');
+		const document = await languageServer.openFakeDocument('<div onload="a"></div>', 'astro');
 		const completions = await languageServer.handle.sendCompletionRequest(
 			document.uri,
 			Position.create(0, 13)
@@ -101,6 +101,7 @@ describe('TypeScript - Completions', async () => {
 
 		expect(completions?.items).to.not.be.empty;
 
+		// Make sure we have the `alert` completion, which is a global function
 		const allLabels = completions?.items.map((item) => item.label);
 		expect(allLabels).to.include('alert');
 	});

--- a/packages/language-server/test/units/parseCSS.test.ts
+++ b/packages/language-server/test/units/parseCSS.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import ts from 'typescript/lib/typescript.js';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getAstroMetadata } from '../../src/core/parseAstro.js';
 import { extractStylesheets } from '../../src/core/parseCSS.js';
 import { parseHTML } from '../../src/core/parseHTML.js';
@@ -8,10 +9,11 @@ describe('parseCSS - Can find all the styles in an Astro file', () => {
 	it('Can find all the styles in an Astro file, including nested tags', () => {
 		const input = `<style>h1{color: blue;}</style><div><style>h2{color: red;}</style></div>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const astroDocument = TextDocument.create('file.astro', 'astro', 0, input);
 		const html = parseHTML(snapshot, 0);
 		const astroAst = getAstroMetadata('file.astro', input).ast;
 
-		const styleTags = extractStylesheets(snapshot, html.htmlDocument, astroAst);
+		const styleTags = extractStylesheets(snapshot, astroDocument, html.htmlDocument, astroAst);
 
 		expect(styleTags.length).to.equal(2);
 	});

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import ts from 'typescript/lib/typescript.js';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getAstroMetadata } from '../../src/core/parseAstro.js';
 import { parseHTML } from '../../src/core/parseHTML.js';
 import { extractScriptTags } from '../../src/core/parseJS.js';
@@ -8,10 +9,11 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 	it('Can find all the scripts in an Astro file, including nested tags', () => {
 		const input = `<script>console.log('hi')</script><div><script>console.log('hi2')</script></div>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const astroDocument = TextDocument.create('file.astro', 'astro', 0, input);
 		const html = parseHTML(snapshot, 0);
 		const astroAst = getAstroMetadata('file.astro', input).ast;
 
-		const scriptTags = extractScriptTags(snapshot, html.htmlDocument, astroAst);
+		const scriptTags = extractScriptTags(snapshot, astroDocument, html.htmlDocument, astroAst);
 
 		expect(scriptTags.length).to.equal(2);
 	});
@@ -19,10 +21,11 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 	it('Ignore JSON scripts', () => {
 		const input = `<script type="application/json">{foo: "bar"}</script>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const astroDocument = TextDocument.create('file.astro', 'astro', 0, input);
 		const html = parseHTML(snapshot, 0);
 		const astroAst = getAstroMetadata('file.astro', input).ast;
 
-		const scriptTags = extractScriptTags(snapshot, html.htmlDocument, astroAst);
+		const scriptTags = extractScriptTags(snapshot, astroDocument, html.htmlDocument, astroAst);
 
 		expect(scriptTags.length).to.equal(0);
 	});
@@ -30,10 +33,11 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 	it('returns the proper capabilities for inline script tags', () => {
 		const input = `<script is:inline>console.log('hi')</script>`;
 		const snapshot = ts.ScriptSnapshot.fromString(input);
+		const astroDocument = TextDocument.create('file.astro', 'astro', 0, input);
 		const html = parseHTML(snapshot, 0);
 		const astroAst = getAstroMetadata('file.astro', input).ast;
 
-		const scriptTags = extractScriptTags(snapshot, html.htmlDocument, astroAst);
+		const scriptTags = extractScriptTags(snapshot, astroDocument, html.htmlDocument, astroAst);
 
 		scriptTags[0].mappings.forEach((mapping) => {
 			expect(mapping.data).to.deep.equal({


### PR DESCRIPTION
## Changes

We calculate inline scripts and styles (inside HTML events and `style` attributes respectively) using the positions from the AST the compiler returns. This is fine, however the offset it returns consider multiple bytes characters, unlike LSP (well, it's in reality more complicated than that because of encoding and stuff, but it's still somewhat that)

This PR changes it so we uses the Point returned instead, which do consider lines and columns character by character

Fixes https://github.com/withastro/language-tools/issues/862

## Testing

Added a bunch of tests

## Docs

N/A