### PR TITLE
chore(astro-check): remove unused fast-glob dep

### DIFF
--- a/packages/astro-check/package.json
+++ b/packages/astro-check/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@astrojs/language-server": "^2.14.1",
     "chokidar": "^3.5.3",
-    "fast-glob": "^3.3.1",
     "kleur": "^4.1.5",
     "yargs": "^17.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.5.3
-      fast-glob:
-        specifier: ^3.3.1
-        version: 3.3.1
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -4357,6 +4354,7 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+    dev: true
 
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}


### PR DESCRIPTION
## Changes

I don't think it matters in practice since `fast-glob` is also used by astro and language-server, but this helps keep the exact deps used concise.

## Testing

existing tests should pass

## Docs

n/a
