### PR TITLE
Update bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -29,3 +29,12 @@ body:
         5. Error! Describe what went wrong (and what was expected instead)...
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Link to Minimal Reproducible Example
+      description: |
+        Provide a link to a minimal reproducible example. Please link directly to the file which is causing the issue!
+        If the file is in a private repository you can share a minimal version using a service like [GitHub Gist](https://gist.github.com/) or [Pastebin](https://pastebin.com).
+      placeholder: 'https://github.com/user/repo/blob/main/src/pages/index.astro'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -33,8 +33,8 @@ body:
     attributes:
       label: Link to Minimal Reproducible Example
       description: |
-        Provide a link to a minimal reproducible example. Please link directly to the file which is causing the issue!
-        If the file is in a private repository you can share a minimal version using a service like [GitHub Gist](https://gist.github.com/) or [Pastebin](https://pastebin.com).
+        Provide a link to a minimal reproducible example. If the error only happens in one file, please specify in which file and where precisely does the error happen.
+        If the file is in a private repository you can share a minimal version by copying the file's content in this issue, or using a service like [GitHub Gist](https://gist.github.com/) or [Pastebin](https://pastebin.com).
       placeholder: 'https://github.com/user/repo/blob/main/src/pages/index.astro'
     validations:
       required: true


### PR DESCRIPTION
Add text input to bug issue template for providing link to reproduction

## Changes

- adds new required input for providing a link to a reproduction to the bug issue template 

![image](https://github.com/user-attachments/assets/ad9a82e1-22c2-4da7-806b-40154f273e2e)


## Testing

- checked rendered template in fork (see screenshot)

## Docs

- update to issue template only
