### PR TITLE
Fix description for "Content-intellisense" VSC extension setting

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -146,7 +146,7 @@
           "scope": "resource",
           "type": "boolean",
           "default": false,
-          "description": "Enable experimental support for content collection intellisense inside Markdown, MDX and Markdoc. Note that this require also enabling the feature in your Astro config (experimental.contentCollectionIntellisense) (Astro 4.14+)"
+          "description": "Enable experimental support for content collection intellisense inside Markdown, MDX and Markdoc. Note that this requires also enabling the feature in your Astro config (experimental.contentIntellisense) (Astro 4.14+)"
         },
         "astro.auto-import-cache.enabled": {
           "scope": "resource",


### PR DESCRIPTION
## Changes

- The description of this setting refers to the relevant Astro configuration file option as "experimental.contentCollectionIntellisense". This is incorrect; I changed it to say "experimental.contentIntellisense".
- Grammar fix ("require" → "requires")

## Testing

No tests were added, this is just a documentation fix.

## Docs

No docs were added, this is just a documentation fix.
