### PR TITLE
feat: put emmet in JSX mode to avoid expressions completions

### DIFF
--- a/.changeset/ten-adults-sparkle.md
+++ b/.changeset/ten-adults-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Fixes Emmet completions sometimes showing in places they shouldn't

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -62,7 +62,11 @@ export function getLanguageServicePlugins(connection: Connection, ts: typeof imp
 	return [
 		createHtmlService(),
 		createCssService(),
-		createEmmetService(),
+		createEmmetService({
+			mappedLanguages: {
+				html: 'jsx',
+			},
+		}),
 		...createTypeScriptServices(ts),
 		createTypeScriptTwoSlashService(ts),
 		createTypescriptAddonsService(),


### PR DESCRIPTION
## Changes

By forcing JSX mode on Emmet instead of HTML, we don't get the useless completions inside expressions. I'm not sure 100% what else it changes, as it's not documented, but reading through Emmet's source code I couldn't find anything too bad.

Close https://github.com/withastro/language-tools/discussions/835

## Testing

For some reason, I can't seem to be able to get emmet completions in the tests. I remember something similar happening in the previous language-server as well, I'm not too sure why that happens!

## Docs

N/A
