### PR TITLE
Adds support for SCSS and LESS intellisense inside style tags

### DIFF
--- a/.changeset/wet-kangaroos-hide.md
+++ b/.changeset/wet-kangaroos-hide.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/language-server": minor
+"@astrojs/check": minor
+"astro-vscode": minor
+---
+
+Adds support for SCSS and LESS intellisense inside style tags

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -21,7 +21,7 @@
     "test:match": "pnpm run test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^2.9.1",
+    "@astrojs/compiler": "^2.10.0",
     "@jridgewell/sourcemap-codec": "^1.4.15",
     "@volar/kit": "~2.4.0-alpha.15",
     "@volar/language-core": "~2.4.0-alpha.15",

--- a/packages/language-server/src/core/index.ts
+++ b/packages/language-server/src/core/index.ts
@@ -174,7 +174,7 @@ export class AstroVirtualCode implements VirtualCode {
 
 		this.htmlDocument = htmlDocument;
 		htmlVirtualCode.embeddedCodes = [
-			extractStylesheets(tsx.ranges.styles),
+			...extractStylesheets(tsx.ranges.styles),
 			...extractScriptTags(tsx.ranges.scripts),
 		];
 

--- a/packages/language-server/test/css/completions.test.ts
+++ b/packages/language-server/test/css/completions.test.ts
@@ -55,4 +55,47 @@ describe('CSS - Completions', () => {
 		expect(completions!.items).to.not.be.empty;
 		expect(completions?.items.map((i) => i.label)).to.include('aliceblue');
 	});
+
+	it('Can provide completions inside SCSS blocks', async () => {
+		const document = await languageServer.openFakeDocument(
+			`<style lang="scss">
+  $c: red;
+	.foo {
+		color: $
+	}
+</style>
+`,
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(3, 10)
+		);
+
+		const allLabels = completions?.items.map((i) => i.label);
+
+		expect(completions!.items).to.not.be.empty;
+		expect(allLabels).to.include('$c');
+	});
+
+	it('Can provide completions inside LESS blocks', async () => {
+		const document = await languageServer.openFakeDocument(
+			`<style lang="less">
+	@link-color: #428bca;
+	h1 {
+		color: @
+	}
+</style>
+`,
+			'astro'
+		);
+		const completions = await languageServer.handle.sendCompletionRequest(
+			document.uri,
+			Position.create(3, 10)
+		);
+
+		const allLabels = completions?.items.map((i) => i.label);
+		expect(completions!.items).to.not.be.empty;
+		expect(allLabels).to.include('@link-color');
+	});
 });

--- a/packages/language-server/test/typescript/scripts.test.ts
+++ b/packages/language-server/test/typescript/scripts.test.ts
@@ -1,4 +1,4 @@
-import { FullDocumentDiagnosticReport } from '@volar/language-server';
+import { FullDocumentDiagnosticReport, Position } from '@volar/language-server';
 import { expect } from 'chai';
 import { type LanguageServer, getLanguageServer } from '../server.js';
 
@@ -30,5 +30,33 @@ describe('TypeScript - Diagnostics', async () => {
 		)) as FullDocumentDiagnosticReport;
 
 		expect(diagnostics.items).length(0);
+	});
+
+	it('still supports script tags with unknown types', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<script type="something-else">const hello = "Hello, Astro!";</script>',
+			'astro'
+		);
+
+		const hoverInfo = await languageServer.handle.sendHoverRequest(
+			document.uri,
+			Position.create(0, 38)
+		);
+
+		expect(hoverInfo).to.not.be.undefined;
+	});
+
+	it('ignores is:raw script tags', async () => {
+		const document = await languageServer.openFakeDocument(
+			'<script is:raw>const hello = "Hello, Astro!";</script>',
+			'astro'
+		);
+
+		const hoverInfo = await languageServer.handle.sendHoverRequest(
+			document.uri,
+			Position.create(0, 38)
+		);
+
+		expect(hoverInfo).to.be.null;
 	});
 });

--- a/packages/language-server/test/units/parseJS.test.ts
+++ b/packages/language-server/test/units/parseJS.test.ts
@@ -11,13 +11,12 @@ describe('parseJS - Can find all the scripts in an Astro file', () => {
 		expect(scriptTags.length).to.equal(2);
 	});
 
-	// TODO: This will be outdated in the future, once we add JSON support
-	it('Ignore JSON scripts', () => {
+	it('Includes JSON scripts', () => {
 		const input = `<script type="application/json">{foo: "bar"}</script>`;
 		const { ranges } = astro2tsx(input, 'file.astro');
 		const scriptTags = extractScriptTags(ranges.scripts);
 
-		expect(scriptTags.length).to.equal(0);
+		expect(scriptTags.length).to.equal(1);
 	});
 
 	it('returns the proper capabilities for inline script tags', async () => {

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@volar/language-core": "~2.4.0-alpha.15",
     "@volar/typescript": "~2.4.0-alpha.15",
-    "@astrojs/compiler": "^2.7.0",
+    "@astrojs/compiler": "^2.10.0",
     "@jridgewell/sourcemap-codec": "^1.4.15",
     "semver": "^7.3.8",
     "vscode-languageserver-textdocument": "^1.0.11"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -229,7 +229,7 @@
     "vscode-tmgrammar-test": "^0.1.2"
   },
   "dependencies": {
-    "@astrojs/compiler": "^2.9.1",
+    "@astrojs/compiler": "^2.10.0",
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.14.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   packages/language-server:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.9.1
-        version: 2.9.1
+        specifier: ^2.10.0
+        version: 2.10.0
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.4.15
@@ -179,8 +179,8 @@ importers:
   packages/ts-plugin:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.10.0
+        version: 2.10.0
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.4.15
@@ -222,8 +222,8 @@ importers:
   packages/vscode:
     dependencies:
       '@astrojs/compiler':
-        specifier: ^2.9.1
-        version: 2.9.1
+        specifier: ^2.10.0
+        version: 2.10.0
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -309,12 +309,12 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
-  /@astrojs/compiler@2.7.0:
-    resolution: {integrity: sha512-XpC8MAaWjD1ff6/IfkRq/5k1EFj6zhCNqXRd5J43SVJEBj/Bsmizkm8N0xOYscGcDFQkRgEw6/eKnI5x/1l6aA==}
-    dev: false
+  /@astrojs/compiler@2.10.0:
+    resolution: {integrity: sha512-V8ym+4kYCKmMeSdfDvm/SrlmUlKLkKzfWV3cKyiStEKW/D+YsXaQiBZcSCtuKXq8aQhsDw9HtCTZilhEMBX+BA==}
 
   /@astrojs/compiler@2.9.1:
     resolution: {integrity: sha512-s8Ge2lWHx/s3kl4UoerjL/iPtwdtogNM/BLOaGCwQA6crMOVYpphy5wUkYlKyuh8GAeGYH/5haLAFBsgNy9AQQ==}
+    dev: true
 
   /@astrojs/internal-helpers@0.2.1:
     resolution: {integrity: sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A==}
@@ -2771,7 +2771,7 @@ packages:
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
     dependencies:
-      '@astrojs/compiler': 2.9.1
+      '@astrojs/compiler': 2.10.0
       '@astrojs/internal-helpers': 0.2.1
       '@astrojs/markdown-remark': 4.2.1
       '@astrojs/telemetry': 3.0.4
@@ -6179,7 +6179,7 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
-      '@astrojs/compiler': 2.9.1
+      '@astrojs/compiler': 2.10.0
       prettier: 3.2.5
       sass-formatter: 0.7.6
     dev: false


### PR DESCRIPTION
## Changes

> Require https://github.com/withastro/compiler/pull/1032

A long time ago (before the port to Volar), this was actually supported, but we lost it without noticing. This PR adds it back.

Fixes https://github.com/withastro/language-tools/issues/916

## Testing

Added tests

## Docs

N/A
