### PR TITLE
Fix `Astro.glob` CodeLens

### DIFF
--- a/.changeset/tame-balloons-type.md
+++ b/.changeset/tame-balloons-type.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Fixes code lens on `Astro.glob` not working as expected

--- a/packages/language-server/test/astro/codelens.test.ts
+++ b/packages/language-server/test/astro/codelens.test.ts
@@ -1,0 +1,20 @@
+import * as _ from '@volar/language-server/node';
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { LanguageServer, getLanguageServer } from '../server.js';
+
+describe('Astro - Code Lens', () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+
+	it('Can provide a codelens for Astro.glob', async () => {
+		const document = await languageServer.openFakeDocument('---\nAstro.glob(".");\n---\n', 'astro');
+
+		const codeLens = await languageServer.handle.connection.sendRequest(_.CodeLensRequest.type, {
+			textDocument: { uri: document.uri },
+		});
+
+		expect(codeLens).to.have.lengthOf(1);
+	});
+});


### PR DESCRIPTION
## Changes

Following the amazing TBD call you and Ema gave, I discovered the existence of the `Astro.glob` CodeLens and as it was not working, I decided to fix it.

Before this change, the `Astro.glob` CodeLens was not being displayed:

<img width="343" alt="SCR-20240730-qozl" src="https://github.com/user-attachments/assets/75729cb9-0e36-4e06-bcf5-2b53fc3d9749">

After this change, the `Astro.glob` CodeLens is now displayed:

<img width="342" alt="SCR-20240730-qphq" src="https://github.com/user-attachments/assets/6d74e2c1-176c-4dd8-92f4-966dc61e79f1">

<img width="354" alt="SCR-20240730-qpsq" src="https://github.com/user-attachments/assets/761611f0-6dcd-4332-8ae7-879daf7b489b">

To give a bit more context to the change, the `document.uri` in `provideCodeLenses()` was the one of a Volar embedded document so calling `getSourceFile()` on the TS program with it was returning `undefined`. To fix this, I decode the embedded document URI to get the original file URI, and use its `fsPath` to get the source file and also to get the directory name to get the glob result.

To get the CodeLens to show, I only needed `"editor.codeLens": true` in my Visual Studio Code settings.

## Testing

So this is the weird part as I only tested the change manually. I did not find any existing tests for this (and I assume these would have failed before the change).

I was kinda hoping to be able to get started with something basic like this:

```ts
const document = await languageServer.openFakeDocument('---\nawait Astro.glob("../content/docs/**/*.md");\n---', 'astro');
const codeLenses = await languageServer.handle.sendCodeLensesRequest(
  document.uri,
  Position.create(1, 0)
);
```

Altho, I don't think there is a test utility such as `sendCodeLensesRequest()` like `sendCompletionRequest()` for example. Maybe I am totally wrong (my usage of Volar is very limited). Would be happy to add tests if you think it's relevant and if you can guide me on how to do it.

## Docs

This is a bug fix only for an undocumented (as far as I know) feature.

## Remaining tasks

I did not add a changeset yet as I wanted to get your feedback first and see if the approach I took was correct.