### PR TITLE
feat: migrate to TS Plugin

### DIFF
--- a/packages/language-server/src/nodeServer.ts
+++ b/packages/language-server/src/nodeServer.ts
@@ -1,10 +1,8 @@
 import {
-	MessageType,
-	ShowMessageNotification,
 	type WorkspaceFolder,
 	createConnection,
 	createServer,
-	createTypeScriptProject,
+	createSimpleProject,
 	loadTsdkByPath,
 } from '@volar/language-server/node';
 import { URI, Utils } from 'vscode-uri';
@@ -13,9 +11,7 @@ import {
 	type CollectionConfigInstance,
 	SUPPORTED_FRONTMATTER_EXTENSIONS_KEYS,
 } from './core/frontmatterHolders.js';
-import { addAstroTypes } from './core/index.js';
 import { getLanguagePlugins, getLanguageServicePlugins } from './languageServerPlugin.js';
-import { getAstroInstall } from './utils.js';
 
 const connection = createConnection();
 const server = createServer(connection);
@@ -74,41 +70,7 @@ connection.onInitialize((params) => {
 
 	return server.initialize(
 		params,
-		createTypeScriptProject(typescript, diagnosticMessages, ({ env }) => {
-			return {
-				languagePlugins: getLanguagePlugins(collectionConfig),
-				setup({ project }) {
-					const { languageServiceHost, configFileName } = project.typescript!;
-
-					const rootPath = configFileName
-						? configFileName.split('/').slice(0, -1).join('/')
-						: env.workspaceFolders[0]!.fsPath;
-					const nearestPackageJson = typescript.findConfigFile(
-						rootPath,
-						typescript.sys.fileExists,
-						'package.json',
-					);
-
-					const astroInstall = getAstroInstall([rootPath], {
-						nearestPackageJson: nearestPackageJson,
-						readDirectory: typescript.sys.readDirectory,
-					});
-
-					if (astroInstall === 'not-found') {
-						connection.sendNotification(ShowMessageNotification.type, {
-							message: `Couldn't find Astro in workspace "${rootPath}". Experience might be degraded. For the best experience, please make sure Astro is installed into your project and restart the language server.`,
-							type: MessageType.Warning,
-						});
-					}
-
-					addAstroTypes(
-						typeof astroInstall === 'string' ? undefined : astroInstall,
-						typescript,
-						languageServiceHost,
-					);
-				},
-			};
-		}),
+		createSimpleProject(getLanguagePlugins(collectionConfig)),
 		getLanguageServicePlugins(connection, typescript, collectionConfig),
 	);
 });

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "publisher": "astro-build",
   "engines": {
-    "vscode": "^1.82.0"
+    "vscode": "^1.87.0"
   },
   "activationEvents": [
     "onLanguage:astro",
@@ -51,67 +51,45 @@
     "typescriptServerPlugins": [
       {
         "name": "astro-ts-plugin-bundle",
-        "enableForWorkspaceTypeScriptVersions": true
+        "enableForWorkspaceTypeScriptVersions": true,
+        "configNamespace": "typescript",
+        "languages": [
+          "astro"
+        ]
       }
     ],
-    "commands": [
-      {
-        "command": "astro.reloadProjects",
-        "title": "Astro: Reload Projects"
-      },
-      {
-        "command": "astro.findFileReferences",
-        "title": "Astro: Find File References"
-      },
-      {
-        "command": "astro.selectTypescriptVersion",
-        "title": "Astro: Select Typescript Version..."
-      },
-      {
-        "command": "astro.openTsConfig",
-        "title": "Astro: Open TypeScript config"
-      }
-    ],
-    "menus": {
-      "commandPalette": [
-        {
-          "command": "astro.reloadProjects",
-          "when": "editorLangId == astro"
-        },
-        {
-          "command": "astro.findFileReferences",
-          "when": "editorLangId == astro"
-        },
-        {
-          "command": "astro.selectTypescriptVersion",
-          "when": "editorLangId == astro"
-        },
-        {
-          "command": "astro.openTsConfig",
-          "when": "editorLangId == astro"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "astro.findFileReferences",
-          "when": "editorLangId == astro",
-          "group": "4_search"
-        }
-      ],
-      "editor/title/context": [
-        {
-          "command": "astro.findFileReferences",
-          "when": "resourceLangId == astro && resourceScheme == file"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "astro.findFileReferences",
-          "when": "resourceLangId == astro",
-          "group": "4_search"
-        }
-      ]
-    },
+		"menus": {
+			"editor/context": [
+				{
+					"command": "typescript.goToSourceDefinition",
+					"when": "tsSupportsSourceDefinition && resourceLangId == astro",
+					"group": "navigation@9"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "typescript.findAllFileReferences",
+					"when": "tsSupportsFileReferences && resourceLangId == astro",
+					"group": "4_search"
+				}
+			],
+			"editor/title/context": [
+				{
+					"command": "typescript.findAllFileReferences",
+					"when": "tsSupportsFileReferences && resourceLangId == astro"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "typescript.reloadProjects",
+					"when": "editorLangId == astro && typescript.isManagedFile"
+				},
+				{
+					"command": "typescript.goToProjectConfig",
+					"when": "editorLangId == astro"
+				}
+			]
+		},
     "breakpoints": [
       {
         "language": "astro"
@@ -148,12 +126,6 @@
           "type": "boolean",
           "default": false,
           "description": "Enable experimental support for content collection intellisense inside Markdown, MDX and Markdoc. Note that this require also enabling the feature in your Astro config (experimental.contentCollectionIntellisense) (Astro 4.14+)"
-        },
-        "astro.updateImportsOnFileMove.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Controls whether the extension updates imports when a file is moved to a new location. In most cases, you'll want to keep this disabled as TypeScript and the Astro TypeScript plugin already handles this for you. Having multiple tools updating imports at the same time can lead to corrupted files."
         }
       }
     },


### PR DESCRIPTION
## Changes

Rework on #726.

- [x] Get TS plugin mode works
- [ ] Integrate language-server and ts-plugin's language plugins
- [ ] Move TS LS enhance logics (packages/language-server/src/plugins/typescript/*) to TS plugin
- [ ] Write real temporary files for .mts/.mjs virtual script to support extra virtual scripts in TS plugin
- [ ] Rewrite some tests in TS plugin

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
