### PR TITLE
Fixes script and style tags being wrongfully included in the generated TSX

### DIFF
--- a/.changeset/smooth-ravens-visit.md
+++ b/.changeset/smooth-ravens-visit.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/check": patch
+"astro-vscode": patch
+---
+
+Fixes script and style tags being wrongfully included in the generated TSX

--- a/packages/language-server/src/core/astro2tsx.ts
+++ b/packages/language-server/src/core/astro2tsx.ts
@@ -20,7 +20,11 @@ export interface LSPTSXRanges {
 
 export function safeConvertToTSX(content: string, options: ConvertToTSXOptions) {
 	try {
-		const tsx = convertToTSX(content, { filename: options.filename });
+		const tsx = convertToTSX(content, {
+			filename: options.filename,
+			includeScripts: false,
+			includeStyles: false,
+		});
 		return tsx;
 	} catch (e) {
 		console.error(

--- a/packages/language-server/test/typescript/scripts.test.ts
+++ b/packages/language-server/test/typescript/scripts.test.ts
@@ -1,0 +1,34 @@
+import { FullDocumentDiagnosticReport } from '@volar/language-server';
+import { expect } from 'chai';
+import { type LanguageServer, getLanguageServer } from '../server.js';
+
+describe('TypeScript - Diagnostics', async () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+
+	it('treats script tags as modules', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<script>import * as path from "node:path";path;const hello = "Hello, Astro!";</script><script>console.log(hello);</script>',
+			'astro'
+		);
+		const diagnostics = (await languageServer.handle.sendDocumentDiagnosticRequest(
+			document.uri
+		)) as FullDocumentDiagnosticReport;
+
+		expect(diagnostics.items).length(2);
+	});
+
+	it('treats inline script tags as not isolated modules', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<script is:inline>const hello = "Hello, Astro!";</script><script is:inline>console.log(hello);</script>',
+			'astro'
+		);
+
+		const diagnostics = (await languageServer.handle.sendDocumentDiagnosticRequest(
+			document.uri
+		)) as FullDocumentDiagnosticReport;
+
+		expect(diagnostics.items).length(0);
+	});
+});


### PR DESCRIPTION
## Changes

I'm just dumb, I forgot to turn on the new flag I added 🤦‍♀️

## Testing

Added tests that would've covered this. The reason it got through is because the current tests tested that the features (completions, diagnostics etc) works in script tags and that the extraction was done properly (which both are true). However, the errors only happened in actual "end to end" situation where the diagnostics from TSX and the extracted script tags are merged, which wasn't covered (well it was, but separately). Anyway, it's covered now

## Docs

N/A
