### PR TITLE
fix: update display colors for zero errors and warnings

### DIFF
--- a/.changeset/cool-beers-lick.md
+++ b/.changeset/cool-beers-lick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/check': patch
+---
+
+When no errors or warnings are detected, display "0 errors" or "0 warnings" in a dimmed color on the console instead of red or yellow.

--- a/packages/astro-check/src/index.ts
+++ b/packages/astro-check/src/index.ts
@@ -82,10 +82,14 @@ export async function check(flags: Partial<Flags>): Promise<boolean | void> {
 			[
 				bold(`Result (${result.fileChecked} file${result.fileChecked === 1 ? '' : 's'}): `),
 				['error', 'warning', 'hint'].includes(minimumSeverity)
-					? bold(red(`${result.errors} ${result.errors === 1 ? 'error' : 'errors'}`))
+					? result.errors > 0
+						? bold(red(`${result.errors} ${result.errors === 1 ? 'error' : 'errors'}`))
+						: dim('0 errors')
 					: undefined,
 				['warning', 'hint'].includes(minimumSeverity)
-					? bold(yellow(`${result.warnings} ${result.warnings === 1 ? 'warning' : 'warnings'}`))
+					? result.warnings > 0
+						? bold(yellow(`${result.warnings} ${result.warnings === 1 ? 'warning' : 'warnings'}`))
+						: dim('0 warnings')
 					: undefined,
 				['hint'].includes(minimumSeverity)
 					? dim(`${result.hints} ${result.hints === 1 ? 'hint' : 'hints'}\n`)


### PR DESCRIPTION
## Changes

This PR changes the text color on the console to a more subtle color when there are no errors or warnings. The red and yellow colors can be quite distracting when everything is okey.

Before:

<img width="762" height="200" alt="image" src="https://github.com/user-attachments/assets/7c5af461-e113-454e-97e0-adf3d270438f" />

After:


<img width="729" height="192" alt="image" src="https://github.com/user-attachments/assets/b824443d-2e39-42ad-8a42-1a0649f12f12" />


## Testing

Tested locally by replacing the code in node_modules.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset file is included.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
