### PR TITLE
fix: scripts affecting intellisense

### DIFF
--- a/.changeset/light-bananas-fail.md
+++ b/.changeset/light-bananas-fail.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": minor
+"astro-vscode": minor
+---
+
+Improves the handling of script and style tags. This release fixes numerous issues where the presence of those tags could break intellisense in certain parts of the file.

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -21,7 +21,7 @@
     "test:match": "pnpm run test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^2.7.0",
+    "@astrojs/compiler": "^2.9.1",
     "@jridgewell/sourcemap-codec": "^1.4.15",
     "@volar/kit": "~2.4.0-alpha.15",
     "@volar/language-core": "~2.4.0-alpha.15",

--- a/packages/language-server/src/core/parseCSS.ts
+++ b/packages/language-server/src/core/parseCSS.ts
@@ -1,169 +1,45 @@
-import type { ParentNode, ParseResult } from '@astrojs/compiler/types';
-import { is } from '@astrojs/compiler/utils';
+import type { TSXExtractedStyle } from '@astrojs/compiler/types';
 import type { CodeInformation, VirtualCode } from '@volar/language-core';
 import { Segment, toString } from 'muggle-string';
-import type ts from 'typescript';
-import type { HTMLDocument, Node } from 'vscode-html-languageservice';
 import { buildMappings } from '../buildMappings.js';
-import type { AttributeNodeWithPosition } from './compilerUtils.js';
 
-export function extractStylesheets(
-	snapshot: ts.IScriptSnapshot,
-	htmlDocument: HTMLDocument,
-	ast: ParseResult['ast']
-): VirtualCode[] {
-	const embeddedCSSCodes: VirtualCode[] = findEmbeddedStyles(snapshot, htmlDocument.roots);
+export function extractStylesheets(styles: TSXExtractedStyle[]): VirtualCode {
+	return mergeCSSContexts(styles);
+}
 
-	const inlineStyles = findInlineStyles(ast);
-	if (inlineStyles.length > 0) {
-		const codes: Segment<CodeInformation>[] = [];
-		for (const inlineStyle of inlineStyles) {
-			codes.push('x { ');
-			codes.push([
-				inlineStyle.value,
-				undefined,
-				inlineStyle.position.start.offset + 'style="'.length,
-				{
-					completion: true,
-					verification: false,
-					semantic: true,
-					navigation: true,
-					structure: true,
-					format: false,
-				},
-			]);
-			codes.push(' }\n');
-		}
+function mergeCSSContexts(inlineStyles: TSXExtractedStyle[]): VirtualCode {
+	const codes: Segment<CodeInformation>[] = [];
 
-		const mappings = buildMappings(codes);
-		const text = toString(codes);
-
-		embeddedCSSCodes.push({
-			id: 'inline.css',
-			languageId: 'css',
-			snapshot: {
-				getText: (start, end) => text.substring(start, end),
-				getLength: () => text.length,
-				getChangeRange: () => undefined,
+	for (const javascriptContext of inlineStyles) {
+		if (javascriptContext.type === 'style-attribute') codes.push('__ { ');
+		codes.push([
+			javascriptContext.content,
+			undefined,
+			javascriptContext.position.start,
+			{
+				verification: true,
+				completion: true,
+				semantic: true,
+				navigation: true,
+				structure: true,
+				format: false,
 			},
-			embeddedCodes: [],
-			mappings,
-		});
+		]);
+		if (javascriptContext.type === 'style-attribute') codes.push(' }\n');
 	}
 
-	return embeddedCSSCodes;
-}
+	const mappings = buildMappings(codes);
+	const text = toString(codes);
 
-/**
- * Find all embedded styles in a document.
- * Embedded styles are styles that are defined in `<style>` tags.
- */
-function findEmbeddedStyles(snapshot: ts.IScriptSnapshot, roots: Node[]): VirtualCode[] {
-	const embeddedCSSCodes: VirtualCode[] = [];
-	let cssIndex = 0;
-
-	getEmbeddedCSSInNodes(roots);
-
-	function getEmbeddedCSSInNodes(nodes: Node[]) {
-		for (const [_, node] of nodes.entries()) {
-			if (
-				node.tag === 'style' &&
-				node.startTagEnd !== undefined &&
-				node.endTagStart !== undefined
-			) {
-				const styleText = snapshot.getText(node.startTagEnd, node.endTagStart);
-				embeddedCSSCodes.push({
-					id: `${cssIndex}.css`,
-					languageId: 'css',
-					snapshot: {
-						getText: (start, end) => styleText.substring(start, end),
-						getLength: () => styleText.length,
-						getChangeRange: () => undefined,
-					},
-					mappings: [
-						{
-							sourceOffsets: [node.startTagEnd],
-							generatedOffsets: [0],
-							lengths: [styleText.length],
-							data: {
-								verification: false,
-								completion: true,
-								semantic: true,
-								navigation: true,
-								structure: true,
-								format: false,
-							},
-						},
-					],
-					embeddedCodes: [],
-				});
-				cssIndex++;
-			}
-
-			if (node.children) getEmbeddedCSSInNodes(node.children);
-		}
-	}
-
-	return embeddedCSSCodes;
-}
-
-/**
- * Find all inline styles using the Astro AST
- * Inline styles are styles that are defined in the `style` attribute of an element.
- * TODO: Merge this with `findEmbeddedCSS`? Unlike scripts, there's no scoping being done here, so merging all of it in
- * the same virtual file is possible, though it might make mapping more tricky.
- */
-function findInlineStyles(ast: ParseResult['ast']): AttributeNodeWithPosition[] {
-	const styleAttrs: AttributeNodeWithPosition[] = [];
-
-	// `@astrojs/compiler`'s `walk` method is async, so we can't use it here. Arf
-	function walkDown(parent: ParentNode) {
-		if (!parent.children) return;
-
-		parent.children.forEach((child) => {
-			if (is.element(child)) {
-				const styleAttribute = child.attributes.find(
-					(attr) => attr.name === 'style' && attr.kind === 'quoted'
-				);
-
-				if (styleAttribute && styleAttribute.position) {
-					styleAttrs.push(styleAttribute as AttributeNodeWithPosition);
-				}
-			}
-
-			if (is.parent(child)) {
-				walkDown(child);
-			}
-		});
-	}
-
-	walkDown(ast);
-
-	return styleAttrs;
-}
-
-// TODO: Provide completion for classes and IDs
-export function collectClassesAndIdsFromDocument(ast: ParseResult['ast']): string[] {
-	const classesAndIds: string[] = [];
-	function walkDown(parent: ParentNode) {
-		if (!parent.children) return;
-
-		parent.children.forEach((child) => {
-			if (is.element(child)) {
-				const classOrIDAttributes = child.attributes
-					.filter((attr) => attr.kind === 'quoted' && (attr.name === 'class' || attr.name === 'id'))
-					.flatMap((attr) => attr.value.split(' '));
-
-				classesAndIds.push(...classOrIDAttributes);
-			}
-
-			if (is.parent(child)) {
-				walkDown(child);
-			}
-		});
-	}
-
-	walkDown(ast);
-
-	return classesAndIds;
+	return {
+		id: 'style.css',
+		languageId: 'css',
+		snapshot: {
+			getText: (start, end) => text.substring(start, end),
+			getLength: () => text.length,
+			getChangeRange: () => undefined,
+		},
+		embeddedCodes: [],
+		mappings,
+	};
 }

--- a/packages/language-server/src/core/parseJS.ts
+++ b/packages/language-server/src/core/parseJS.ts
@@ -1,204 +1,73 @@
-import type { ParentNode, ParseResult } from '@astrojs/compiler/types';
-import { is } from '@astrojs/compiler/utils';
+import type { TSXExtractedScript } from '@astrojs/compiler/types';
 import type { CodeInformation, VirtualCode } from '@volar/language-core';
 import { Segment, toString } from 'muggle-string';
-import type ts from 'typescript';
-import type { HTMLDocument, Node } from 'vscode-html-languageservice';
 import { buildMappings } from '../buildMappings';
 
-export function extractScriptTags(
-	snapshot: ts.IScriptSnapshot,
-	htmlDocument: HTMLDocument,
-	ast: ParseResult['ast']
-): VirtualCode[] {
-	const embeddedJSCodes: VirtualCode[] = findModuleScripts(snapshot, htmlDocument.roots);
+export function extractScriptTags(scripts: TSXExtractedScript[]): VirtualCode[] {
+	const embeddedJSCodes: VirtualCode[] = [];
 
-	const javascriptContexts = [
-		...findClassicScripts(htmlDocument, snapshot),
-		...findEventAttributes(ast),
-	].sort((a, b) => a.startOffset - b.startOffset);
+	const moduleScripts = scripts
+		.filter((script) => script.type === 'module' || script.type === 'processed-module')
+		.map(moduleScriptToVirtualCode) satisfies VirtualCode[];
 
-	if (javascriptContexts.length > 0) {
-		// classic scripts share the same scope
-		// merging them brings about redeclaration errors
-		embeddedJSCodes.push(mergeJSContexts(javascriptContexts));
-	}
+	const inlineScripts = scripts
+		.filter((script) => script.type === 'event-attribute' || script.type === 'inline')
+		.sort((a, b) => a.position.start - b.position.start);
+
+	embeddedJSCodes.push(...moduleScripts, mergeJSContexts(inlineScripts));
 
 	return embeddedJSCodes;
 }
 
-function getScriptType(scriptTag: Node): 'classic' | 'module' | 'processed module' {
-	// script tags without attributes are processed and converted into module scripts
-	if (!scriptTag.attributes || Object.entries(scriptTag.attributes).length === 0)
-		return 'processed module';
-	// even when it is not processed by vite, scripts with type=module remain modules
-	if (scriptTag.attributes['type']?.includes('module') === true) return 'module';
-	// whenever there are attributes, is:inline is implied and in the absence of type=module, the script is classic
-	return 'classic';
-}
-
-/**
- * Get all the isolated scripts in the HTML document
- * Isolated scripts are scripts that are hoisted by Astro and as such, are isolated from the rest of the code because of the implicit `type="module"`
- * All the isolated scripts are passed to the TypeScript language server as separate `.mts` files.
- */
-function findModuleScripts(snapshot: ts.IScriptSnapshot, roots: Node[]): VirtualCode[] {
-	const embeddedScripts: VirtualCode[] = [];
-	let scriptIndex = 0;
-
-	getEmbeddedScriptsInNodes(roots);
-
-	function getEmbeddedScriptsInNodes(nodes: Node[]) {
-		for (const [_, node] of nodes.entries()) {
-			if (
-				node.tag === 'script' &&
-				node.startTagEnd !== undefined &&
-				node.endTagStart !== undefined &&
-				getScriptType(node) !== 'classic'
-			) {
-				const scriptText = snapshot.getText(node.startTagEnd, node.endTagStart);
-				const extension = getScriptType(node) === 'processed module' ? 'mts' : 'mjs';
-				const languageId = getScriptType(node) === 'processed module' ? 'typescript' : 'javascript';
-				embeddedScripts.push({
-					id: `${scriptIndex}.${extension}`,
-					languageId: languageId,
-					snapshot: {
-						getText: (start, end) => scriptText.substring(start, end),
-						getLength: () => scriptText.length,
-						getChangeRange: () => undefined,
-					},
-					mappings: [
-						{
-							sourceOffsets: [node.startTagEnd],
-							generatedOffsets: [0],
-							lengths: [scriptText.length],
-							data: {
-								verification: true,
-								completion: true,
-								semantic: true,
-								navigation: true,
-								structure: true,
-								format: false,
-							},
-						},
-					],
-					embeddedCodes: [],
-				});
-				scriptIndex++;
-			}
-
-			if (node.children) getEmbeddedScriptsInNodes(node.children);
-		}
+function moduleScriptToVirtualCode(script: TSXExtractedScript, index: number): VirtualCode {
+	let extension = 'mts';
+	let languageId = 'typescript';
+	if (script.type === 'module') {
+		extension = 'mjs';
+		languageId = 'javascript';
 	}
 
-	return embeddedScripts;
-}
-
-interface JavaScriptContext {
-	content: string;
-	startOffset: number;
-}
-
-/**
- * Get all the inline scripts in the HTML document
- * Inline scripts are scripts that are not hoisted by Astro and as such, are not isolated from the rest of the code.
- * All the inline scripts are concatenated into a single `.mjs` file and passed to the TypeScript language server.
- */
-function findClassicScripts(
-	htmlDocument: HTMLDocument,
-	snapshot: ts.IScriptSnapshot
-): JavaScriptContext[] {
-	const inlineScripts: JavaScriptContext[] = [];
-
-	getInlineScriptsInNodes(htmlDocument.roots);
-
-	function getInlineScriptsInNodes(nodes: Node[]) {
-		for (const [_, node] of nodes.entries()) {
-			if (
-				node.tag === 'script' &&
-				node.startTagEnd !== undefined &&
-				node.endTagStart !== undefined &&
-				!isJSON(node.attributes?.type) &&
-				getScriptType(node) === 'classic'
-			) {
-				const scriptText = snapshot.getText(node.startTagEnd, node.endTagStart);
-				inlineScripts.push({
-					startOffset: node.startTagEnd,
-					content: scriptText,
-				});
-			}
-
-			if (node.children) getInlineScriptsInNodes(node.children);
-		}
-	}
-
-	return inlineScripts;
-}
-
-/**
- * Include both MIME JSON types and `importmap` and `speculationrules` script types
- * See MIME Types -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
- * See Script Types -> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
- */
-const JSON_TYPES = ['application/json', 'application/ld+json', 'importmap', 'speculationrules'];
-
-/**
- * Check if the script has a type, and if it's included in JSON_TYPES above.
- * @param type Found in the `type` attribute of the script tag
- */
-function isJSON(type: string | null | undefined): boolean {
-	if (!type) return false;
-
-	// HTML attributes are quoted, slice " and ' at the start and end of the string
-	return JSON_TYPES.includes(type.slice(1, -1));
-}
-
-function findEventAttributes(ast: ParseResult['ast']): JavaScriptContext[] {
-	const eventAttrs: JavaScriptContext[] = [];
-
-	// `@astrojs/compiler`'s `walk` method is async, so we can't use it here. Arf
-	function walkDown(parent: ParentNode) {
-		if (!parent.children) return;
-
-		parent.children.forEach((child) => {
-			if (is.element(child)) {
-				const eventAttribute = child.attributes.find(
-					(attr) => htmlEventAttributes.includes(attr.name) && attr.kind === 'quoted'
-				);
-
-				if (eventAttribute && eventAttribute.position) {
-					eventAttrs.push({
-						// Add a semicolon to the end of the event attribute to attempt to prevent errors from spreading to the rest of the document
-						// This is not perfect, but it's better than nothing
-						// See: https://github.com/microsoft/vscode/blob/e8e04769ec817a3374c3eaa26a08d3ae491820d5/extensions/html-language-features/server/src/modes/embeddedSupport.ts#L192
-						content: eventAttribute.value + ';',
-						startOffset: eventAttribute.position.start.offset + `${eventAttribute.name}="`.length,
-					});
-				}
-			}
-
-			if (is.parent(child)) {
-				walkDown(child);
-			}
-		});
-	}
-
-	walkDown(ast);
-
-	return eventAttrs;
+	return {
+		id: `${index}.${extension}`,
+		languageId,
+		snapshot: {
+			getText: (start, end) => script.content.substring(start, end),
+			getLength: () => script.content.length,
+			getChangeRange: () => undefined,
+		},
+		mappings: [
+			{
+				sourceOffsets: [script.position.start],
+				generatedOffsets: [0],
+				lengths: [script.content.length],
+				data: {
+					verification: true,
+					completion: true,
+					semantic: true,
+					navigation: true,
+					structure: true,
+					format: false,
+				},
+			},
+		],
+		embeddedCodes: [],
+	};
 }
 
 /**
  * Merge all the inline and non-hoisted scripts into a single `.mjs` file
  */
-function mergeJSContexts(javascriptContexts: JavaScriptContext[]): VirtualCode {
+function mergeJSContexts(inlineScripts: TSXExtractedScript[]): VirtualCode {
 	const codes: Segment<CodeInformation>[] = [];
 
-	for (const javascriptContext of javascriptContexts) {
+	for (const javascriptContext of inlineScripts) {
 		codes.push([
-			javascriptContext.content,
+			// Add a semicolon to the end of the event attribute to attempt to prevent errors from spreading to the rest of the document
+			// This is not perfect, but it's better than nothing
+			// See: https://github.com/microsoft/vscode/blob/e8e04769ec817a3374c3eaa26a08d3ae491820d5/extensions/html-language-features/server/src/modes/embeddedSupport.ts#L192
+			javascriptContext.content + ';',
 			undefined,
-			javascriptContext.startOffset,
+			javascriptContext.position.start,
 			{
 				verification: true,
 				completion: true,
@@ -225,91 +94,3 @@ function mergeJSContexts(javascriptContexts: JavaScriptContext[]): VirtualCode {
 		mappings,
 	};
 }
-
-const htmlEventAttributes = [
-	'onabort',
-	'onafterprint',
-	'onauxclick',
-	'onbeforematch',
-	'onbeforeprint',
-	'onbeforeunload',
-	'onblur',
-	'oncancel',
-	'oncanplay',
-	'oncanplaythrough',
-	'onchange',
-	'onclick',
-	'onclose',
-	'oncontextlost',
-	'oncontextmenu',
-	'oncontextrestored',
-	'oncopy',
-	'oncuechange',
-	'oncut',
-	'ondblclick',
-	'ondrag',
-	'ondragend',
-	'ondragenter',
-	'ondragleave',
-	'ondragover',
-	'ondragstart',
-	'ondrop',
-	'ondurationchange',
-	'onemptied',
-	'onended',
-	'onerror',
-	'onfocus',
-	'onformdata',
-	'onhashchange',
-	'oninput',
-	'oninvalid',
-	'onkeydown',
-	'onkeypress',
-	'onkeyup',
-	'onlanguagechange',
-	'onload',
-	'onloadeddata',
-	'onloadedmetadata',
-	'onloadstart',
-	'onmessage',
-	'onmessageerror',
-	'onmousedown',
-	'onmouseenter',
-	'onmouseleave',
-	'onmousemove',
-	'onmouseout',
-	'onmouseover',
-	'onmouseup',
-	'onoffline',
-	'ononline',
-	'onpagehide',
-	'onpageshow',
-	'onpaste',
-	'onpause',
-	'onplay',
-	'onplaying',
-	'onpopstate',
-	'onprogress',
-	'onratechange',
-	'onrejectionhandled',
-	'onreset',
-	'onresize',
-	'onscroll',
-	'onscrollend',
-	'onsecuritypolicyviolation',
-	'onseeked',
-	'onseeking',
-	'onselect',
-	'onslotchange',
-	'onstalled',
-	'onstorage',
-	'onsubmit',
-	'onsuspend',
-	'ontimeupdate',
-	'ontoggle',
-	'onunhandledrejection',
-	'onunload',
-	'onvolumechange',
-	'onwaiting',
-	'onwheel',
-];

--- a/packages/language-server/src/core/parseJS.ts
+++ b/packages/language-server/src/core/parseJS.ts
@@ -14,7 +14,11 @@ export function extractScriptTags(scripts: TSXExtractedScript[]): VirtualCode[] 
 		.filter((script) => script.type === 'event-attribute' || script.type === 'inline')
 		.sort((a, b) => a.position.start - b.position.start);
 
-	embeddedJSCodes.push(...moduleScripts, mergeJSContexts(inlineScripts));
+	embeddedJSCodes.push(...moduleScripts);
+	const mergedJSContext = mergeJSContexts(inlineScripts);
+	if (mergedJSContext) {
+		embeddedJSCodes.push(mergedJSContext);
+	}
 
 	return embeddedJSCodes;
 }
@@ -57,7 +61,11 @@ function moduleScriptToVirtualCode(script: TSXExtractedScript, index: number): V
 /**
  * Merge all the inline and non-hoisted scripts into a single `.mjs` file
  */
-function mergeJSContexts(inlineScripts: TSXExtractedScript[]): VirtualCode {
+function mergeJSContexts(inlineScripts: TSXExtractedScript[]): VirtualCode | undefined {
+	if (inlineScripts.length === 0) {
+		return undefined;
+	}
+
 	const codes: Segment<CodeInformation>[] = [];
 
 	for (const javascriptContext of inlineScripts) {

--- a/packages/language-server/test/css/completions.test.ts
+++ b/packages/language-server/test/css/completions.test.ts
@@ -41,4 +41,18 @@ describe('CSS - Completions', () => {
 		expect(completions!.items).to.not.be.empty;
 		expect(completions?.items.map((i) => i.label)).to.include('aliceblue');
 	});
+
+	it('Can provide completions inside inline styles with multi-bytes characters in the file', async () => {
+		const document = await languageServer.openFakeDocument(
+			`<div>あ</div><div style="color: ;"></div>`,
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 30)
+		);
+
+		expect(completions!.items).to.not.be.empty;
+		expect(completions?.items.map((i) => i.label)).to.include('aliceblue');
+	});
 });

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -91,4 +91,35 @@ describe('TypeScript - Completions', async () => {
 		);
 		expect(edits?.additionalTextEdits?.[0].range.start.line).to.equal(0);
 	});
+
+	it('Can get completions inside HTML events', async () => {
+		const document = await languageServer.openFakeDocument('<div onload="a"></div>', 'astro');
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 13)
+		);
+
+		expect(completions?.items).to.not.be.empty;
+
+		// Make sure we have the `alert` completion, which is a global function
+		const allLabels = completions?.items.map((item) => item.label);
+		expect(allLabels).to.include('alert');
+	});
+
+	it('Can get completions inside HTML events with multi-bytes characters in the file', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<div>あ</div><div onload="a"></div>',
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(0, 24)
+		);
+
+		expect(completions?.items).to.not.be.empty;
+
+		// Make sure we have the `alert` completion, which is a global function
+		const allLabels = completions?.items.map((item) => item.label);
+		expect(allLabels).to.include('alert');
+	});
 });

--- a/packages/language-server/test/units/parseCSS.test.ts
+++ b/packages/language-server/test/units/parseCSS.test.ts
@@ -1,18 +1,14 @@
 import { expect } from 'chai';
-import ts from 'typescript/lib/typescript.js';
-import { getAstroMetadata } from '../../src/core/parseAstro.js';
+import { astro2tsx } from '../../src/core/astro2tsx.js';
 import { extractStylesheets } from '../../src/core/parseCSS.js';
-import { parseHTML } from '../../src/core/parseHTML.js';
 
 describe('parseCSS - Can find all the styles in an Astro file', () => {
 	it('Can find all the styles in an Astro file, including nested tags', () => {
 		const input = `<style>h1{color: blue;}</style><div><style>h2{color: red;}</style></div>`;
-		const snapshot = ts.ScriptSnapshot.fromString(input);
-		const html = parseHTML(snapshot, 0);
-		const astroAst = getAstroMetadata('file.astro', input).ast;
+		const { ranges } = astro2tsx(input, 'file.astro');
 
-		const styleTags = extractStylesheets(snapshot, html.htmlDocument, astroAst);
+		const styleTags = extractStylesheets(ranges.styles);
 
-		expect(styleTags.length).to.equal(2);
+		expect(styleTags).to.not.be.undefined;
 	});
 });

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -229,7 +229,7 @@
     "vscode-tmgrammar-test": "^0.1.2"
   },
   "dependencies": {
-    "@astrojs/compiler": "^2.7.0",
+    "@astrojs/compiler": "^2.9.1",
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.13.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   packages/language-server:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.9.1
+        version: 2.9.1
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.4.15
@@ -222,8 +222,8 @@ importers:
   packages/vscode:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.9.1
+        version: 2.9.1
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -260,7 +260,7 @@ importers:
         version: 2.3.2
       '@vscode/vsce':
         specifier: latest
-        version: 2.29.0
+        version: 2.30.0
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
@@ -315,6 +315,10 @@ packages:
 
   /@astrojs/compiler@2.7.0:
     resolution: {integrity: sha512-XpC8MAaWjD1ff6/IfkRq/5k1EFj6zhCNqXRd5J43SVJEBj/Bsmizkm8N0xOYscGcDFQkRgEw6/eKnI5x/1l6aA==}
+    dev: false
+
+  /@astrojs/compiler@2.9.1:
+    resolution: {integrity: sha512-s8Ge2lWHx/s3kl4UoerjL/iPtwdtogNM/BLOaGCwQA6crMOVYpphy5wUkYlKyuh8GAeGYH/5haLAFBsgNy9AQQ==}
 
   /@astrojs/internal-helpers@0.2.1:
     resolution: {integrity: sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A==}
@@ -2445,8 +2449,8 @@ packages:
       '@vscode/vsce-sign-win32-x64': 2.0.2
     dev: true
 
-  /@vscode/vsce@2.29.0:
-    resolution: {integrity: sha512-63+aEO8SpjE6qKiIh2Cqy/P9zC7+USElGwpEdkyPp89xIBDBr5IqeNS3zkD3mp3wZqbvHIpJsCCNu74WQirYCg==}
+  /@vscode/vsce@2.30.0:
+    resolution: {integrity: sha512-MBYpXdCY1SCdc2u/y11kmJuSODKFyZRpeRTQq5p4rSg05QSjSy5pz6h/BGLNdSahgXfKRBATEkjAcJFdJuDz8Q==}
     engines: {node: '>= 16'}
     hasBin: true
     dependencies:
@@ -2688,7 +2692,7 @@ packages:
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
     dependencies:
-      '@astrojs/compiler': 2.7.0
+      '@astrojs/compiler': 2.9.1
       '@astrojs/internal-helpers': 0.2.1
       '@astrojs/markdown-remark': 4.2.1
       '@astrojs/telemetry': 3.0.4
@@ -2771,7 +2775,7 @@ packages:
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
     dependencies:
-      '@astrojs/compiler': 2.7.0
+      '@astrojs/compiler': 2.9.1
       '@astrojs/internal-helpers': 0.2.1
       '@astrojs/markdown-remark': 4.2.1
       '@astrojs/telemetry': 3.0.4


### PR DESCRIPTION
## Changes

Requires https://github.com/withastro/compiler/pull/1019

This PR reworks how script and style are extracted from files, using the compiler's information instead of crawling through various ASTs. This makes file updates simpler, much faster, and also more correct as the ASTs sometimes had wrong or misleading positions due to how they were being generated.

Fixes https://github.com/withastro/language-tools/issues/800
Fixes https://github.com/withastro/language-tools/issues/862
This PR also fixes an issue where CSS selection ranges didn't work inside style tags, reported on Discord

## Testing

Tests should pass!

## Docs

N/A
