### PR TITLE
refactor(language-server): unused resolveLanguageServiceHost hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,19 @@
   },
   "packageManager": "pnpm@8.6.2",
   "pnpm": {
+    "overrides": {
+      "@volar/eslint": "https://pkg.pr.new/volarjs/volar.js/@volar/eslint@6256f04",
+      "@volar/jsdelivr": "https://pkg.pr.new/volarjs/volar.js/@volar/jsdelivr@6256f04",
+      "@volar/language-core": "https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04",
+      "@volar/kit": "https://pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04",
+      "@volar/language-service": "https://pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04",
+      "@volar/language-server": "https://pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04",
+      "@volar/source-map": "https://pkg.pr.new/volarjs/volar.js/@volar/source-map@6256f04",
+      "@volar/monaco": "https://pkg.pr.new/volarjs/volar.js/@volar/monaco@6256f04",
+      "@volar/test-utils": "https://pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04",
+      "@volar/typescript": "https://pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04",
+      "@volar/vscode": "https://pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04"
+    },
     "peerDependencyRules": {
       "ignoreMissing": [
         "vue",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,19 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  '@volar/eslint': https://pkg.pr.new/volarjs/volar.js/@volar/eslint@6256f04
+  '@volar/jsdelivr': https://pkg.pr.new/volarjs/volar.js/@volar/jsdelivr@6256f04
+  '@volar/language-core': https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04
+  '@volar/kit': https://pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04
+  '@volar/language-service': https://pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04
+  '@volar/language-server': https://pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04
+  '@volar/source-map': https://pkg.pr.new/volarjs/volar.js/@volar/source-map@6256f04
+  '@volar/monaco': https://pkg.pr.new/volarjs/volar.js/@volar/monaco@6256f04
+  '@volar/test-utils': https://pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04
+  '@volar/typescript': https://pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04
+  '@volar/vscode': https://pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04
+
 importers:
 
   .:
@@ -82,20 +95,20 @@ importers:
         specifier: ^1.4.15
         version: 1.4.15
       '@volar/kit':
-        specifier: ~2.4.0
-        version: 2.4.0(typescript@5.5.4)
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04(typescript@5.5.4)'
       '@volar/language-core':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
       '@volar/language-server':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04'
       '@volar/language-service':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       '@volar/typescript':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04'
       fast-glob:
         specifier: ^3.2.12
         version: 3.2.12
@@ -104,25 +117,25 @@ importers:
         version: 0.4.1
       volar-service-css:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       volar-service-emmet:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       volar-service-html:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       volar-service-prettier:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)(prettier@3.2.5)
+        version: 0.0.61(@volar/language-service@2.4.4)(prettier@3.2.5)
       volar-service-typescript:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       volar-service-typescript-twoslash-queries:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       volar-service-yaml:
         specifier: 0.0.61
-        version: 0.0.61(@volar/language-service@2.4.0)
+        version: 0.0.61(@volar/language-service@2.4.4)
       vscode-html-languageservice:
         specifier: ^5.2.0
         version: 5.2.0
@@ -146,8 +159,8 @@ importers:
         specifier: ^18.17.8
         version: 18.17.8
       '@volar/test-utils':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04'
       astro:
         specifier: ^4.14.0
         version: 4.14.0(@types/node@18.17.8)(typescript@5.5.4)
@@ -191,11 +204,11 @@ importers:
         specifier: ^1.4.15
         version: 1.4.15
       '@volar/language-core':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
       '@volar/typescript':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04'
       semver:
         specifier: ^7.3.8
         version: 7.5.4
@@ -262,11 +275,11 @@ importers:
         specifier: ^1.82.0
         version: 1.83.0
       '@volar/language-server':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04'
       '@volar/vscode':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04'
       '@vscode/test-electron':
         specifier: ^2.3.2
         version: 2.3.2
@@ -305,8 +318,8 @@ importers:
         version: 2.5.0
     devDependencies:
       '@volar/language-core':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04
+        version: '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -2684,73 +2697,6 @@ packages:
         optional: true
       vue:
         optional: true
-    dev: true
-
-  /@volar/kit@2.4.0(typescript@5.5.4):
-    resolution: {integrity: sha512-uqwtPKhrbnP+3f8hs+ltDYXLZ6Wdbs54IzkaPocasI4aBhqWLht5qXctE1MqpZU52wbH359E0u9nhxEFmyon+w==}
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      '@volar/language-service': 2.4.0
-      '@volar/typescript': 2.4.0
-      typesafe-path: 0.2.2
-      typescript: 5.5.4
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
-    dev: false
-
-  /@volar/language-core@2.4.0:
-    resolution: {integrity: sha512-FTla+khE+sYK0qJP+6hwPAAUwiNHVMph4RUXpxf/FIPKUP61NFrVZorml4mjFShnueR2y9/j8/vnh09YwVdH7A==}
-    dependencies:
-      '@volar/source-map': 2.4.0
-
-  /@volar/language-server@2.4.0:
-    resolution: {integrity: sha512-rmGIjAxWekWQiGH97Mosb4juiD/hfFYNQKV5Py9r7vDOLSkbIwRhITbwHm88NJKs8P6TNc6w/PfBXN6yjKadJg==}
-    dependencies:
-      '@volar/language-core': 2.4.0
-      '@volar/language-service': 2.4.0
-      '@volar/typescript': 2.4.0
-      path-browserify: 1.0.1
-      request-light: 0.7.0
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-protocol: 3.17.5
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
-
-  /@volar/language-service@2.4.0:
-    resolution: {integrity: sha512-4P3yeQXIL68mLfS3n6P3m02IRg3GnLHUU9k/1PCHEfm5FG9bySkDOc72dbBn2vAa2BxOqm18bmmZXrsWuQ5AOw==}
-    dependencies:
-      '@volar/language-core': 2.4.0
-      vscode-languageserver-protocol: 3.17.5
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
-
-  /@volar/source-map@2.4.0:
-    resolution: {integrity: sha512-2ceY8/NEZvN6F44TXw2qRP6AQsvCYhV2bxaBPWxV9HqIfkbRydSksTFObCF1DBDNBfKiZTS8G/4vqV6cvjdOIQ==}
-
-  /@volar/test-utils@2.4.0:
-    resolution: {integrity: sha512-hCXPEY/JrH7ooFvMIUu5V3xaqnCLEwqkKoeMT1UHC6DvsQOGsuyaFsJu2k59aCtE8mxAyq7qww7S4k8kRH8hFw==}
-    dependencies:
-      '@volar/language-core': 2.4.0
-      '@volar/language-server': 2.4.0
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
-    dev: true
-
-  /@volar/typescript@2.4.0:
-    resolution: {integrity: sha512-9zx3lQWgHmVd+JRRAHUSRiEhe4TlzL7U7e6ulWXOxHH/WNYxzKwCvZD7WYWEZFdw4dHfTD9vUR0yPQO6GilCaQ==}
-    dependencies:
-      '@volar/language-core': 2.4.0
-      path-browserify: 1.0.1
-      vscode-uri: 3.0.8
-
-  /@volar/vscode@2.4.0:
-    resolution: {integrity: sha512-VOnUgtmu+xGOqVKouRM8ZSeVOFPqmcTDfi3wif5peXpkOPsCgNdS/zns0xunuh9J6Ck5SV+QffPfmNW9XARnxw==}
-    dependencies:
-      '@volar/language-server': 2.4.0
-      path-browserify: 1.0.1
-      vscode-languageclient: 9.0.1
-      vscode-nls: 5.2.0
     dev: true
 
   /@vscode/emmet-helper@2.9.3:
@@ -7967,7 +7913,7 @@ packages:
       vite: 5.4.0(@types/node@18.17.8)
     dev: true
 
-  /volar-service-css@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-css@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-Ct9L/w+IB1JU8F4jofcNCGoHy6TF83aiapfZq9A0qYYpq+Kk5dH+ONS+rVZSsuhsunq8UvAuF8Gk6B8IFLfniw==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -7975,13 +7921,13 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       vscode-css-languageservice: 6.3.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-emmet@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-emmet@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-iiYqBxjjcekqrRruw4COQHZME6EZYWVbkHjHDbULpml3g8HGJHzpAMkj9tXNCPxf36A+f1oUYjsvZt36qPg4cg==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -7991,12 +7937,12 @@ packages:
     dependencies:
       '@emmetio/css-parser': 0.4.0
       '@emmetio/html-matcher': 1.3.0
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       '@vscode/emmet-helper': 2.9.3
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-html@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-html@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-yFE+YmmgqIL5HI4ORqP++IYb1QaGcv+xBboI0WkCxJJ/M35HZj7f5rbT3eQ24ECLXFbFCFanckwyWJVz5KmN3Q==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -8004,13 +7950,13 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       vscode-html-languageservice: 5.3.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-prettier@0.0.61(@volar/language-service@2.4.0)(prettier@3.2.5):
+  /volar-service-prettier@0.0.61(@volar/language-service@2.4.4)(prettier@3.2.5):
     resolution: {integrity: sha512-F612nql5I0IS8HxXemCGvOR2Uxd4XooIwqYVUvk7WSBxP/+xu1jYvE3QJ7EVpl8Ty3S4SxPXYiYTsG3bi+gzIQ==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -8021,12 +7967,12 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       prettier: 3.2.5
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-99FICGrEF0r1E2tV+SvprHPw9Knyg7BdW2fUch0tf59kG+KG+Tj4tL6tUg+cy8f23O/VXlmsWFMIE+bx1dXPnQ==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -8034,11 +7980,11 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-typescript@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-typescript@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-4kRHxVbW7wFBHZWRU6yWxTgiKETBDIJNwmJUAWeP0mHaKpnDGj/astdRFKqGFRYVeEYl45lcUPhdJyrzanjsdQ==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -8046,7 +7992,7 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       path-browserify: 1.0.1
       semver: 7.6.3
       typescript-auto-import-cache: 0.3.3
@@ -8055,7 +8001,7 @@ packages:
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-yaml@0.0.61(@volar/language-service@2.4.0):
+  /volar-service-yaml@0.0.61(@volar/language-service@2.4.4):
     resolution: {integrity: sha512-L+gbDiLDQQ1rZUbJ3mf3doDsoQUa8OZM/xdpk/unMg1Vz24Zmi2Ign8GrZyBD7bRoIQDwOH9gdktGDKzRPpUNw==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
@@ -8063,7 +8009,7 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 2.4.0
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
       vscode-uri: 3.0.8
       yaml-language-server: 1.15.0
     dev: false
@@ -8471,4 +8417,88 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+    dev: true
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04(typescript@5.5.4)':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04}
+    id: '@pkg.pr.new/volarjs/volar.js/@volar/kit@6256f04'
+    name: '@volar/kit'
+    version: 2.4.4
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
+      '@volar/typescript': '@pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04'
+      typesafe-path: 0.2.2
+      typescript: 5.5.4
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+    dev: false
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04}
+    name: '@volar/language-core'
+    version: 2.4.4
+    dependencies:
+      '@volar/source-map': '@pkg.pr.new/volarjs/volar.js/@volar/source-map@6256f04'
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04}
+    name: '@volar/language-server'
+    version: 2.4.4
+    dependencies:
+      '@volar/language-core': '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
+      '@volar/language-service': '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04'
+      '@volar/typescript': '@pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04'
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/language-service@6256f04}
+    name: '@volar/language-service'
+    version: 2.4.4
+    dependencies:
+      '@volar/language-core': '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/source-map@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/source-map@6256f04}
+    name: '@volar/source-map'
+    version: 2.4.4
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/test-utils@6256f04}
+    name: '@volar/test-utils'
+    version: 2.4.4
+    dependencies:
+      '@volar/language-core': '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
+      '@volar/language-server': '@pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04'
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+    dev: true
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/typescript@6256f04}
+    name: '@volar/typescript'
+    version: 2.4.4
+    dependencies:
+      '@volar/language-core': '@pkg.pr.new/volarjs/volar.js/@volar/language-core@6256f04'
+      path-browserify: 1.0.1
+      vscode-uri: 3.0.8
+
+  '@pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04':
+    resolution: {tarball: https://pkg.pr.new/volarjs/volar.js/@volar/vscode@6256f04}
+    name: '@volar/vscode'
+    version: 2.4.4
+    dependencies:
+      '@volar/language-server': '@pkg.pr.new/volarjs/volar.js/@volar/language-server@6256f04'
+      path-browserify: 1.0.1
+      vscode-languageclient: 9.0.1
+      vscode-nls: 5.2.0
     dev: true


### PR DESCRIPTION
## Changes

resolveLanguageServiceHost hook is a bad abstraction. Its problem is that the hook logic cannot be universal to TS plugin. We plan to deprecate resolveLanguageServiceHost hook in Volar 2.5 and migrate to a more reasonable setup hook in this PR. setup hooks are also available for TS plugins, but PR did not implement this in order not to change the old behavior.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
