### PR TITLE
fix: reload content on collections change

### DIFF
--- a/.changeset/empty-crabs-destroy.md
+++ b/.changeset/empty-crabs-destroy.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/language-server': patch
+'@astrojs/ts-plugin': patch
+'astro-vscode': patch
+---
+
+Fixes certain cases where content schemas would not be reloaded properly when they were updated

--- a/packages/language-server/src/core/frontmatterHolders.ts
+++ b/packages/language-server/src/core/frontmatterHolders.ts
@@ -15,18 +15,23 @@ const SUPPORTED_FRONTMATTER_EXTENSIONS_VALUES = Object.values(SUPPORTED_FRONTMAT
 export const frontmatterRE = /^---(.*?)^---/ms;
 
 export type CollectionConfig = {
-	folder: URI;
-	config: {
-		collections: {
-			hasSchema: boolean;
-			name: string;
-		}[];
-		entries: Record<string, string>;
-	};
+	reload: (folders: { uri: string }[]) => void;
+	configs: {
+		folder: URI;
+		config: CollectionConfigInstance;
+	}[];
 };
 
-function getCollectionName(collectionConfigs: CollectionConfig[], fileURI: string) {
-	for (const collection of collectionConfigs) {
+export type CollectionConfigInstance = {
+	collections: {
+		hasSchema: boolean;
+		name: string;
+	}[];
+	entries: Record<string, string>;
+};
+
+function getCollectionName(collectionConfig: CollectionConfig, fileURI: string) {
+	for (const collection of collectionConfig.configs) {
 		if (collection.config.entries[fileURI]) {
 			return collection.config.entries[fileURI];
 		}
@@ -34,7 +39,7 @@ function getCollectionName(collectionConfigs: CollectionConfig[], fileURI: strin
 }
 
 export function getFrontmatterLanguagePlugin(
-	collectionConfigs: CollectionConfig[],
+	collectionConfig: CollectionConfig,
 ): LanguagePlugin<URI, FrontmatterHolder> {
 	return {
 		getLanguageId(scriptId) {
@@ -55,7 +60,7 @@ export function getFrontmatterLanguagePlugin(
 					languageId,
 					snapshot,
 					getCollectionName(
-						collectionConfigs,
+						collectionConfig,
 						// The scriptId here is encoded and somewhat normalized, as such we can't use it directly to compare with
 						// the file URLs in the collection config entries that Astro generates.
 						decodeURIComponent(scriptId.toString()).toLowerCase(),

--- a/packages/language-server/src/languageServerPlugin.ts
+++ b/packages/language-server/src/languageServerPlugin.ts
@@ -23,16 +23,13 @@ import { create as createTypescriptAddonsService } from './plugins/typescript-ad
 import { create as createTypeScriptServices } from './plugins/typescript/index.js';
 import { create as createYAMLService } from './plugins/yaml.js';
 
-export function getLanguagePlugins(collectionConfigs: CollectionConfig[]) {
+export function getLanguagePlugins(collectionConfig: CollectionConfig) {
 	const languagePlugins: LanguagePlugin<URI>[] = [
 		getAstroLanguagePlugin(),
 		getVueLanguagePlugin(),
 		getSvelteLanguagePlugin(),
+		getFrontmatterLanguagePlugin(collectionConfig),
 	];
-
-	if (collectionConfigs.length) {
-		languagePlugins.push(getFrontmatterLanguagePlugin(collectionConfigs));
-	}
 
 	return languagePlugins;
 }
@@ -40,7 +37,7 @@ export function getLanguagePlugins(collectionConfigs: CollectionConfig[]) {
 export function getLanguageServicePlugins(
 	connection: Connection,
 	ts: typeof import('typescript'),
-	collectionConfigs: CollectionConfig[],
+	collectionConfig: CollectionConfig,
 ) {
 	const LanguageServicePlugins = [
 		createHtmlService(),
@@ -51,11 +48,8 @@ export function getLanguageServicePlugins(
 		createTypescriptAddonsService(),
 		createAstroService(ts),
 		getPrettierService(),
+		createYAMLService(collectionConfig),
 	];
-
-	if (collectionConfigs.length) {
-		LanguageServicePlugins.push(createYAMLService(collectionConfigs));
-	}
 
 	return LanguageServicePlugins;
 

--- a/packages/language-server/src/nodeServer.ts
+++ b/packages/language-server/src/nodeServer.ts
@@ -140,7 +140,6 @@ connection.onInitialized(() => {
 			);
 
 			if (shouldReload) {
-				console.log('changes detected, reloading project');
 				server.project.reload();
 			}
 		});

--- a/packages/language-server/test/content-intellisense/caching.test.ts
+++ b/packages/language-server/test/content-intellisense/caching.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Position } from '@volar/language-server';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+import { URI } from 'vscode-uri';
+import { type LanguageServer, getLanguageServer } from '../server.js';
+import { fixtureDir } from '../utils.js';
+
+const contentSchemaPath = path.resolve(fixtureDir, '.astro', 'collections', 'caching.schema.json');
+
+describe('Content Intellisense - Caching', async () => {
+	let languageServer: LanguageServer;
+
+	before(async () => (languageServer = await getLanguageServer()));
+
+	it('Properly updates the schema when they are updated', async () => {
+		const document = await languageServer.handle.openTextDocument(
+			path.resolve(__dirname, '..', 'fixture', 'src', 'content', 'caching', 'caching.md'),
+			'markdown',
+		);
+
+		const hover = await languageServer.handle.sendHoverRequest(document.uri, Position.create(1, 1));
+
+		expect(hover?.contents).to.deep.equal({
+			kind: 'markdown',
+			value: 'I will be changed',
+		});
+
+		fs.writeFileSync(
+			contentSchemaPath,
+			fs.readFileSync(contentSchemaPath, 'utf-8').replaceAll('I will be changed', 'I am changed'),
+		);
+
+		await languageServer.handle.didChangeWatchedFiles([
+			{
+				uri: URI.file(contentSchemaPath).toString(),
+				type: 2,
+			},
+		]);
+
+		const hover2 = await languageServer.handle.sendHoverRequest(
+			document.uri,
+			Position.create(1, 1),
+		);
+
+		expect(hover2?.contents).to.deep.equal({
+			kind: 'markdown',
+			value: 'I am changed',
+		});
+	});
+
+	after(async () => {
+		fs.writeFileSync(
+			contentSchemaPath,
+			fs.readFileSync(contentSchemaPath, 'utf-8').replaceAll('I am changed', 'I will be changed'),
+		);
+	});
+});

--- a/packages/language-server/test/fixture/src/content/caching/caching.md
+++ b/packages/language-server/test/fixture/src/content/caching/caching.md
@@ -1,0 +1,3 @@
+---
+title: 'A title'
+---

--- a/packages/language-server/test/fixture/src/content/config.ts
+++ b/packages/language-server/test/fixture/src/content/config.ts
@@ -10,4 +10,11 @@ const blog = defineCollection({
 	}),
 });
 
-export const collections = { blog };
+const caching = defineCollection({
+	type: 'content',
+	schema: z.object({
+		title: z.string().describe("I will be changed"),
+	}),
+});
+
+export const collections = { blog, caching };

--- a/packages/language-server/test/typescript/caching.test.ts
+++ b/packages/language-server/test/typescript/caching.test.ts
@@ -9,8 +9,7 @@ import { expect } from 'chai';
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { URI } from 'vscode-uri';
 import { type LanguageServer, getLanguageServer } from '../server.js';
-
-const fixtureDir = path.join(__dirname, '../fixture');
+import { fixtureDir } from '../utils.js';
 
 describe('TypeScript - Cache invalidation', async () => {
 	let languageServer: LanguageServer;

--- a/packages/language-server/test/typescript/completions.test.ts
+++ b/packages/language-server/test/typescript/completions.test.ts
@@ -3,8 +3,7 @@ import { Position } from '@volar/language-server';
 import { expect } from 'chai';
 import { before, describe, it } from 'mocha';
 import { type LanguageServer, getLanguageServer } from '../server.js';
-
-const fixtureDir = path.join(__dirname, '../fixture');
+import { fixtureDir } from '../utils.js';
 
 describe('TypeScript - Completions', async () => {
 	let languageServer: LanguageServer;

--- a/packages/language-server/test/typescript/renames.test.ts
+++ b/packages/language-server/test/typescript/renames.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 import type { RenameFilesParams } from 'vscode-languageserver-protocol';
 import { WillRenameFilesRequest } from 'vscode-languageserver-protocol';
 import { type LanguageServer, getLanguageServer } from '../server.js';
-
-const fixtureDir = path.join(__dirname, '../fixture');
+import { fixtureDir } from '../utils.js';
 
 describe('TypeScript - Renaming', async () => {
 	let languageServer: LanguageServer;

--- a/packages/language-server/test/utils.ts
+++ b/packages/language-server/test/utils.ts
@@ -1,4 +1,7 @@
+import path from 'node:path';
 import type { Point, Position } from '@astrojs/compiler';
+
+export const fixtureDir = path.join(__dirname, './fixture');
 
 export function createCompilerPosition(start: Point, end: Point): Position {
 	return {

--- a/packages/ts-plugin/src/frontmatter.ts
+++ b/packages/ts-plugin/src/frontmatter.ts
@@ -25,8 +25,8 @@ export type CollectionConfig = {
 	};
 };
 
-function getCollectionName(collectionConfigs: CollectionConfig[], fsPath: string) {
-	for (const collection of collectionConfigs) {
+function getCollectionName(collectionConfig: CollectionConfig[], fsPath: string) {
+	for (const collection of collectionConfig) {
 		if (collection.config.entries[fsPath]) {
 			return collection.config.entries[fsPath];
 		}
@@ -34,7 +34,7 @@ function getCollectionName(collectionConfigs: CollectionConfig[], fsPath: string
 }
 
 export function getFrontmatterLanguagePlugin(
-	collectionConfigs: CollectionConfig[],
+	collectionConfig: CollectionConfig[],
 ): LanguagePlugin<string, FrontmatterHolder> {
 	return {
 		getLanguageId(scriptId) {
@@ -57,7 +57,7 @@ export function getFrontmatterLanguagePlugin(
 					snapshot,
 					// In TypeScript plugins, unlike in the language server, the scriptId is just a string file path
 					// so we'll have to convert it to a URL to match the collection config entries
-					getCollectionName(collectionConfigs, pathToFileURL(fileName).toString().toLowerCase()),
+					getCollectionName(collectionConfig, pathToFileURL(fileName).toString().toLowerCase()),
 				);
 			}
 		},

--- a/packages/vscode/src/client.ts
+++ b/packages/vscode/src/client.ts
@@ -39,7 +39,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<LabsIn
 		: vscode.Uri.joinPath(context.extensionUri, 'dist/node/server.js').fsPath;
 
 	const runOptions = { execArgv: [] };
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=' + 6009] };
+	const debugOptions = {
+		execArgv: ['--nolazy', '--inspect=' + Math.floor(Math.random() * 20000 + 10000)],
+	};
 
 	const serverOptions: lsp.ServerOptions = {
 		run: {


### PR DESCRIPTION
## Changes

This reworks a bit how we handle reloading schemas and add support for reloading the entire collections config. This PR focuses on fixing the language server handling of it, the TypeScript plugin part isn't as problematic, the only thing it doesn't handle is new collections being added, file updates works correctly (since they only care about the .ts part, not the schema)

## Testing

I added a (1) test, this is generally hard to test because there's so many moving parts to it, the editor seeing the file changes, Astro reloading the file etc. 

The one test should at least make sure the general idea for updating schemas works

## Docs

N/A