### PR TITLE
fix: mdoc language identifier

### DIFF
--- a/.changeset/lazy-masks-behave.md
+++ b/.changeset/lazy-masks-behave.md
@@ -1,0 +1,8 @@
+---
+"@astrojs/language-server": patch
+"@astrojs/ts-plugin": patch
+"astro-vscode": patch
+---
+
+Fixes content intellisense not working inside Markdoc files using the `markdoc` language identifier
+ 

--- a/packages/language-server/src/core/frontmatterHolders.ts
+++ b/packages/language-server/src/core/frontmatterHolders.ts
@@ -8,7 +8,7 @@ import {
 import type ts from 'typescript';
 import type { URI } from 'vscode-uri';
 
-export const SUPPORTED_FRONTMATTER_EXTENSIONS = { md: 'markdown', mdx: 'mdx', mdoc: 'mdoc' };
+export const SUPPORTED_FRONTMATTER_EXTENSIONS = { md: 'markdown', mdx: 'mdx', mdoc: 'markdoc' };
 export const SUPPORTED_FRONTMATTER_EXTENSIONS_KEYS = Object.keys(SUPPORTED_FRONTMATTER_EXTENSIONS);
 const SUPPORTED_FRONTMATTER_EXTENSIONS_VALUES = Object.values(SUPPORTED_FRONTMATTER_EXTENSIONS);
 

--- a/packages/ts-plugin/src/frontmatter.ts
+++ b/packages/ts-plugin/src/frontmatter.ts
@@ -8,7 +8,7 @@ import {
 } from '@volar/language-core';
 import type ts from 'typescript';
 
-const SUPPORTED_FRONTMATTER_EXTENSIONS = { md: 'markdown', mdx: 'mdx', mdoc: 'mdoc' };
+const SUPPORTED_FRONTMATTER_EXTENSIONS = { md: 'markdown', mdx: 'mdx', mdoc: 'markdoc' };
 const SUPPORTED_FRONTMATTER_EXTENSIONS_KEYS = Object.keys(SUPPORTED_FRONTMATTER_EXTENSIONS);
 const SUPPORTED_FRONTMATTER_EXTENSIONS_VALUES = Object.values(SUPPORTED_FRONTMATTER_EXTENSIONS);
 

--- a/packages/vscode/src/client.ts
+++ b/packages/vscode/src/client.ts
@@ -75,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<LabsIn
 		documentSelector: [
 			{ language: 'astro' },
 			...(hasContentIntellisense
-				? [{ language: 'markdown' }, { language: 'mdx' }, { language: 'mdoc' }]
+				? [{ language: 'markdown' }, { language: 'mdx' }, { language: 'markdoc' }]
 				: []),
 		],
 		initializationOptions,


### PR DESCRIPTION
## Changes

- changes mdoc language identifier from `mdoc` to `markdoc`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- existing tests

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

- bugfix
