### PR TITLE
Add logic for auto-updating schema config from collection metadata

### DIFF
--- a/packages/vscode/src/client.ts
+++ b/packages/vscode/src/client.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as protocol from '@volar/language-server/protocol';
 import type { LabsInfo } from '@volar/vscode';
 import {
@@ -14,6 +15,7 @@ import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient/node';
 
 let client: lsp.BaseLanguageClient;
+let collectionsWatcher: vscode.FileSystemWatcher;
 
 type InitOptions = {
 	typescript: {
@@ -73,6 +75,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<LabsIn
 		contentIntellisense: hasContentIntellisense,
 	} satisfies InitOptions;
 
+	if (hasContentIntellisense && rootPath) {
+		await initializeCollectionSchemaAutoconfig(rootPath);
+	}
+
 	const clientOptions = {
 		documentSelector: [
 			{ language: 'astro' },
@@ -98,8 +104,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<LabsIn
 	return volarLabs.extensionExports;
 }
 
-export function deactivate(): Thenable<any> | undefined {
-	return client?.stop();
+export async function deactivate() {
+	return Promise.allSettled([client?.stop(), collectionsWatcher?.dispose()]);
 }
 
 async function getConfiguredServerPath(workspaceState: vscode.Memento) {
@@ -148,4 +154,101 @@ async function getConfiguredServerPath(workspaceState: vscode.Memento) {
 	} else {
 		return lsPath;
 	}
+}
+
+/**
+ * Factory that creates an updater function to run when collection metadata changes.
+ * @param rootPath The root path of the user’s Astro project.
+ */
+const createSchemaConfigUpdater = (rootPath: string) => async (uri: vscode.Uri) => {
+	try {
+		// Read the Astro-generated collections metadata.
+		const collectionsMetaBytes = await vscode.workspace.fs.readFile(uri);
+		const collectionsMetaString = new TextDecoder().decode(collectionsMetaBytes);
+		const collectionsMeta = JSON.parse(collectionsMetaString) as {
+			collections: Array<{ hasSchema: boolean; name: string }>;
+			entries: Record<string, string>;
+		};
+
+		const configScope = 'json.schemas';
+		/** The current `json.schemas` configuration in this workspace. */
+		const jsonConfig =
+			vscode.workspace.getConfiguration().inspect<any[]>(configScope)?.workspaceValue || [];
+		/** User-authored entries from the `json.schemas` array. */
+		const userEntriesJSON = jsonConfig.filter((item) => !('__astro__' in item));
+
+		/** Entries for `json.schemas` based on collection metadata. */
+		const autoGenEntriesJSON = collectionsMeta.collections
+			.map(({ name }) => ({
+				fileMatch: Object.entries(collectionsMeta.entries)
+					.filter(([file, collection]) => collection === name && file.endsWith('.json'))
+					.map(([file]) => fileURLToPath(file).replace(rootPath.toLowerCase(), '')),
+				url: `./.astro/collections/${name}.schema.json`,
+				__astro__: true,
+			}))
+			// Skip entries with no file matches.
+			.filter(({ fileMatch }) => fileMatch.length > 0);
+
+		// Update `json.schemas` in workspace settings, adding auto-generated values.
+		await vscode.workspace
+			.getConfiguration()
+			.update(configScope, [...userEntriesJSON, ...autoGenEntriesJSON]);
+
+		const yamlSchemasConfigScope = 'yaml.schemas';
+		/** The current `yaml.schemas` configuration in this workspace. */
+		const yamlConfig =
+			vscode.workspace
+				.getConfiguration()
+				.inspect<Record<string, string | string[]>>(yamlSchemasConfigScope)?.workspaceValue || {};
+		/** User-authored entries from the `yaml.schemas` object. */
+		const userEntriesYAML = Object.entries(yamlConfig).filter(
+			([, val]) => typeof val === 'string' || val.at(-1) !== '__astro__',
+		);
+
+		/** Entries for `yaml.schemas` based on collection metadata. */
+		const autoGenEntriesYAML = collectionsMeta.collections
+			.map(
+				({ name }) =>
+					[
+						`./.astro/collections/${name}.schema.json`,
+						Object.entries(collectionsMeta.entries)
+							.filter(
+								([file, collection]) =>
+									collection === name && (file.endsWith('.yml') || file.endsWith('.yaml')),
+							)
+							.map(([file]) => fileURLToPath(file).replace(rootPath.toLowerCase(), '')),
+					] as const,
+			)
+			.filter(([, files]) => files.length > 0)
+			.map(([schema, files]) => [schema, [...files, '__astro__']] as const);
+
+		// Update `yaml.schemas` in workspace settings, adding auto-generated values.
+		await vscode.workspace
+			.getConfiguration()
+			.update(
+				yamlSchemasConfigScope,
+				Object.fromEntries([...userEntriesYAML, ...autoGenEntriesYAML]),
+			);
+	} catch (error) {
+		console.error(error);
+	}
+};
+
+/**
+ * Watch for changes to the `.astro/collections/collections.json` metadata and mirror it to the
+ * VS Code workspace configuration for JSON and YAML schemas.
+ * @param rootPath The root path of the user’s Astro project.
+ */
+async function initializeCollectionSchemaAutoconfig(rootPath: string) {
+	const updateSchemaConfig = createSchemaConfigUpdater(rootPath);
+
+	const collectionsPath = '.astro/collections/collections.json';
+	collectionsWatcher = vscode.workspace.createFileSystemWatcher(
+		new vscode.RelativePattern(rootPath, collectionsPath),
+	);
+	collectionsWatcher.onDidChange(updateSchemaConfig);
+	collectionsWatcher.onDidCreate(updateSchemaConfig);
+	collectionsWatcher.onDidDelete(updateSchemaConfig);
+
+	await updateSchemaConfig(vscode.Uri.file(`${rootPath}/${collectionsPath}`));
 }


### PR DESCRIPTION
## Changes

This PR adds some logic to try and simplify use of Astro-generated JSON schemas for data files in content collections. We [document](https://docs.astro.build/en/guides/content-collections/#collection-json-schemas) these schemas, but the VS Code config to use them isn’t so lovely.

Sharing mainly for feedback at this point as there are several less than optimal things here, and I may be doing things wrong in any case.

Notes:

- AFAICT there is no way to set the `json.schemas`/`yaml.schemas` settings in an ephemeral “per session” way. We can only update a user’s workspace config directly (i.e. the one that lives in `.vscode/settings.json` in a project). That’s pretty annoying as it means the generated changes this added logic creates would show up in e.g. git diffs. All the worse because…

- Currently I’m using the `.astro/collections/collections.json` metadata file we generate for the [“content intellisense” experimental feature](https://docs.astro.build/en/reference/experimental-flags/content-intellisense/). But this doesn’t give me e.g. globs for which files are impacted. This makes the auto-updated settings **_verbose_**, because we list all impacted files, and will mean every new file incurs a change to `settings.json` to commit. Here’s an example of enabling this in the Astro Docs repo which uses YAML files for i18n:

	```json
	  "yaml.schemas": {
	    "./.astro/collections/i18n.schema.json": [
	      "/src/content/i18n/ar.yml",
	      "/src/content/i18n/de.yml",
	      "/src/content/i18n/es.yml",
	      "/src/content/i18n/en.yml",
	      "/src/content/i18n/hi.yml",
	      "/src/content/i18n/fr.yml",
	      "/src/content/i18n/it.yml",
	      "/src/content/i18n/ko.yml",
	      "/src/content/i18n/ja.yml",
	      "/src/content/i18n/pl.yml",
	      "/src/content/i18n/ru.yml",
	      "/src/content/i18n/zh-cn.yml",
	      "/src/content/i18n/zh-tw.yml",
	      "/src/content/i18n/pt-br.yml",
	      "__astro__"
	    ]
	  }
	```
	
	If configuring this manually you’d usually do this instead, which is much cleaner:
	
	```json
	"yaml.schemas": {
	  "./.astro/collections/i18n.schema.json": "/src/content/i18n/*.yml"
	}
	```

- Because we write to a user’s config, we need a way to distinguish auto-generated and user-authored config to avoid overwriting a user’s settings. There’s no really good way to do this. I’ve hacked around it here by adding an `__astro__` boolean property for JSON schema entries, and adding `__astro__` as the last entry to each array for YAML schemas. Pretty gross.

Anyway, mainly sharing so this isn’t lost on my hard drive. If anyone has ideas of how to make this less rubbish, feel free to share!

## Testing

Manually tested in VS Code.

## Docs

TO DO