### PR TITLE
remove `import.meta.env` as an option for export const prerender

### DIFF
--- a/.changeset/tricky-coins-hammer.md
+++ b/.changeset/tricky-coins-hammer.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/language-server": patch
+"astro-vscode": patch
+---
+
+Updates the autocomplete options for `export const prerender=` to remove `import.meta.env`, as this option was removed in Astro 4.14

--- a/packages/language-server/src/plugins/typescript-addons/snippets.ts
+++ b/packages/language-server/src/plugins/typescript-addons/snippets.ts
@@ -58,7 +58,7 @@ export function getSnippetCompletions(frontmatter: FrontmatterStatus): Completio
 					'[Astro reference](https://docs.astro.build/en/guides/server-side-rendering/#configuring-individual-routes)',
 				].join('\n'),
 			},
-			insertText: 'export const prerender = ${1|true,false,import.meta.env.|}',
+			insertText: 'export const prerender = ${1|true,false|}',
 			insertTextFormat: 2,
 		},
 	];


### PR DESCRIPTION
## Changes

Astro 4.14 removed the option for dynamic prerendering. This removes the editor hint that you can do it.

## Testing

Not tested. Trusted Erika.

## Docs

No docs; only updates editor hover text.