### PR TITLE
chore: upgrade chokidar

### DIFF
--- a/.changeset/giant-pots-bathe.md
+++ b/.changeset/giant-pots-bathe.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/check": patch
+---
+
+Upgrades chokidar to v4

--- a/packages/astro-check/package.json
+++ b/packages/astro-check/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@astrojs/language-server": "^2.14.1",
-    "chokidar": "^3.5.3",
+    "chokidar": "^4.0.1",
     "kleur": "^4.1.5",
     "yargs": "^17.7.2"
   },

--- a/packages/astro-check/src/index.ts
+++ b/packages/astro-check/src/index.ts
@@ -31,8 +31,12 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 
 	if (flags.watch) {
 		function createWatcher(rootPath: string, extensions: string[]) {
-			return watch(`${rootPath}/**/*{${extensions.join(',')}}`, {
-				ignored: (ignoredPath) => ignoredPath.includes('node_modules'),
+			return watch(rootPath, {
+				ignored(pathStr, stats) {
+					if (pathStr.includes('node_modules') || pathStr.includes('.git')) return true;
+					if (stats?.isFile() && !extensions.includes(path.extname(pathStr))) return true;
+					return false;
+				},
 				ignoreInitial: true,
 			});
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^2.14.1
         version: link:../language-server
       chokidar:
-        specifier: ^3.5.3
-        version: 3.5.3
+        specifier: ^4.0.1
+        version: 4.0.1
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -3074,6 +3074,7 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: true
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3255,6 +3256,7 @@ packages:
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
+    dev: true
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -3503,6 +3505,14 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.0.1
+    dev: false
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -4511,6 +4521,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /function-bind@1.1.1:
@@ -5011,6 +5022,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
+    dev: true
 
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -6229,6 +6241,7 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /npm-run-path@5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -6752,6 +6765,12 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+    dev: true
+
+  /readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
+    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}


### PR DESCRIPTION
## Changes

Upgrade chokidar to v4.

## Testing

Tested on a separate repo to make sure `astro check --watch` still works

## Docs

n/a. added a changeset in case the chokidar upgrade could affect someone, but i think it shouldn't.
